### PR TITLE
Pluggy type registry, MCP channel fix, Discord typing and ack clear

### DIFF
--- a/agent_core.yaml
+++ b/agent_core.yaml
@@ -28,7 +28,7 @@ http:
   bind_port: 8788
 
 endpoints:
-  - class: agent_core.endpoints.stub.StubEndpoint
+  - type: builtin.stub
     name: dev-stub
     description: "Dev/test stub endpoint."
     params: {}
@@ -40,19 +40,19 @@ bus_hooks:
 # Existing — Claude Code lifecycle hooks (untouched).
 pipelines:
   SessionStart:
-    - tool: agent_core.hooks.tools.time_injector.TimeInjector
+    - type: builtin.time_injector
       params:
         format: "%A, %B %d, %Y %I:%M %p %Z"
         track_session: true
 
   UserPromptSubmit:
-    - tool: agent_core.hooks.tools.time_injector.TimeInjector
+    - type: builtin.time_injector
       params:
         format: "%A, %B %d, %Y %I:%M %p %Z"
         track_session: true
 
   SessionEnd:
-    - tool: agent_core.hooks.tools.handoff_writer.HandoffWriter
+    - type: builtin.handoff_writer
       params:
         output_path: ".agent-core/handoffs/test-handoff.md"
         transcript_tail_lines: 200

--- a/docs/examples/pepper-agent-core.yaml
+++ b/docs/examples/pepper-agent-core.yaml
@@ -18,11 +18,11 @@
 
 pipelines:
   SessionStart:
-    - tool: agent_core.hooks.tools.time_injector.TimeInjector
+    - type: builtin.time_injector
       params:
         format: "%A, %B %d, %Y %I:%M %p %Z"
 
-    - tool: agent_core.hooks.tools.identity_injector.IdentityInjector
+    - type: builtin.identity_injector
       params:
         base_path: "C:\\Users\\jeffr\\.pepper\\Memory"
         files:
@@ -31,7 +31,7 @@ pipelines:
           - "pepper/handoff.md"
 
   PreCompact:
-    - tool: agent_core.hooks.tools.handoff_writer.HandoffWriter
+    - type: builtin.handoff_writer
       params:
         output_path: "C:\\Users\\jeffr\\.pepper\\Memory\\pepper\\handoff.md"
         transcript_tail_lines: 200
@@ -39,7 +39,7 @@ pipelines:
         agent_name: "Pepper"
 
   SessionEnd:
-    - tool: agent_core.hooks.tools.handoff_writer.HandoffWriter
+    - type: builtin.handoff_writer
       params:
         output_path: "C:\\Users\\jeffr\\.pepper\\Memory\\pepper\\handoff.md"
         transcript_tail_lines: 200

--- a/packages/agent-core-channel/src/agent_core_channel/stdio_server.py
+++ b/packages/agent-core-channel/src/agent_core_channel/stdio_server.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import TYPE_CHECKING, Any, cast
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Self, cast
 
 import anyio
 from mcp.server.lowlevel.server import NotificationOptions, Server
@@ -134,6 +135,24 @@ class _InitializationGateWriteStream:
     ) -> None:
         self._inner = inner
         self._initialized = initialized
+
+    async def __aenter__(self) -> Self:
+        """MCP ``ServerSession`` uses ``async with read_stream, write_stream``; delegate."""
+        inner_enter = getattr(self._inner, "__aenter__", None)
+        if inner_enter is not None:
+            await inner_enter()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        inner_exit = getattr(self._inner, "__aexit__", None)
+        if inner_exit is not None:
+            return await inner_exit(exc_type, exc_val, exc_tb)
+        return None
 
     async def send(self, message: SessionMessage) -> None:
         await self._inner.send(message)

--- a/packages/agent-core-channel/tests/test_stdio_server.py
+++ b/packages/agent-core-channel/tests/test_stdio_server.py
@@ -104,6 +104,35 @@ async def test_initialization_gate_opens_after_initialize_response_is_sent():
 
 
 @pytest.mark.asyncio
+async def test_initialization_gate_supports_async_context_manager():
+    """MCP session enters the write stream with ``async with``; wrapper must delegate."""
+
+    class _InnerWithAcm:
+        def __init__(self) -> None:
+            self.entered = False
+            self.exited = False
+
+        async def __aenter__(self) -> _InnerWithAcm:
+            self.entered = True
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            self.exited = True
+
+        async def send(self, _msg: object) -> None:
+            pass
+
+    inner = _InnerWithAcm()
+    initialized = anyio.Event()
+    gated = _InitializationGateWriteStream(inner, initialized)  # type: ignore[arg-type]
+
+    async with gated:
+        assert inner.entered is True
+        assert inner.exited is False
+    assert inner.exited is True
+
+
+@pytest.mark.asyncio
 async def test_sse_pump_waits_for_initialization_before_consuming_events(monkeypatch):
     async def fake_iter_notify_events(*, agent: str, daemon_url: str):
         yield {"content": "INBOX: 1 pending", "meta": {"count": 1}}

--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -125,6 +125,7 @@ class DiscordEndpoint:
         name: str,
         target: str,
         token_env: str,
+        outbound_channel_id: str | None = None,
         env_file: str | Path | None = None,
         access_config_path: str | Path | None = None,
         attachments_dir: str | Path | None = None,
@@ -136,6 +137,7 @@ class DiscordEndpoint:
         self.name = name
         self.target = target
         self.token_env = token_env
+        self.outbound_channel_id = outbound_channel_id
         self.env_file: Path | None = Path(env_file).expanduser() if env_file else None
         self.access_config_path: Path | None = (
             Path(access_config_path).expanduser() if access_config_path else None
@@ -159,6 +161,12 @@ class DiscordEndpoint:
         # OrderedDict so the head is the oldest entry — used for both LRU
         # eviction at the cap and TTL eviction in the sweep loop.
         self._pending_acks: OrderedDict[str, tuple[str, str, float]] = OrderedDict()
+        # Inbound bus envelope id → (Discord message id, channel id) for
+        # outbound TextMessage replies that set in_reply_to but omit metadata.
+        self._inbound_envelope_discord: OrderedDict[str, tuple[str, str]] = OrderedDict()
+        # Discord message ids we published to the bus and have not "finished"
+        # yet (cleared when ack reaction is removed or TTL/LRU evicts).
+        self._awaiting_reply_ids: set[str] = set()
 
     def _add_listener(self, handler: Callable[..., Any], event_name: str) -> None:
         """Register an event handler against the discord.py client.
@@ -174,6 +182,35 @@ class DiscordEndpoint:
             # the @client.event protocol as a fallback.
             handler.__name__ = event_name  # type: ignore[attr-defined]
             self._client.event(handler)
+
+    def _remember_inbound_mapping(
+        self, envelope_id: str, discord_message_id: str, channel_id: str
+    ) -> None:
+        """Map a published inbound envelope id to Discord ids (LRU-capped)."""
+        self._inbound_envelope_discord[envelope_id] = (discord_message_id, channel_id)
+        while len(self._inbound_envelope_discord) > self.pending_acks_max:
+            self._inbound_envelope_discord.popitem(last=False)
+
+    async def _typing_while_pending(self, channel: Any, message_id: str) -> None:
+        """Hold Discord 'typing…' until this message is cleared from the awaiting set."""
+        typing_factory = getattr(channel, "typing", None)
+        if typing_factory is None:
+            return
+        try:
+            async with typing_factory():
+                while message_id in self._awaiting_reply_ids:
+                    # Short poll so ack clear / stop() drops the id promptly; the
+                    # typing context manager (discord.py) keeps the indicator fresh.
+                    await asyncio.sleep(0.2)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.debug(
+                "discord(%s): typing loop for message %s ended",
+                self.name,
+                message_id,
+                exc_info=True,
+            )
 
     # --- Endpoint Protocol ---
 
@@ -345,10 +382,21 @@ class DiscordEndpoint:
         )
 
     async def deliver(self, envelope: Envelope) -> None:
-        """Handle ToolInvocation envelopes; warn on others."""
+        """Handle ToolInvocation and TextMessage envelopes."""
         if self._handle is None:
             raise EndpointUnavailable(f"discord '{self.name}' not started")
 
+        if envelope.kind == "TextMessage":
+            try:
+                result = await self._deliver_text_message(envelope)
+                await self._reply(envelope, json.dumps(result))
+            except _ToolError as exc:
+                await self._reply(envelope, f"error: {exc}")
+            except Exception as exc:
+                log.exception("discord TextMessage delivery raised")
+                await self._reply(envelope, f"error: {exc}")
+            await self._handle.ack(envelope.id)
+            return
         if envelope.kind != "ToolInvocation":
             await self._reply(envelope, f"warning: unsupported envelope kind '{envelope.kind}'")
             await self._handle.ack(envelope.id)
@@ -367,6 +415,45 @@ class DiscordEndpoint:
             await self._reply(envelope, f"error: {exc}")
 
         await self._handle.ack(envelope.id)
+
+    async def _deliver_text_message(self, envelope: Envelope) -> dict:
+        """Route a bus TextMessage to Discord send."""
+        if not isinstance(envelope.payload, TextMessagePayload):
+            raise _ToolError("TextMessage envelope payload is invalid")
+
+        discord_meta = envelope.metadata.get("discord", {})
+        channel_id = None
+        reply_to: str | None = None
+        if isinstance(discord_meta, dict):
+            channel_id = discord_meta.get("channel_id")
+            # Prefer explicit reply_to; else message_id (legacy); else resolve
+            # from bus in_reply_to → inbound envelope id (agent replies often
+            # only set in_reply_to).
+            reply_to = discord_meta.get("reply_to") or discord_meta.get("message_id")
+            if reply_to is not None:
+                reply_to = str(reply_to)
+        if (
+            not reply_to
+            and envelope.in_reply_to
+            and envelope.in_reply_to in self._inbound_envelope_discord
+        ):
+            mapped_mid, mapped_ch = self._inbound_envelope_discord[envelope.in_reply_to]
+            reply_to = mapped_mid
+            if not channel_id:
+                channel_id = mapped_ch
+        if not channel_id:
+            channel_id = self.outbound_channel_id
+        if not channel_id:
+            raise _ToolError(
+                "TextMessage requires metadata.discord.channel_id or endpoint outbound_channel_id"
+            )
+
+        args = _SendArgs(
+            channel_id=str(channel_id),
+            text=envelope.payload.text,
+            reply_to=reply_to,
+        )
+        return await self._send(args)
 
     async def _dispatch(self, tool: str, args: dict) -> Any:
         if tool == "send":
@@ -404,6 +491,9 @@ class DiscordEndpoint:
     async def stop(self) -> None:
         if _active_endpoints.get(self.name) is self:
             _active_endpoints.pop(self.name, None)
+        # Drop typing / threading state so background typing tasks exit promptly.
+        self._awaiting_reply_ids.clear()
+        self._inbound_envelope_discord.clear()
         if self._sweep_task is not None:
             self._sweep_task.cancel()
             try:
@@ -534,7 +624,21 @@ class DiscordEndpoint:
                 created_at=datetime.now(timezone.utc),
             )
             assert self._handle is not None
-            await self._handle.publish(env)
+            self._remember_inbound_mapping(
+                env.id, str(message.id), str(message.channel.id)
+            )
+            mid = str(message.id)
+            self._awaiting_reply_ids.add(mid)
+            try:
+                await self._handle.publish(env)
+            except BaseException:
+                self._awaiting_reply_ids.discard(mid)
+                self._inbound_envelope_discord.pop(env.id, None)
+                raise
+            asyncio.create_task(
+                self._typing_while_pending(message.channel, mid),
+                name=f"discord-{self.name}-typing-{mid}",
+            )
 
         return on_message
 
@@ -595,6 +699,7 @@ class DiscordEndpoint:
         self._pending_acks[message_id] = (emoji, channel_id, time.monotonic())
         while len(self._pending_acks) > self.pending_acks_max:
             old_id, (old_emoji, old_ch, _ts) = self._pending_acks.popitem(last=False)
+            self._awaiting_reply_ids.discard(old_id)
             asyncio.create_task(
                 self._remote_remove_ack(old_id, old_emoji, old_ch),
                 name=f"discord-endpoint-{self.name}-evict-ack",
@@ -636,6 +741,7 @@ class DiscordEndpoint:
             if ts >= cutoff:
                 break
             self._pending_acks.pop(head_id)
+            self._awaiting_reply_ids.discard(head_id)
             asyncio.create_task(
                 self._remote_remove_ack(head_id, emoji, channel_id),
                 name=f"discord-endpoint-{self.name}-ttl-ack",
@@ -656,12 +762,14 @@ class DiscordEndpoint:
             raise
 
     async def _clear_pending_ack(self, channel, message_id: str) -> None:
-        entry = self._pending_acks.pop(message_id, None)
+        mid = str(message_id)
+        self._awaiting_reply_ids.discard(mid)
+        entry = self._pending_acks.pop(mid, None)
         if entry is None:
             return
         emoji, _channel_id, _ts = entry
         try:
-            msg = await channel.fetch_message(message_id)
+            msg = await channel.fetch_message(mid)
         except Exception:
             return
         if msg is None:

--- a/packages/agent-core-discord/tests/test_endpoint_inbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_inbound.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from agent_core.bus.envelope import EndpointInfo, Envelope, EventPayload, TextMessagePayload
@@ -109,6 +111,24 @@ async def test_on_message_adds_ack_reaction(monkeypatch):
     try:
         await fake.fire("on_message", msg)
         assert "👀" in msg.reactions
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_on_message_holds_typing_until_ack_cleared(monkeypatch):
+    ep, handle, fake = await _start_endpoint(monkeypatch)
+    ch = _FakeChannel(id="200")
+    fake.add_channel(ch)
+    msg = _msg(id="m-typing")
+    msg.channel = ch
+    try:
+        await fake.fire("on_message", msg)
+        await asyncio.sleep(0.08)
+        assert ch._typing_count >= 1
+        await ep._clear_pending_ack(ch, "m-typing")
+        await asyncio.sleep(0.35)
+        assert ch._typing_count == 0
     finally:
         await ep.stop()
 

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -15,7 +15,13 @@ from agent_core.bus.envelope import (
     ToolInvocationPayload,
 )
 from agent_core_discord.endpoint import DiscordEndpoint
-from tests.conftest import _FakeChannel, _FakeDiscordClient, _FakeGuild, _FakeMessage
+from tests.conftest import (
+    _FakeChannel,
+    _FakeDiscordClient,
+    _FakeGuild,
+    _FakeMessage,
+    _FakeUser,
+)
 
 
 class _Recording:
@@ -287,8 +293,72 @@ async def test_unknown_tool_returns_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_non_toolinvocation_returns_warning(monkeypatch):
+async def test_textmessage_uses_discord_metadata_channel_and_replies(monkeypatch):
     ep, handle, fake = await _started(monkeypatch)
+    ch = _FakeChannel(id="200")
+    incoming = _FakeMessage(id="m-in", channel_id="200", content="hello")
+    ch._messages["m-in"] = incoming
+    fake.add_channel(ch)
+    try:
+        env = Envelope(
+            id="e",
+            correlation_id=uuid.uuid4().hex,
+            from_="agent-test",
+            to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(text="hi"),
+            metadata={"discord": {"channel_id": "200", "message_id": "m-in"}},
+            created_at=datetime.now(timezone.utc),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 1
+        assert ch.sent[0]["content"] == "hi"
+        assert ch.sent[0]["reference"] is not None
+        ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
+        result = json.loads(ack.payload.note)
+        assert result["status"] == "sent"
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_textmessage_uses_default_outbound_channel(monkeypatch):
+    monkeypatch.setenv("X_TOK", "tok")
+    handle = _Recording()
+    fake = _FakeDiscordClient()
+    ch = _FakeChannel(id="200")
+    fake.add_channel(ch)
+    ep = DiscordEndpoint(
+        name="discord-test",
+        target="agent-test",
+        token_env="X_TOK",
+        outbound_channel_id="200",
+        _client_factory=lambda **kw: fake,
+    )
+    await ep.start(handle)
+    try:
+        env = Envelope(
+            id="e",
+            correlation_id=uuid.uuid4().hex,
+            from_="agent-test",
+            to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(text="fallback send"),
+            created_at=datetime.now(timezone.utc),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 1
+        assert ch.sent[0]["content"] == "fallback send"
+        ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
+        result = json.loads(ack.payload.note)
+        assert result["status"] == "sent"
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_textmessage_without_channel_returns_error(monkeypatch):
+    ep, handle, _fake = await _started(monkeypatch)
     try:
         env = Envelope(
             id="e",
@@ -301,8 +371,53 @@ async def test_non_toolinvocation_returns_warning(monkeypatch):
         )
         await ep.deliver(env)
         ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
-        assert "warning" in ack.payload.note.lower()
-        assert "TextMessage" in ack.payload.note
+        assert ack.payload.note.lower().startswith("error:")
+        assert "channel_id" in ack.payload.note
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_textmessage_in_reply_to_clears_ack_without_discord_message_id(monkeypatch):
+    """Bus replies often only set in_reply_to; map inbound envelope id → Discord message."""
+    monkeypatch.setenv("X_TOK", "tok")
+    handle = _Recording()
+    fake = _FakeDiscordClient()
+    ch = _FakeChannel(id="200")
+    fake.add_channel(ch)
+    ep = DiscordEndpoint(
+        name="discord-test",
+        target="agent-test",
+        token_env="X_TOK",
+        outbound_channel_id="200",
+        _client_factory=lambda **kw: fake,
+    )
+    await ep.start(handle)
+    user_msg = _FakeMessage(id="m-user", channel_id="200", content="ping")
+    user_msg.author = _FakeUser(id="u1", name="alice", bot=False)
+    user_msg.guild = type("G", (), {"id": "g1"})()
+    user_msg.channel = ch
+    ch._messages[str(user_msg.id)] = user_msg
+    try:
+        await fake.fire("on_message", user_msg)
+        assert "👀" in user_msg.reactions
+        inbound_id = handle.published[0].id
+        out = Envelope(
+            id="out1",
+            correlation_id=uuid.uuid4().hex,
+            in_reply_to=inbound_id,
+            from_="agent-test",
+            to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(text="pong"),
+            metadata={},
+            created_at=datetime.now(timezone.utc),
+        )
+        await ep.deliver(out)
+        assert "👀" not in user_msg.reactions
+        assert len(ch.sent) == 1
+        assert ch.sent[0]["content"] == "pong"
+        assert ch.sent[0]["reference"] is not None
     finally:
         await ep.stop()
 

--- a/packages/core/docs/plugins.md
+++ b/packages/core/docs/plugins.md
@@ -22,14 +22,12 @@ hookimpl = pluggy.HookimplMarker("agent_core")
 
 ## Hook surface
 
-- `resolve_endpoint_class(endpoint_class)`  
-  Return a class to construct an endpoint from YAML `endpoints[].class`.
-- `resolve_bus_hook_class(hook_class)`  
-  Return a class to construct a bus hook from YAML `bus_hooks`.
-- `resolve_hook_tool_class(tool_class)`  
-  Return a class for hook pipeline tools.
-- `resolve_class(class_path)`  
-  Generic fallback resolver; used after the specific `resolve_*` hooks.
+- `register_endpoint_types()`  
+  Return endpoint type registrations used for YAML `endpoints[].type`.
+- `register_bus_hook_types()`  
+  Return bus-hook type registrations used for YAML `bus_hooks[].type`.
+- `register_hook_tool_types()`  
+  Return hook-tool type registrations used for pipeline tool ids.
 - `configure_endpoint_instance(instance, endpoint_name, endpoint_config, services)`  
   Post-construction endpoint wiring.
 - `configure_bus_hook_instance(instance, stage, hook_config, services)`  
@@ -39,13 +37,8 @@ hookimpl = pluggy.HookimplMarker("agent_core")
 
 ## Resolution order
 
-Runtime class resolution uses this precedence:
-
-1. Specific resolver (`resolve_endpoint_class`, `resolve_bus_hook_class`, or `resolve_hook_tool_class`)
-2. Generic resolver (`resolve_class`)
-3. Dotted import fallback (`module.Class`)
-
-Returning `None` means "not handled".
+Runtime resolution uses the plugin registry maps built at startup.
+Unknown type ids fail startup/config load immediately.
 
 ## RunnerServices
 
@@ -63,5 +56,17 @@ Core ships with a built-in runtime plugin that:
 
 - attaches `notify_broker` to endpoints implementing `NotificationBrokerAwareEndpoint`
 - keeps bus-hook wiring and config validation as no-op defaults
+
+Core also ships an entrypoint-loaded alias plugin:
+
+- endpoint aliases:
+  - `builtin.claude_code_mcp` -> `agent_core.endpoints.claude_code_mcp.ClaudeCodeMCPEndpoint`
+  - `builtin.discord` -> `agent_core_discord.endpoint.DiscordEndpoint`
+  - `builtin.stub` -> `agent_core.endpoints.stub.StubEndpoint`
+  - `builtin.scheduler` -> `agent_core.endpoints.scheduler.SchedulerEndpoint`
+- hook tool aliases:
+  - `builtin.handoff_writer` -> `agent_core.hooks.tools.handoff_writer.HandoffWriter`
+  - `builtin.identity_injector` -> `agent_core.hooks.tools.identity_injector.IdentityInjector`
+  - `builtin.time_injector` -> `agent_core.hooks.tools.time_injector.TimeInjector`
 
 Your plugin hooks run alongside these defaults.

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 agent-core = "agent_core.cli:app"
 
 [project.entry-points."agent_core"]
+aliases = "agent_core.plugins.builtin_aliases"
 example = "agent_core.plugins.example_entrypoint"
 
 [build-system]

--- a/packages/core/src/agent_core/bus/runner.py
+++ b/packages/core/src/agent_core/bus/runner.py
@@ -8,16 +8,18 @@ enforces v1 invariants: loopback-only bind unless an auth hook is configured
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
-import pluggy
 import yaml
 
 from agent_core.bus.core import Bus, BusConfig, BusHookSpec, EndpointSpec
 from agent_core.bus.http_host import HTTPHost, MCPHostable
 from agent_core.bus.notify_broker import NotificationBroker
 from agent_core.bus.protocol import BusHook, Endpoint
-from agent_core.plugins.manager import create_plugin_manager
+from agent_core.plugins.manager import (
+    create_plugin_manager,
+    get_bus_hook_types,
+    get_endpoint_types,
+)
 from agent_core.plugins.specs import RunnerServices
 
 
@@ -26,29 +28,6 @@ class BusBootError(Exception):
 
 
 _LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
-
-
-def _import_class(
-    path: str,
-    plugin_manager: pluggy.PluginManager,
-    *,
-    kind: str = "generic",
-) -> Any:
-    resolved = None
-    if kind == "endpoint":
-        resolved = plugin_manager.hook.resolve_endpoint_class(endpoint_class=path)
-    elif kind == "bus_hook":
-        resolved = plugin_manager.hook.resolve_bus_hook_class(hook_class=path)
-    elif kind == "hook_tool":
-        resolved = plugin_manager.hook.resolve_hook_tool_class(tool_class=path)
-    if resolved is None:
-        resolved = plugin_manager.hook.resolve_class(class_path=path)
-    if resolved is not None:
-        return resolved
-    module_path, _, _ = path.rpartition(".")
-    if not module_path:
-        raise BusBootError(f"invalid class path: {path!r}")
-    raise BusBootError(f"could not resolve class: {path!r}")
 
 
 def _validate_http(http_cfg: dict, has_auth_hook: bool) -> None:
@@ -64,6 +43,8 @@ async def build_bus_from_config(path: Path) -> tuple[Bus, HTTPHost | None]:
     raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
     plugin_manager = create_plugin_manager()
     plugin_manager.hook.validate_config(raw_config=raw)
+    endpoint_types = get_endpoint_types(plugin_manager)
+    bus_hook_types = get_bus_hook_types(plugin_manager)
 
     bus_cfg_raw = raw.get("bus", {})
     storage_path = Path(bus_cfg_raw.get("storage_path", "~/.agent-core/bus.sqlite")).expanduser()
@@ -91,17 +72,20 @@ async def build_bus_from_config(path: Path) -> tuple[Bus, HTTPHost | None]:
     has_auth_hook = False
     for stage in ("pre_publish", "pre_deliver"):
         for entry in (raw.get("bus_hooks", {}) or {}).get(stage, []) or []:
-            if "class" not in entry:
-                raise BusBootError(f"hook entry missing required 'class' field: {entry!r}")
-            cls = _import_class(entry["class"], plugin_manager, kind="bus_hook")
+            if "type" not in entry:
+                raise BusBootError(f"hook entry missing required 'type' field: {entry!r}")
+            hook_type = str(entry["type"])
+            cls = bus_hook_types.get(hook_type)
+            if cls is None:
+                raise BusBootError(f"unknown bus hook type: {hook_type!r}")
             try:
                 instance = cls(**entry.get("params", {}))
             except Exception as exc:
                 raise BusBootError(
-                    f"{entry['class']!r} does not satisfy BusHook protocol: {exc}"
+                    f"bus hook type {hook_type!r} does not satisfy BusHook protocol: {exc}"
                 ) from exc
             if not isinstance(instance, BusHook):
-                raise BusBootError(f"{entry['class']!r} does not satisfy BusHook protocol")
+                raise BusBootError(f"bus hook type {hook_type!r} does not satisfy BusHook protocol")
             plugin_manager.hook.configure_bus_hook_instance(
                 instance=instance,
                 stage=stage,
@@ -116,11 +100,14 @@ async def build_bus_from_config(path: Path) -> tuple[Bus, HTTPHost | None]:
 
     # Endpoints.
     for entry in raw.get("endpoints", []) or []:
-        if "class" not in entry:
-            raise BusBootError(f"endpoint entry missing required 'class' field: {entry!r}")
+        if "type" not in entry:
+            raise BusBootError(f"endpoint entry missing required 'type' field: {entry!r}")
         if "name" not in entry:
             raise BusBootError(f"endpoint entry missing required 'name' field: {entry!r}")
-        cls = _import_class(entry["class"], plugin_manager, kind="endpoint")
+        endpoint_type = str(entry["type"])
+        cls = endpoint_types.get(endpoint_type)
+        if cls is None:
+            raise BusBootError(f"unknown endpoint type: {endpoint_type!r}")
         params = entry.get("params", {})
         # Runner-side convention (not enforced by the Endpoint Protocol):
         # every endpoint class must accept `name` as a constructor kwarg.
@@ -130,10 +117,10 @@ async def build_bus_from_config(path: Path) -> tuple[Bus, HTTPHost | None]:
             instance = cls(name=entry["name"], **params)
         except Exception as exc:
             raise BusBootError(
-                f"{entry['class']!r} does not satisfy Endpoint protocol: {exc}"
+                f"endpoint type {endpoint_type!r} does not satisfy Endpoint protocol: {exc}"
             ) from exc
         if not isinstance(instance, Endpoint):
-            raise BusBootError(f"{entry['class']!r} does not satisfy Endpoint protocol")
+            raise BusBootError(f"endpoint type {endpoint_type!r} does not satisfy Endpoint protocol")
         plugin_manager.hook.configure_endpoint_instance(
             instance=instance,
             endpoint_name=entry["name"],

--- a/packages/core/src/agent_core/endpoints/claude_code_mcp.py
+++ b/packages/core/src/agent_core/endpoints/claude_code_mcp.py
@@ -55,7 +55,7 @@ class SessionRegistry(Middleware):
     the spec-defined stable identifier across HTTP requests in a streamable-
     HTTP session; `id(session)` happens to also be stable in stateful mode
     but isn't load-bearing — and using the string makes us robust to clients
-    that genuinely open new logical sessions (most-recent-wins).
+    that genuinely open new logical sessions.
     """
 
     def __init__(self, endpoint: ClaudeCodeMCPEndpoint) -> None:
@@ -130,8 +130,7 @@ class ClaudeCodeMCPEndpoint:
         )
         self._handle: BusHandle | None = None
         self._pending: list[Envelope] = []
-        self._session_active: bool = False  # set true when an MCP session is attached
-        self._active_session: Any = None  # ServerSession, when connected
+        self._sessions: set[Any] = set()
         self._notify_debounce_seconds_by_urgency: dict[str, float] = {
             "red": 0.05,
             "yellow": 0.5,
@@ -148,30 +147,18 @@ class ClaudeCodeMCPEndpoint:
         self._notify_broker = broker
 
     def _register_session(self, session: Any) -> None:
-        """Capture the active ServerSession.
-
-        Most-recent-wins: a new session replaces any prior one. The previous
-        session's `_claim_session.finally:` will eventually run (when its
-        task group cancels) and call `_unregister_session(old_session)`,
-        which is identity-checked and will no-op against the new slot.
-        """
-        replaced = self._active_session is not None and self._active_session is not session
-        self._active_session = session
-        self._session_active = True
-        if replaced:
-            log.info(
-                "endpoint '%s': replaced active session with newer connection",
-                self.name,
-            )
-        else:
-            log.debug("endpoint '%s' captured active session", self.name)
+        """Register a connected ServerSession."""
+        before = len(self._sessions)
+        self._sessions.add(session)
+        if len(self._sessions) != before:
+            log.debug("endpoint '%s' registered session count=%d", self.name, len(self._sessions))
 
     def _unregister_session(self, session: Any) -> None:
-        """Clear the slot if the session matches the one we hold."""
-        if self._active_session is session:
-            self._active_session = None
-            self._session_active = False
-            log.debug("endpoint '%s' released active session", self.name)
+        """Unregister a ServerSession."""
+        before = len(self._sessions)
+        self._sessions.discard(session)
+        if len(self._sessions) != before:
+            log.debug("endpoint '%s' unregistered session count=%d", self.name, len(self._sessions))
 
     async def _call_list_pending(self, batch_window_seconds: int = 0) -> list[dict]:
         """Mailbox view sorted by urgency, optionally batched by sender.
@@ -258,17 +245,15 @@ class ClaudeCodeMCPEndpoint:
         knows direct push isn't available and applies its retry/log semantics.
 
         The broker fan-out is unconditional; the HTTP push leg inside
-        _fire_after_debounce is already guarded by `if self._active_session is
-        not None`, so this path is safe to take with no session attached."""
+        _fire_after_debounce is guarded by the connected session set."""
         self.queue_for_pickup(envelope)
         await self._notify_mail_arrived(envelope.urgency)
-        if not self._session_active:
+        if not self._sessions:
             raise EndpointUnavailable(f"no MCP session connected for {self.name}")
 
     async def stop(self) -> None:
         self._handle = None
-        self._session_active = False
-        self._active_session = None
+        self._sessions.clear()
         if self._debounce_task is not None and not self._debounce_task.done():
             self._debounce_task.cancel()
             try:
@@ -418,32 +403,32 @@ class ClaudeCodeMCPEndpoint:
             except Exception:
                 log.warning("endpoint '%s': broker publish failed", self.name, exc_info=True)
 
-        session = self._active_session
-        if session is None:
+        sessions = list(self._sessions)
+        if not sessions:
             log.info(
                 "endpoint '%s': debounce fired; no active session, skipping HTTP push",
                 self.name,
             )
             return
-        try:
-            message = self._make_channel_notification(summary)
-            log.info(
-                "endpoint '%s': pushing notifications/claude/channel to session %d (count=%d)",
-                self.name,
-                id(session),
-                summary["meta"]["count"],
-            )
-            await session.send_message(message)
-            log.info("endpoint '%s': push to session %d returned", self.name, id(session))
-        except Exception:
-            log.warning(
-                "endpoint '%s': push to active session failed; clearing slot",
-                self.name,
-                exc_info=True,
-            )
-            if self._active_session is session:
-                self._active_session = None
-                self._session_active = False
+        message = self._make_channel_notification(summary)
+        for session in sessions:
+            try:
+                log.info(
+                    "endpoint '%s': pushing notifications/claude/channel to session %d (count=%d)",
+                    self.name,
+                    id(session),
+                    summary["meta"]["count"],
+                )
+                await session.send_message(message)
+                log.info("endpoint '%s': push to session %d returned", self.name, id(session))
+            except Exception:
+                log.warning(
+                    "endpoint '%s': push to session %d failed; unregistering",
+                    self.name,
+                    id(session),
+                    exc_info=True,
+                )
+                self._unregister_session(session)
 
     def _register_tools(self) -> None:
         """Register the bus's MCP tool surface on the FastMCP server."""

--- a/packages/core/src/agent_core/hooks/pipeline.py
+++ b/packages/core/src/agent_core/hooks/pipeline.py
@@ -35,7 +35,7 @@ from rich.logging import RichHandler
 
 from agent_core.hooks.protocol import HookTool
 from agent_core.models import PipelineConfig, ToolResult
-from agent_core.plugins.manager import create_plugin_manager
+from agent_core.plugins.manager import create_plugin_manager, get_hook_tool_types
 
 logging.basicConfig(
     level=logging.INFO,
@@ -57,28 +57,27 @@ class Pipeline:
         self.config = PipelineConfig(**raw)
         self.config_path = config_path
         self._plugin_manager = create_plugin_manager()
+        self._hook_tool_types = get_hook_tool_types(self._plugin_manager)
 
         for event, tools in self.config.pipelines.items():
-            tool_names = [t.tool.rsplit(".", 1)[-1] for t in tools]
+            tool_names = [t.type for t in tools]
             logger.info(
                 "Event '%s': %d tool(s) registered — %s", event, len(tools), ", ".join(tool_names)
             )
 
-    def _import_tool_class(self, class_path: str) -> type | None:
-        """Dynamically import a tool class from its fully qualified path."""
-        resolved = self._plugin_manager.hook.resolve_hook_tool_class(tool_class=class_path)
-        if resolved is None:
-            resolved = self._plugin_manager.hook.resolve_class(class_path=class_path)
+    def _import_tool_class(self, tool_type: str) -> type | None:
+        """Resolve a hook tool class from a registered tool type id."""
+        resolved = self._hook_tool_types.get(tool_type)
         if resolved is not None:
             cls = resolved
         else:
-            logger.error("Failed to import tool '%s': no plugin resolved class path", class_path)
+            logger.error("Failed to import tool '%s': unknown hook tool type", tool_type)
             return None
 
         if not isinstance(cls, type) or not issubclass(cls, HookTool):
             instance = cls()
             if not isinstance(instance, HookTool):
-                logger.error("Tool '%s' does not implement HookTool protocol", class_path)
+                logger.error("Tool '%s' does not implement HookTool protocol", tool_type)
                 return None
 
         return cls
@@ -93,7 +92,7 @@ class Pipeline:
         results: list[ToolResult] = []
 
         for tool_config in tool_configs:
-            cls = self._import_tool_class(tool_config.tool)
+            cls = self._import_tool_class(tool_config.type)
             if cls is None:
                 continue
 
@@ -103,9 +102,9 @@ class Pipeline:
                     event=event, hook_input=hook_input, params=tool_config.params
                 )
                 results.append(result)
-                logger.info("Tool '%s' executed successfully", tool_config.tool.rsplit(".", 1)[-1])
+                logger.info("Tool '%s' executed successfully", tool_config.type)
             except Exception as e:
-                logger.error("Tool '%s' failed during execution: %s", tool_config.tool, e)
+                logger.error("Tool '%s' failed during execution: %s", tool_config.type, e)
 
         return results
 

--- a/packages/core/src/agent_core/models.py
+++ b/packages/core/src/agent_core/models.py
@@ -8,9 +8,8 @@ the pipeline runner, and the CLI configuration layer. There are three models:
   content (the actual payload injected into the hook response).
 
 - **ToolConfig**: A single entry in a pipeline configuration, identifying
-  which tool class to load and what parameters to pass to it. The ``tool``
-  field is a fully qualified Python class path that the pipeline runner
-  resolves at runtime via importlib.
+  which hook tool type to load and what parameters to pass to it. The ``type``
+  field is a plugin-registered type id resolved by the pipeline runner.
 
 - **PipelineConfig**: The root configuration object that maps Claude Code
   hook event names (e.g. ``"SessionStart"``, ``"PreToolUse"``) to ordered
@@ -27,9 +26,9 @@ Example usage::
     # Configure a pipeline from data
     config = PipelineConfig(pipelines={
         "SessionStart": [
-            ToolConfig(tool="agent_core.hooks.tools.time_injector.TimeInjector"),
+            ToolConfig(type="builtin.time_injector"),
             ToolConfig(
-                tool="agent_core.hooks.tools.kb_injector.KBInjector",
+                type="plugin.kb_injector",
                 params={"index_path": "knowledge/index.md"},
             ),
         ],
@@ -69,15 +68,12 @@ class ToolResult(BaseModel):
 class ToolConfig(BaseModel):
     """Configuration for a single tool in a hook pipeline.
 
-    Each ``ToolConfig`` tells the pipeline runner which tool class to
-    instantiate and what parameters to pass to it. The ``tool`` field is
-    a fully qualified Python class path (e.g.
-    ``"agent_core.hooks.tools.time_injector.TimeInjector"``) that the
-    runner resolves dynamically via ``importlib``.
+    Each ``ToolConfig`` tells the pipeline runner which hook tool type to
+    instantiate and what parameters to pass to it. The ``type`` field is
+    a plugin-registered type id (e.g. ``"builtin.time_injector"``).
 
     Attributes:
-        tool: Fully qualified Python class path to the hook tool
-            implementation. The referenced class must conform to the
+        type: Registered hook tool type id. The resolved class must conform to the
             ``HookTool`` protocol (see ``agent_core.protocol``).
         params: Optional dictionary of keyword arguments passed to the
             tool's constructor. Defaults to an empty dict. These let
@@ -87,12 +83,12 @@ class ToolConfig(BaseModel):
     Example::
 
         config = ToolConfig(
-            tool="agent_core.hooks.tools.time_injector.TimeInjector",
+            type="builtin.time_injector",
             params={"format": "%Y-%m-%d"},
         )
     """
 
-    tool: str
+    type: str
     params: dict = {}
 
 
@@ -118,11 +114,11 @@ class PipelineConfig(BaseModel):
 
         config = PipelineConfig(pipelines={
             "SessionStart": [
-                ToolConfig(tool="agent_core.hooks.tools.time_injector.TimeInjector"),
-                ToolConfig(tool="agent_core.hooks.tools.kb_injector.KBInjector"),
+                ToolConfig(type="builtin.time_injector"),
+                ToolConfig(type="plugin.kb_injector"),
             ],
             "PreToolUse": [
-                ToolConfig(tool="agent_core.hooks.tools.guard.GuardTool"),
+                ToolConfig(type="plugin.guard"),
             ],
         })
     """

--- a/packages/core/src/agent_core/plugins/builtin_aliases.py
+++ b/packages/core/src/agent_core/plugins/builtin_aliases.py
@@ -1,0 +1,51 @@
+"""Built-in alias plugin for common endpoint/tool class paths.
+
+This plugin provides short, stable aliases that resolve to concrete runtime
+classes. It is loaded through the ``agent_core`` entrypoint group.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pluggy
+
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+from agent_core.endpoints.scheduler import SchedulerEndpoint
+from agent_core.endpoints.stub import StubEndpoint
+from agent_core.hooks.tools.handoff_writer import HandoffWriter
+from agent_core.hooks.tools.identity_injector import IdentityInjector
+from agent_core.hooks.tools.time_injector import TimeInjector
+
+hookimpl = pluggy.HookimplMarker("agent_core")
+
+
+_ENDPOINT_TYPES: dict[str, type[Any]] = {
+    "builtin.claude_code_mcp": ClaudeCodeMCPEndpoint,
+    "builtin.stub": StubEndpoint,
+    "builtin.scheduler": SchedulerEndpoint,
+}
+
+_HOOK_TOOL_TYPES: dict[str, type[Any]] = {
+    "builtin.handoff_writer": HandoffWriter,
+    "builtin.identity_injector": IdentityInjector,
+    "builtin.time_injector": TimeInjector,
+}
+
+
+@hookimpl
+def register_endpoint_types() -> dict[str, type[Any]]:
+    endpoint_types = dict(_ENDPOINT_TYPES)
+    if "builtin.discord" not in endpoint_types:
+        try:
+            from agent_core_discord.endpoint import DiscordEndpoint  # type: ignore[import-untyped]
+        except ImportError:
+            pass
+        else:
+            endpoint_types["builtin.discord"] = DiscordEndpoint
+    return endpoint_types
+
+
+@hookimpl
+def register_hook_tool_types() -> dict[str, type[Any]]:
+    return dict(_HOOK_TOOL_TYPES)

--- a/packages/core/src/agent_core/plugins/example_entrypoint.py
+++ b/packages/core/src/agent_core/plugins/example_entrypoint.py
@@ -16,23 +16,18 @@ hookimpl = pluggy.HookimplMarker("agent_core")
 
 
 @hookimpl
-def resolve_class(class_path: str) -> type[Any] | None:
-    return None
+def register_endpoint_types() -> dict[str, type[Any]]:
+    return {}
 
 
 @hookimpl
-def resolve_endpoint_class(endpoint_class: str) -> type[Any] | None:
-    return None
+def register_bus_hook_types() -> dict[str, type[Any]]:
+    return {}
 
 
 @hookimpl
-def resolve_bus_hook_class(hook_class: str) -> type[Any] | None:
-    return None
-
-
-@hookimpl
-def resolve_hook_tool_class(tool_class: str) -> type[Any] | None:
-    return None
+def register_hook_tool_types() -> dict[str, type[Any]]:
+    return {}
 
 
 @hookimpl

--- a/packages/core/src/agent_core/plugins/manager.py
+++ b/packages/core/src/agent_core/plugins/manager.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import importlib
 import logging
+from collections.abc import Iterable
 from typing import Any
 
 import pluggy
@@ -13,6 +13,10 @@ from agent_core.plugins.specs import AgentCoreSpecs
 
 log = logging.getLogger(__name__)
 hookimpl = pluggy.HookimplMarker("agent_core")
+
+
+class PluginRegistryError(Exception):
+    """Raised when plugin type registrations are invalid."""
 
 
 class BuiltinRuntimePlugin:
@@ -34,30 +38,45 @@ class BuiltinRuntimePlugin:
         return None
 
 
-class BuiltinImportResolverPlugin:
-    """Built-in fallback resolver for dotted import class paths."""
-
-    @hookimpl(trylast=True)
-    def resolve_class(self, class_path: str) -> type[Any] | None:
-        module_path, _, class_name = class_path.rpartition(".")
-        if not module_path:
-            return None
-        try:
-            module = importlib.import_module(module_path)
-        except ImportError:
-            return None
-        resolved = getattr(module, class_name, None)
-        return resolved if isinstance(resolved, type) else None
-
-
 def create_plugin_manager() -> pluggy.PluginManager:
     """Create and populate the agent_core Pluggy manager."""
     pm = pluggy.PluginManager("agent_core")
     pm.add_hookspecs(AgentCoreSpecs)
     pm.register(BuiltinRuntimePlugin(), name="agent_core_builtin_runtime")
-    pm.register(BuiltinImportResolverPlugin(), name="agent_core_builtin_import_resolver")
     try:
         pm.load_setuptools_entrypoints("agent_core")
     except Exception:
         log.warning("failed loading agent_core entry-point plugins", exc_info=True)
     return pm
+
+
+def _merge_type_maps(
+    groups: Iterable[dict[str, type[Any]]] | dict[str, type[Any]],
+    *,
+    kind: str,
+) -> dict[str, type[Any]]:
+    merged: dict[str, type[Any]] = {}
+    if isinstance(groups, dict):
+        groups_iterable: Iterable[dict[str, type[Any]]] = [groups]
+    else:
+        groups_iterable = groups
+    for mapping in groups_iterable:
+        for type_id, cls in mapping.items():
+            if type_id in merged and merged[type_id] is not cls:
+                raise PluginRegistryError(
+                    f"duplicate {kind} type id {type_id!r} registered by multiple plugins"
+                )
+            merged[type_id] = cls
+    return merged
+
+
+def get_endpoint_types(pm: pluggy.PluginManager) -> dict[str, type[Any]]:
+    return _merge_type_maps(pm.hook.register_endpoint_types(), kind="endpoint")
+
+
+def get_bus_hook_types(pm: pluggy.PluginManager) -> dict[str, type[Any]]:
+    return _merge_type_maps(pm.hook.register_bus_hook_types(), kind="bus-hook")
+
+
+def get_hook_tool_types(pm: pluggy.PluginManager) -> dict[str, type[Any]]:
+    return _merge_type_maps(pm.hook.register_hook_tool_types(), kind="hook-tool")

--- a/packages/core/src/agent_core/plugins/specs.py
+++ b/packages/core/src/agent_core/plugins/specs.py
@@ -25,21 +25,20 @@ class RunnerServices:
 class AgentCoreSpecs:
     """Hook contracts for discovery and runtime wiring."""
 
-    @hookspec(firstresult=True)
-    def resolve_class(self, class_path: str) -> type[Any] | None:
-        """Return a class for `class_path`, or None to defer."""
+    @hookspec
+    def register_endpoint_types(self) -> dict[str, type[Endpoint]]:
+        """Return endpoint type-id -> class registrations."""
+        raise NotImplementedError
 
-    @hookspec(firstresult=True)
-    def resolve_endpoint_class(self, endpoint_class: str) -> type[Endpoint] | None:
-        """Return an endpoint class for `endpoint_class`, or None to defer."""
+    @hookspec
+    def register_bus_hook_types(self) -> dict[str, type[BusHook]]:
+        """Return bus-hook type-id -> class registrations."""
+        raise NotImplementedError
 
-    @hookspec(firstresult=True)
-    def resolve_bus_hook_class(self, hook_class: str) -> type[BusHook] | None:
-        """Return a bus-hook class for `hook_class`, or None to defer."""
-
-    @hookspec(firstresult=True)
-    def resolve_hook_tool_class(self, tool_class: str) -> type[HookTool] | None:
-        """Return a hook-tool class for `tool_class`, or None to defer."""
+    @hookspec
+    def register_hook_tool_types(self) -> dict[str, type[HookTool]]:
+        """Return hook-tool type-id -> class registrations."""
+        raise NotImplementedError
 
     @hookspec
     def configure_endpoint_instance(

--- a/packages/core/tests/bus/test_cli_dlq.py
+++ b/packages/core/tests/bus/test_cli_dlq.py
@@ -16,7 +16,7 @@ def _write_config(tmp_path: Path) -> Path:
         "bus": {"storage_path": str(tmp_path / "bus.sqlite")},
         "endpoints": [
             {
-                "class": "agent_core.endpoints.stub.StubEndpoint",
+                "type": "builtin.stub",
                 "name": "stub",
                 "params": {},
             }

--- a/packages/core/tests/bus/test_cli_run.py
+++ b/packages/core/tests/bus/test_cli_run.py
@@ -18,7 +18,7 @@ def cfg_path(tmp_path: Path) -> Path:
         "bus": {"storage_path": str(tmp_path / "bus.sqlite")},
         "endpoints": [
             {
-                "class": "agent_core.endpoints.stub.StubEndpoint",
+                "type": "builtin.stub",
                 "name": "stub",
                 "description": "test",
                 "params": {},

--- a/packages/core/tests/bus/test_cli_status.py
+++ b/packages/core/tests/bus/test_cli_status.py
@@ -16,13 +16,13 @@ def _write_config(tmp_path: Path) -> Path:
         "bus": {"storage_path": str(tmp_path / "bus.sqlite")},
         "endpoints": [
             {
-                "class": "agent_core.endpoints.stub.StubEndpoint",
+                "type": "builtin.stub",
                 "name": "stub-a",
                 "description": "first",
                 "params": {},
             },
             {
-                "class": "agent_core.endpoints.stub.StubEndpoint",
+                "type": "builtin.stub",
                 "name": "stub-b",
                 "description": "second",
                 "params": {},

--- a/packages/core/tests/bus/test_cli_trace.py
+++ b/packages/core/tests/bus/test_cli_trace.py
@@ -16,7 +16,7 @@ def _write_config(tmp_path: Path) -> Path:
         "bus": {"storage_path": str(tmp_path / "bus.sqlite")},
         "endpoints": [
             {
-                "class": "agent_core.endpoints.stub.StubEndpoint",
+                "type": "builtin.stub",
                 "name": "a",
                 "params": {},
             }

--- a/packages/core/tests/bus/test_integration.py
+++ b/packages/core/tests/bus/test_integration.py
@@ -23,13 +23,13 @@ def cfg_path(tmp_path: Path) -> Path:
         },
         "endpoints": [
             {
-                "class": "agent_core.endpoints.stub.StubEndpoint",
+                "type": "builtin.stub",
                 "name": "alice",
                 "description": "First test endpoint.",
                 "params": {},
             },
             {
-                "class": "agent_core.endpoints.stub.StubEndpoint",
+                "type": "builtin.stub",
                 "name": "bob",
                 "description": "Second test endpoint.",
                 "params": {},

--- a/packages/core/tests/bus/test_runner.py
+++ b/packages/core/tests/bus/test_runner.py
@@ -21,13 +21,13 @@ def cfg_path(tmp_path: Path) -> Path:
         "http": {"bind_host": "127.0.0.1", "bind_port": 18788},
         "endpoints": [
             {
-                "class": "agent_core.endpoints.stub.StubEndpoint",
+                "type": "builtin.stub",
                 "name": "stub-a",
                 "description": "First stub.",
                 "params": {"auto_ack": True},
             },
             {
-                "class": "agent_core.endpoints.stub.StubEndpoint",
+                "type": "builtin.stub",
                 "name": "stub-b",
                 "description": "Second stub.",
                 "params": {},
@@ -56,7 +56,7 @@ class TestRunner:
         config = {
             "endpoints": [
                 {
-                    "class": "agent_core.endpoints.does_not_exist.Foo",
+                    "type": "does.not_exist.Foo",
                     "name": "x",
                     "params": {},
                 }
@@ -68,11 +68,11 @@ class TestRunner:
             await build_bus_from_config(p)
 
     async def test_class_not_endpoint_protocol(self, tmp_path: Path):
-        # Pick something that's importable but doesn't satisfy Endpoint.
-        config = {"endpoints": [{"class": "datetime.datetime", "name": "x", "params": {}}]}
+        # Unknown class aliases are rejected in strict plugin-resolution mode.
+        config = {"endpoints": [{"type": "datetime.datetime", "name": "x", "params": {}}]}
         p = tmp_path / "bad.yaml"
         p.write_text(yaml.dump(config))
-        with pytest.raises(BusBootError, match="does not satisfy Endpoint"):
+        with pytest.raises(BusBootError, match="unknown endpoint type"):
             await build_bus_from_config(p)
 
     async def test_non_loopback_bind_refused(self, tmp_path: Path):
@@ -86,17 +86,17 @@ class TestRunner:
             await build_bus_from_config(p)
 
     async def test_endpoint_missing_name_raises(self, tmp_path: Path):
-        config = {"endpoints": [{"class": "agent_core.endpoints.stub.StubEndpoint", "params": {}}]}
+        config = {"endpoints": [{"type": "builtin.stub", "params": {}}]}
         p = tmp_path / "bad.yaml"
         p.write_text(yaml.dump(config))
         with pytest.raises(BusBootError, match="missing required 'name'"):
             await build_bus_from_config(p)
 
-    async def test_endpoint_missing_class_raises(self, tmp_path: Path):
+    async def test_endpoint_missing_type_raises(self, tmp_path: Path):
         config = {"endpoints": [{"name": "x", "params": {}}]}
         p = tmp_path / "bad.yaml"
         p.write_text(yaml.dump(config))
-        with pytest.raises(BusBootError, match="missing required 'class'"):
+        with pytest.raises(BusBootError, match="missing required 'type'"):
             await build_bus_from_config(p)
 
     async def test_plugin_can_resolve_endpoint_class(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -110,26 +110,20 @@ class TestRunner:
 
         class _Hook:
             @staticmethod
-            def resolve_class(*, class_path: str):
-                if class_path == "plugin.stub.Endpoint":
-                    return _PluginEndpoint
-                return None
+            def register_endpoint_types():
+                return {"plugin.stub.Endpoint": _PluginEndpoint}
 
             @staticmethod
             def validate_config(*, raw_config):
                 return None
 
             @staticmethod
-            def resolve_endpoint_class(*, endpoint_class: str):
-                return None
+            def register_bus_hook_types():
+                return {}
 
             @staticmethod
-            def resolve_bus_hook_class(*, hook_class: str):
-                return None
-
-            @staticmethod
-            def resolve_hook_tool_class(*, tool_class: str):
-                return None
+            def register_hook_tool_types():
+                return {}
 
             @staticmethod
             def configure_endpoint_instance(*, instance, endpoint_name, endpoint_config, services):
@@ -144,7 +138,7 @@ class TestRunner:
 
         monkeypatch.setattr("agent_core.bus.runner.create_plugin_manager", lambda: _PluginManager())
 
-        config = {"endpoints": [{"class": "plugin.stub.Endpoint", "name": "plug", "params": {}}]}
+        config = {"endpoints": [{"type": "plugin.stub.Endpoint", "name": "plug", "params": {}}]}
         p = tmp_path / "plugin.yaml"
         p.write_text(yaml.dump(config))
         bus, _ = await build_bus_from_config(p)

--- a/packages/core/tests/test_bus_daemon_integration.py
+++ b/packages/core/tests/test_bus_daemon_integration.py
@@ -32,12 +32,12 @@ http:
   bind_host: 127.0.0.1
   bind_port: 0
 endpoints:
-  - class: agent_core.endpoints.claude_code_mcp.ClaudeCodeMCPEndpoint
+  - type: builtin.claude_code_mcp
     name: agent-test
     description: "test agent for integration"
     params:
       mount: /mcp/agent-test
-  - class: agent_core.endpoints.stub.StubEndpoint
+  - type: builtin.stub
     name: stub
     description: "echo for tests"
 """,

--- a/packages/core/tests/test_bus_daemon_push_integration.py
+++ b/packages/core/tests/test_bus_daemon_push_integration.py
@@ -47,12 +47,12 @@ http:
   bind_host: 127.0.0.1
   bind_port: 0
 endpoints:
-  - class: agent_core.endpoints.claude_code_mcp.ClaudeCodeMCPEndpoint
+  - type: builtin.claude_code_mcp
     name: agent
     description: "agent under test"
     params:
       mount: /mcp/agent
-  - class: agent_core.endpoints.stub.StubEndpoint
+  - type: builtin.stub
     name: stub
     description: "test publisher"
 """,
@@ -113,17 +113,18 @@ endpoints:
                     # Drive a tool call so the SessionRegistry middleware's
                     # spawned `_claim_session` coroutine actually gets a
                     # scheduling opportunity. (The same trick the unit test
-                    # `test_session_active_flag_set_after_mcp_message` uses.)
+                    # `test_session_registry_tracks_connected_sessions_after_mcp_message`
+                    # uses.)
                     await session.call_tool("list_pending", {})
 
                     # Wait briefly for SessionRegistry to claim the session.
                     agent_ep = bus._endpoints_by_name["agent"].endpoint
                     for _ in range(40):
-                        if agent_ep._active_session is not None:
+                        if agent_ep._sessions:
                             break
                         await asyncio.sleep(0.05)
-                    assert agent_ep._active_session is not None, (
-                        "SessionRegistry middleware did not capture the active session"
+                    assert agent_ep._sessions, (
+                        "SessionRegistry middleware did not capture any active session"
                     )
 
                     # Publish an envelope to the agent via the stub's BusHandle,

--- a/packages/core/tests/test_claude_code_mcp.py
+++ b/packages/core/tests/test_claude_code_mcp.py
@@ -333,12 +333,12 @@ async def test_deliver_retried_with_same_envelope_does_not_duplicate():
 
 
 @pytest.mark.asyncio
-async def test_session_active_flag_set_after_mcp_message():
-    """SessionRegistry middleware sets _session_active=True after first MCP message.
+async def test_session_registry_tracks_connected_sessions_after_mcp_message():
+    """SessionRegistry tracks connected sessions after first MCP message.
 
     The new SessionRegistry middleware spawns a long-lived coroutine into
     session._subscription_task_group on the first on_message; the coroutine
-    calls _register_session, which flips _session_active. Because the spawned
+    calls _register_session. Because the spawned
     task only runs once the event loop yields to it, we exercise an actual
     tool call (rather than relying on Client.__aenter__ alone) to ensure the
     registration coroutine has had a chance to run."""
@@ -346,14 +346,13 @@ async def test_session_active_flag_set_after_mcp_message():
     handle = _RecordingHandleWithPending(pending=[])
     await ep.start(handle)
     try:
-        assert ep._session_active is False
+        assert not ep._sessions
         async with Client(ep._mcp) as client:
             # Trigger a tool call so on_message fires and the spawned
             # _claim_session coroutine has scheduling opportunities.
             await client.call_tool("list_pending", {})
             # After the tool call, the session has been registered.
-            assert ep._session_active is True
-            assert ep._active_session is not None
+            assert ep._sessions
             # deliver() must NOT raise while session is active.
             env = _make_envelope("env-active")
             await ep.deliver(env)
@@ -363,5 +362,4 @@ async def test_session_active_flag_set_after_mcp_message():
             assert "env-active" in ids
     finally:
         await ep.stop()
-        assert ep._session_active is False
-        assert ep._active_session is None
+        assert not ep._sessions

--- a/packages/core/tests/test_cli.py
+++ b/packages/core/tests/test_cli.py
@@ -16,7 +16,7 @@ def make_config(tmp_path: Path) -> Path:
         "pipelines": {
             "SessionStart": [
                 {
-                    "tool": "agent_core.hooks.tools.time_injector.TimeInjector",
+                    "type": "builtin.time_injector",
                     "params": {"format": "%Y-%m-%d"},
                 }
             ],

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -55,7 +55,7 @@ def test_start_writes_pid_file_and_stop_kills(tmp_path: Path, monkeypatch: pytes
 bus:
   storage_path: {tmp_path / "bus.sqlite"}
 endpoints:
-  - class: agent_core.endpoints.stub.StubEndpoint
+  - type: builtin.stub
     name: stub
 """,
         encoding="utf-8",

--- a/packages/core/tests/test_models.py
+++ b/packages/core/tests/test_models.py
@@ -23,18 +23,18 @@ class TestToolResult:
 
 class TestToolConfig:
     def test_create_tool_config(self):
-        config = ToolConfig(tool="agent_core.hooks.tools.time_injector.TimeInjector")
-        assert config.tool == "agent_core.hooks.tools.time_injector.TimeInjector"
+        config = ToolConfig(type="builtin.time_injector")
+        assert config.type == "builtin.time_injector"
         assert config.params == {}
 
     def test_tool_config_with_params(self):
         config = ToolConfig(
-            tool="agent_core.hooks.tools.time_injector.TimeInjector",
+            type="builtin.time_injector",
             params={"format": "%Y-%m-%d"},
         )
         assert config.params == {"format": "%Y-%m-%d"}
 
-    def test_tool_config_requires_tool(self):
+    def test_tool_config_requires_type(self):
         with pytest.raises(ValidationError):
             ToolConfig(params={"format": "%Y-%m-%d"})
 
@@ -44,7 +44,7 @@ class TestPipelineConfig:
         config = PipelineConfig(
             pipelines={
                 "SessionStart": [
-                    ToolConfig(tool="agent_core.hooks.tools.time_injector.TimeInjector"),
+                    ToolConfig(type="builtin.time_injector"),
                 ],
             }
         )
@@ -56,7 +56,7 @@ class TestPipelineConfig:
         assert config.pipelines == {}
 
     def test_multiple_events(self):
-        tool = ToolConfig(tool="some.tool.Class")
+        tool = ToolConfig(type="some.tool.Class")
         config = PipelineConfig(
             pipelines={
                 "SessionStart": [tool, tool],

--- a/packages/core/tests/test_notify_broker_publish_hook.py
+++ b/packages/core/tests/test_notify_broker_publish_hook.py
@@ -73,7 +73,7 @@ async def test_endpoint_publishes_to_broker_even_when_no_session():
 async def test_deliver_publishes_to_broker_when_no_session_attached():
     """deliver() must fan out to the broker even when no HTTP MCP session is connected.
 
-    The relay maintains its own SSE subscription independent of _session_active.
+    The relay maintains its own SSE subscription independent of direct HTTP push.
     Without this contract, an agent connected only via the stdio relay (not via
     HTTP MCP) would never wake on new arrivals.
     """
@@ -81,8 +81,7 @@ async def test_deliver_publishes_to_broker_when_no_session_attached():
     queue = await broker.subscribe("agent")
 
     ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent", notify_broker=broker)
-    # Notice: NO session attached. _session_active is False by default.
-    assert ep._session_active is False
+    assert not ep._sessions
 
     env = _env("e1", urgency="red")
     env = env.model_copy(update={"to": "agent"})

--- a/packages/core/tests/test_notify_mail_arrived.py
+++ b/packages/core/tests/test_notify_mail_arrived.py
@@ -98,6 +98,25 @@ async def test_notify_pushes_summary_when_session_active():
 
 
 @pytest.mark.asyncio
+async def test_notify_push_fans_out_to_all_registered_sessions():
+    ep = ClaudeCodeMCPEndpoint(name="a", mount="/mcp/a")
+    _speed_up_debounce(ep)
+    session_a = _RecordingSession()
+    session_b = _RecordingSession()
+    ep._register_session(session_a)
+    ep._register_session(session_b)
+    ep._pending = [_env("e1", urgency="green")]
+
+    await ep._notify_mail_arrived("green")
+    await asyncio.sleep(0.1)
+
+    assert len(session_a.sent) == 1
+    assert len(session_b.sent) == 1
+    assert _extract_method(session_a.sent[0]) == "notifications/claude/channel"
+    assert _extract_method(session_b.sent[0]) == "notifications/claude/channel"
+
+
+@pytest.mark.asyncio
 async def test_notify_channel_meta_values_are_strings_on_http_push_path():
     ep = ClaudeCodeMCPEndpoint(name="a", mount="/mcp/a")
     _speed_up_debounce(ep)
@@ -172,7 +191,7 @@ async def test_notify_summary_groups_by_sender():
 
 
 @pytest.mark.asyncio
-async def test_notify_clears_session_slot_on_send_failure():
+async def test_notify_unregisters_failed_session_on_send_failure():
     ep = ClaudeCodeMCPEndpoint(name="a", mount="/mcp/a")
     _speed_up_debounce(ep)
     session = _RecordingSession(fail_with=ConnectionError("stream closed"))
@@ -182,9 +201,7 @@ async def test_notify_clears_session_slot_on_send_failure():
     await ep._notify_mail_arrived("green")
     await asyncio.sleep(0.1)
 
-    # Slot must have been cleared so future deliveries fall back to polling.
-    assert ep._active_session is None
-    assert ep._session_active is False
+    assert session not in ep._sessions
 
 
 def test_notify_debounce_defaults_are_urgency_aware():

--- a/packages/core/tests/test_pipeline.py
+++ b/packages/core/tests/test_pipeline.py
@@ -15,12 +15,12 @@ def config_file(tmp_path: Path) -> Path:
         "pipelines": {
             "SessionStart": [
                 {
-                    "tool": "agent_core.hooks.tools.time_injector.TimeInjector",
+                    "type": "builtin.time_injector",
                     "params": {"format": "%Y-%m-%d"},
                 }
             ],
             "PreToolUse": [
-                {"tool": "agent_core.hooks.tools.time_injector.TimeInjector"},
+                {"type": "builtin.time_injector"},
             ],
         }
     }
@@ -81,11 +81,11 @@ class TestPipelineRun:
             "pipelines": {
                 "SessionStart": [
                     {
-                        "tool": "agent_core.hooks.tools.time_injector.TimeInjector",
+                        "type": "builtin.time_injector",
                         "params": {"format": "%Y"},
                     },
                     {
-                        "tool": "agent_core.hooks.tools.time_injector.TimeInjector",
+                        "type": "builtin.time_injector",
                         "params": {"format": "%m"},
                     },
                 ],
@@ -103,8 +103,8 @@ class TestPipelineRun:
         config = {
             "pipelines": {
                 "SessionStart": [
-                    {"tool": "nonexistent.module.FakeTool"},
-                    {"tool": "agent_core.hooks.tools.time_injector.TimeInjector"},
+                    {"type": "nonexistent.module.FakeTool"},
+                    {"type": "builtin.time_injector"},
                 ],
             }
         }

--- a/packages/core/tests/test_plugins.py
+++ b/packages/core/tests/test_plugins.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path
 from typing import Any
 
@@ -8,7 +7,6 @@ import yaml
 from agent_core.bus.runner import build_bus_from_config
 from agent_core.hooks.pipeline import Pipeline
 from agent_core.models import ToolResult
-from agent_core.plugins.manager import create_plugin_manager
 
 
 class _PluginEndpoint:
@@ -33,32 +31,20 @@ class _PluginTool:
 def _base_hook():
     class _Hook:
         @staticmethod
-        def resolve_class(*, class_path: str):
-            module_path, _, class_name = class_path.rpartition(".")
-            if not module_path:
-                return None
-            try:
-                module = importlib.import_module(module_path)
-            except ImportError:
-                return None
-            resolved = getattr(module, class_name, None)
-            return resolved if isinstance(resolved, type) else None
-
-        @staticmethod
         def validate_config(*, raw_config):
             return None
 
         @staticmethod
-        def resolve_endpoint_class(*, endpoint_class: str):
-            return None
+        def register_endpoint_types():
+            return {}
 
         @staticmethod
-        def resolve_bus_hook_class(*, hook_class: str):
-            return None
+        def register_bus_hook_types():
+            return {}
 
         @staticmethod
-        def resolve_hook_tool_class(*, tool_class: str):
-            return None
+        def register_hook_tool_types():
+            return {}
 
         @staticmethod
         def configure_endpoint_instance(*, instance, endpoint_name, endpoint_config, services):
@@ -77,34 +63,24 @@ class TestRunnerPluginHooks:
 
         class _Hook(Hook):
             @staticmethod
-            def resolve_endpoint_class(*, endpoint_class: str):
-                if endpoint_class == "plugin.stub.Endpoint":
-                    return _PluginEndpoint
-                return None
+            def register_endpoint_types():
+                return {"plugin.stub.Endpoint": _PluginEndpoint}
 
         class _PluginManager:
             hook = _Hook()
 
         monkeypatch.setattr("agent_core.bus.runner.create_plugin_manager", lambda: _PluginManager())
 
-        config = {"endpoints": [{"class": "plugin.stub.Endpoint", "name": "plug", "params": {}}]}
+        config = {"endpoints": [{"type": "plugin.stub.Endpoint", "name": "plug", "params": {}}]}
         p = tmp_path / "plugin-endpoint.yaml"
         p.write_text(yaml.dump(config), encoding="utf-8")
         bus, _ = await build_bus_from_config(p)
         assert "plug" in bus._endpoints_by_name
 
-    async def test_endpoint_specific_resolver_precedes_generic(
+    async def test_endpoint_requires_specific_resolver(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
         Hook = _base_hook()
-
-        class _GenericEndpoint:
-            def __init__(self, *, name: str, **_: Any):
-                self.name = name
-
-            async def start(self, bus): ...
-            async def deliver(self, envelope): ...
-            async def stop(self): ...
 
         class _SpecificEndpoint:
             def __init__(self, *, name: str, **_: Any):
@@ -116,23 +92,15 @@ class TestRunnerPluginHooks:
 
         class _Hook(Hook):
             @staticmethod
-            def resolve_endpoint_class(*, endpoint_class: str):
-                if endpoint_class == "plugin.stub.Endpoint":
-                    return _SpecificEndpoint
-                return None
-
-            @staticmethod
-            def resolve_class(*, class_path: str):
-                if class_path == "plugin.stub.Endpoint":
-                    return _GenericEndpoint
-                return None
+            def register_endpoint_types():
+                return {"plugin.stub.Endpoint": _SpecificEndpoint}
 
         class _PluginManager:
             hook = _Hook()
 
         monkeypatch.setattr("agent_core.bus.runner.create_plugin_manager", lambda: _PluginManager())
 
-        config = {"endpoints": [{"class": "plugin.stub.Endpoint", "name": "plug", "params": {}}]}
+        config = {"endpoints": [{"type": "plugin.stub.Endpoint", "name": "plug", "params": {}}]}
         p = tmp_path / "plugin-precedence.yaml"
         p.write_text(yaml.dump(config), encoding="utf-8")
         bus, _ = await build_bus_from_config(p)
@@ -147,10 +115,12 @@ class TestRunnerPluginHooks:
 
         class _Hook(Hook):
             @staticmethod
-            def resolve_bus_hook_class(*, hook_class: str):
-                if hook_class == "plugin.stub.BusHook":
-                    return _PluginBusHook
-                return None
+            def register_endpoint_types():
+                return {"plugin.stub.Endpoint": _PluginEndpoint}
+
+            @staticmethod
+            def register_bus_hook_types():
+                return {"plugin.stub.BusHook": _PluginBusHook}
 
             @staticmethod
             def configure_bus_hook_instance(*, instance, stage, hook_config, services):
@@ -162,8 +132,8 @@ class TestRunnerPluginHooks:
         monkeypatch.setattr("agent_core.bus.runner.create_plugin_manager", lambda: _PluginManager())
 
         config = {
-            "endpoints": [{"class": "agent_core.endpoints.stub.StubEndpoint", "name": "stub", "params": {}}],
-            "bus_hooks": {"pre_publish": [{"class": "plugin.stub.BusHook", "params": {}}], "pre_deliver": []},
+            "endpoints": [{"type": "plugin.stub.Endpoint", "name": "stub", "params": {}}],
+            "bus_hooks": {"pre_publish": [{"type": "plugin.stub.BusHook", "params": {}}], "pre_deliver": []},
         }
         p = tmp_path / "plugin-bus-hook.yaml"
         p.write_text(yaml.dump(config), encoding="utf-8")
@@ -195,17 +165,15 @@ class TestPipelinePluginHooks:
 
         class _Hook(Hook):
             @staticmethod
-            def resolve_hook_tool_class(*, tool_class: str):
-                if tool_class == "plugin.stub.Tool":
-                    return _PluginTool
-                return None
+            def register_hook_tool_types():
+                return {"plugin.stub.Tool": _PluginTool}
 
         class _PluginManager:
             hook = _Hook()
 
         monkeypatch.setattr("agent_core.hooks.pipeline.create_plugin_manager", lambda: _PluginManager())
 
-        config = {"pipelines": {"SessionStart": [{"tool": "plugin.stub.Tool"}]}}
+        config = {"pipelines": {"SessionStart": [{"type": "plugin.stub.Tool"}]}}
         config_path = tmp_path / "pipeline-plugin.yaml"
         config_path.write_text(yaml.dump(config), encoding="utf-8")
         pipeline = Pipeline(config_path)
@@ -213,10 +181,37 @@ class TestPipelinePluginHooks:
         assert len(results) == 1
         assert results[0].heading == "Plugin Tool"
 
+class TestEntrypointPluginIntegration:
+    async def test_alias_endpoint_resolves_without_monkeypatch(self, tmp_path: Path):
+        config = {
+            "endpoints": [
+                {
+                    "type": "builtin.stub",
+                    "name": "stub-alias",
+                    "params": {"auto_ack": True},
+                }
+            ]
+        }
+        p = tmp_path / "alias-endpoint.yaml"
+        p.write_text(yaml.dump(config), encoding="utf-8")
+        bus, _ = await build_bus_from_config(p)
+        assert "stub-alias" in bus._endpoints_by_name
 
-class TestPluginManagerResolution:
-    def test_builtin_manager_resolves_dotted_import(self):
-        pm = create_plugin_manager()
-        resolved = pm.hook.resolve_class(class_path="datetime.datetime")
-        assert resolved is not None
-        assert resolved.__name__ == "datetime"
+    def test_alias_hook_tool_resolves_without_monkeypatch(self, tmp_path: Path):
+        config = {
+            "pipelines": {
+                "SessionStart": [
+                    {
+                        "type": "builtin.time_injector",
+                        "params": {"format": "%Y"},
+                    }
+                ]
+            }
+        }
+        config_path = tmp_path / "alias-pipeline.yaml"
+        config_path.write_text(yaml.dump(config), encoding="utf-8")
+        pipeline = Pipeline(config_path)
+        results = pipeline.run("SessionStart", {})
+        assert len(results) == 1
+        assert results[0].heading == "Current Time"
+        assert len(results[0].content) == 4

--- a/packages/core/tests/test_runner_http_host.py
+++ b/packages/core/tests/test_runner_http_host.py
@@ -16,7 +16,7 @@ async def test_runner_returns_none_http_host_when_no_mcp_endpoints(tmp_path):
 bus:
   storage_path: {tmp_path / "bus.sqlite"}
 endpoints:
-  - class: agent_core.endpoints.stub.StubEndpoint
+  - type: builtin.stub
     name: stub
 """,
         encoding="utf-8",
@@ -38,7 +38,7 @@ http:
   bind_host: 127.0.0.1
   bind_port: 0
 endpoints:
-  - class: agent_core.endpoints.claude_code_mcp.ClaudeCodeMCPEndpoint
+  - type: builtin.claude_code_mcp
     name: agent-test
     params:
       mount: /mcp/agent-test
@@ -60,15 +60,15 @@ async def test_runner_constructs_http_host_with_multiple_mcp_endpoints(tmp_path)
 bus:
   storage_path: {tmp_path / "bus.sqlite"}
 endpoints:
-  - class: agent_core.endpoints.claude_code_mcp.ClaudeCodeMCPEndpoint
+  - type: builtin.claude_code_mcp
     name: agent-pepper
     params:
       mount: /mcp/agent-pepper
-  - class: agent_core.endpoints.claude_code_mcp.ClaudeCodeMCPEndpoint
+  - type: builtin.claude_code_mcp
     name: agent-deb
     params:
       mount: /mcp/agent-deb
-  - class: agent_core.endpoints.stub.StubEndpoint
+  - type: builtin.stub
     name: stub
 """,
         encoding="utf-8",

--- a/packages/core/tests/test_scheduler_integration.py
+++ b/packages/core/tests/test_scheduler_integration.py
@@ -31,7 +31,7 @@ def _config_yaml(tmp_path, jobs_yaml: str | None = None) -> str:
         "bus:",
         f"  storage_path: {bus_db}",
         "endpoints:",
-        "  - class: agent_core.endpoints.scheduler.SchedulerEndpoint",
+        "  - type: builtin.scheduler",
         "    name: scheduler",
         "    description: 'scheduler under test'",
         "    params:",
@@ -40,7 +40,7 @@ def _config_yaml(tmp_path, jobs_yaml: str | None = None) -> str:
     if jobs_yaml is not None:
         parts.append(f"      jobs_path: {jobs_yaml}")
     parts += [
-        "  - class: agent_core.endpoints.stub.StubEndpoint",
+        "  - type: builtin.stub",
         "    name: agent-test",
         "    description: 'fake test agent'",
     ]

--- a/packages/core/tests/test_session_registry.py
+++ b/packages/core/tests/test_session_registry.py
@@ -1,4 +1,4 @@
-"""Session registry middleware: captures and releases the active ServerSession."""
+"""Session registry middleware tracks connected ServerSession refs."""
 
 from __future__ import annotations
 
@@ -11,7 +11,8 @@ class _FakeSession:
     """Stand-in object identity for register/unregister tests.
 
     The middleware loop (`on_message` → `_claim_session` → `start_soon`) is
-    covered end-to-end by `test_session_active_flag_set_after_mcp_message`
+    covered end-to-end by
+    `test_session_registry_tracks_connected_sessions_after_mcp_message`
     in `test_claude_code_mcp.py`. These tests drive the sync register/
     unregister methods directly, so the fake only needs unique identity.
     """
@@ -22,8 +23,7 @@ async def test_register_session_captures_reference():
     ep = ClaudeCodeMCPEndpoint(name="a", mount="/mcp/a")
     session = _FakeSession()
     ep._register_session(session)
-    assert ep._active_session is session
-    assert ep._session_active is True
+    assert session in ep._sessions
 
 
 @pytest.mark.asyncio
@@ -32,48 +32,44 @@ async def test_unregister_session_clears_reference():
     session = _FakeSession()
     ep._register_session(session)
     ep._unregister_session(session)
-    assert ep._active_session is None
-    assert ep._session_active is False
+    assert session not in ep._sessions
 
 
 @pytest.mark.asyncio
-async def test_unregister_session_only_clears_if_same_session():
-    """Defensive: unregistering session A while session B is active does NOT clear B."""
+async def test_unregister_unknown_session_is_noop():
+    """Unregistering a session that was never registered changes nothing."""
     ep = ClaudeCodeMCPEndpoint(name="a", mount="/mcp/a")
     session_a = _FakeSession()
     session_b = _FakeSession()
     ep._register_session(session_a)
     ep._unregister_session(session_b)  # different session — should be a no-op
-    assert ep._active_session is session_a
-    assert ep._session_active is True
+    assert session_a in ep._sessions
+    assert len(ep._sessions) == 1
 
 
 @pytest.mark.asyncio
-async def test_register_second_session_replaces_first():
-    """Most-recent-wins: a new session replaces the held one."""
+async def test_register_second_session_keeps_both():
+    """Multiple sessions can coexist in the registry."""
     ep = ClaudeCodeMCPEndpoint(name="a", mount="/mcp/a")
     session_a = _FakeSession()
     session_b = _FakeSession()
     ep._register_session(session_a)
     ep._register_session(session_b)
-    assert ep._active_session is session_b
-    assert ep._session_active is True
+    assert session_a in ep._sessions
+    assert session_b in ep._sessions
 
 
 @pytest.mark.asyncio
-async def test_old_session_unregister_after_replacement_is_noop():
-    """When the old session's `_claim_session.finally:` fires after it was
-    replaced, the identity check in `_unregister_session` must NOT clear
-    the slot now held by the new session.
-    """
+async def test_unregister_one_of_two_sessions_keeps_other():
+    """A late finally from one session does not drop the other session."""
     ep = ClaudeCodeMCPEndpoint(name="a", mount="/mcp/a")
     session_a = _FakeSession()
     session_b = _FakeSession()
     ep._register_session(session_a)
-    ep._register_session(session_b)  # replaces a
-    ep._unregister_session(session_a)  # late finally on the old session
-    assert ep._active_session is session_b
-    assert ep._session_active is True
+    ep._register_session(session_b)
+    ep._unregister_session(session_a)
+    assert session_a not in ep._sessions
+    assert session_b in ep._sessions
 
 
 @pytest.mark.asyncio
@@ -83,4 +79,5 @@ async def test_register_same_session_twice_is_idempotent():
     session = _FakeSession()
     ep._register_session(session)
     ep._register_session(session)  # no raise
-    assert ep._active_session is session
+    assert session in ep._sessions
+    assert len(ep._sessions) == 1


### PR DESCRIPTION
## Summary
- **Pluggy**: Bus runner and hook pipeline resolve endpoints, bus hooks, and hook tools from \egister_*_types\ maps; built-in \uiltin.*\ ids live in \uiltin_aliases.py\. YAML and tests use \	ype:\ instead of \class:\ / \	ool:\.
- **Claude MCP**: Fan-out \
otifications/claude/channel\ to every connected session; remove single-slot session state.
- **agent-core-channel**: \_InitializationGateWriteStream\ implements \__aenter__\ / \__aexit__\ so the MCP stdio handshake matches \ServerSession\'s \sync with write_stream\.
- **Discord**: Clear 👀 when outbound \TextMessage\ uses \in_reply_to\ mapped from the inbound bus envelope; show typing until the ack is cleared or evicted.

## Test plan
- \just test-fast\ (348 passed)
- \pytest packages/agent-core-discord/tests\ (90 passed)
