### PR TITLE
fix(discord): split long outbound messages and return all chunk ids

### DIFF
--- a/packages/agent-core-discord/src/agent_core_discord/chunking.py
+++ b/packages/agent-core-discord/src/agent_core_discord/chunking.py
@@ -1,0 +1,134 @@
+"""Split outbound Discord text into API-safe chunks.
+
+Ports the spirit of Pepper's ``smart_chunk`` with Discord-oriented limits:
+each chunk is at most ``DISCORD_CONTENT_LIMIT`` characters (Discord's hard
+cap). Splits prefer natural boundaries in the last ``TAIL_SEARCH`` chars of
+each chunk window, then sentence endings, words, and finally a hard cut.
+
+See GitHub issue #20 for rationale (2000-char API reject, bus-level ack).
+"""
+
+from __future__ import annotations
+
+# Discord HTTP API maximum for message ``content``.
+DISCORD_CONTENT_LIMIT = 2000
+# Target size before continuation markers / headroom.
+DISCORD_CHUNK_TARGET = 1900
+# When hunting for a soft boundary, prefer breaks in this tail region.
+TAIL_SEARCH = 200
+# Safety valve — avoid spamming the channel on pathological payloads.
+MAX_CHUNKS = 25
+
+
+def _find_soft_split(text: str, limit: int) -> int:
+    """Return index in ``text`` where the first chunk should end (exclusive).
+
+    ``limit`` is the maximum length of the first piece. Search order in the
+    tail window first, then the full prefix, then hard ``limit``.
+    """
+    if len(text) <= limit:
+        return len(text)
+
+    window = text[:limit]
+    lo = max(0, limit - TAIL_SEARCH)
+
+    def in_tail(idx: int) -> bool:
+        return idx > lo and idx > 0
+
+    pos = window.rfind("\n\n", lo, limit)
+    if pos != -1 and in_tail(pos + 1):
+        return pos + 1
+
+    pos = window.rfind("\n", lo, limit)
+    if pos != -1 and in_tail(pos + 1):
+        return pos + 1
+
+    for sep in (". ", "! ", "? "):
+        pos = window.rfind(sep, lo, limit)
+        if pos != -1 and in_tail(pos + len(sep)):
+            return pos + len(sep)
+
+    pos = window.rfind(" ", lo, limit)
+    if pos != -1 and in_tail(pos + 1):
+        return pos + 1
+
+    pos = window.rfind("\n\n", 0, limit)
+    if pos != -1:
+        return pos + 1
+    pos = window.rfind("\n", 0, limit)
+    if pos != -1:
+        return pos + 1
+    for sep in (". ", "! ", "? "):
+        pos = window.rfind(sep, 0, limit)
+        if pos != -1:
+            return pos + len(sep)
+    pos = window.rfind(" ", 0, limit)
+    if pos != -1:
+        return pos + 1
+
+    return limit
+
+
+def smart_chunk_discord(text: str, *, limit: int = DISCORD_CHUNK_TARGET) -> list[str]:
+    """Split ``text`` into chunks each ≤ ``DISCORD_CONTENT_LIMIT``.
+
+    Continuation markers ``(i/n)`` prefix chunks after the first when they fit
+    under the Discord cap.
+
+    Raises:
+        ValueError: if more than ``MAX_CHUNKS`` would be required.
+    """
+    if len(text) <= limit:
+        out = [text]
+        _validate_chunks(out)
+        return out
+
+    chunks: list[str] = []
+    remaining = text
+
+    while remaining:
+        if len(remaining) <= limit:
+            chunks.append(remaining)
+            break
+
+        split_at = _find_soft_split(remaining, limit)
+        if split_at <= 0:
+            split_at = min(limit, len(remaining))
+        # Only trim newlines so spaces at soft boundaries (e.g. word splits) are
+        # not dropped across chunks.
+        piece = remaining[:split_at].rstrip("\n")
+        if not piece:
+            split_at = min(limit, len(remaining))
+            piece = remaining[:split_at]
+        chunks.append(piece)
+        remaining = remaining[split_at:].lstrip("\n")
+
+    if len(chunks) <= 1:
+        _validate_chunks(chunks)
+        return chunks
+
+    n = len(chunks)
+    marked: list[str] = [chunks[0]]
+    for i, c in enumerate(chunks[1:], start=2):
+        marker = f"({i}/{n})\n"
+        combined = marker + c
+        if len(combined) <= DISCORD_CONTENT_LIMIT:
+            marked.append(combined)
+        else:
+            marked.append(c)
+
+    _validate_chunks(marked)
+    return marked
+
+
+def _validate_chunks(chunks: list[str]) -> None:
+    if len(chunks) > MAX_CHUNKS:
+        raise ValueError(
+            f"message would require {len(chunks)} Discord chunks (max {MAX_CHUNKS}); "
+            "refuse to spam the channel"
+        )
+    for c in chunks:
+        if len(c) > DISCORD_CONTENT_LIMIT:
+            raise ValueError(
+                f"internal chunking error: chunk len {len(c)} > {DISCORD_CONTENT_LIMIT}"
+            )

--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -21,9 +21,9 @@ import time
 import uuid
 from collections import OrderedDict
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import unquote, urlparse
 
 from agent_core.bus.envelope import (
@@ -33,7 +33,6 @@ from agent_core.bus.envelope import (
     TextMessagePayload,
 )
 from agent_core.bus.protocol import EndpointUnavailable
-
 from agent_core_discord.access import AccessConfig, InboundContext, gate_message, load_access_config
 from agent_core_discord.args import (
     _DownloadAttachmentsArgs,
@@ -44,6 +43,7 @@ from agent_core_discord.args import (
     _ReactArgs,
     _SendArgs,
 )
+from agent_core_discord.chunking import smart_chunk_discord
 
 if TYPE_CHECKING:
     from agent_core.bus.handle import BusHandle
@@ -53,7 +53,7 @@ log = logging.getLogger(__name__)
 
 # Module-level registry. Lets discord.py event handlers look up the live
 # endpoint by name. Populated in start(), drained in stop().
-_active_endpoints: dict[str, "DiscordEndpoint"] = {}
+_active_endpoints: dict[str, DiscordEndpoint] = {}
 
 
 def _default_attachments_dir(endpoint_name: str) -> Path:
@@ -389,12 +389,17 @@ class DiscordEndpoint:
         if envelope.kind == "TextMessage":
             try:
                 result = await self._deliver_text_message(envelope)
-                await self._reply(envelope, json.dumps(result))
+                urg: Literal["green", "yellow", "red"] = (
+                    "yellow"
+                    if isinstance(result, dict) and result.get("status") == "partial"
+                    else "green"
+                )
+                await self._reply(envelope, json.dumps(result), urgency=urg)
             except _ToolError as exc:
-                await self._reply(envelope, f"error: {exc}")
+                await self._reply(envelope, f"error: {exc}", urgency="yellow")
             except Exception as exc:
                 log.exception("discord TextMessage delivery raised")
-                await self._reply(envelope, f"error: {exc}")
+                await self._reply(envelope, f"error: {exc}", urgency="yellow")
             await self._handle.ack(envelope.id)
             return
         if envelope.kind != "ToolInvocation":
@@ -407,12 +412,17 @@ class DiscordEndpoint:
 
         try:
             result = await self._dispatch(tool, args)
-            await self._reply(envelope, json.dumps(result))
+            urg2: Literal["green", "yellow", "red"] = (
+                "yellow"
+                if isinstance(result, dict) and result.get("status") == "partial"
+                else "green"
+            )
+            await self._reply(envelope, json.dumps(result), urgency=urg2)
         except _ToolError as exc:
-            await self._reply(envelope, f"error: {exc}")
+            await self._reply(envelope, f"error: {exc}", urgency="yellow")
         except Exception as exc:
             log.exception("discord tool '%s' raised", tool)
-            await self._reply(envelope, f"error: {exc}")
+            await self._reply(envelope, f"error: {exc}", urgency="yellow")
 
         await self._handle.ack(envelope.id)
 
@@ -472,7 +482,13 @@ class DiscordEndpoint:
             return await self._get_channel_info(_GetChannelInfoArgs(**args))
         raise _ToolError(f"unknown tool '{tool}'")
 
-    async def _reply(self, incoming: Envelope, note: str) -> None:
+    async def _reply(
+        self,
+        incoming: Envelope,
+        note: str,
+        *,
+        urgency: Literal["green", "yellow", "red"] = "green",
+    ) -> None:
         assert self._handle is not None
         ack = Envelope(
             id=uuid.uuid4().hex,
@@ -481,7 +497,8 @@ class DiscordEndpoint:
             to=incoming.from_,
             kind="Acknowledgment",
             payload=AcknowledgmentPayload(of=incoming.id, note=note),
-            created_at=datetime.now(timezone.utc),
+            urgency=urgency,
+            created_at=datetime.now(UTC),
         )
         try:
             await self._handle.publish(ack)
@@ -621,7 +638,7 @@ class DiscordEndpoint:
                 payload=TextMessagePayload(text=message.content or ""),
                 metadata=metadata,
                 urgency=urgency,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
             assert self._handle is not None
             self._remember_inbound_mapping(
@@ -669,7 +686,7 @@ class DiscordEndpoint:
                 to=self.target,
                 kind="Event",
                 payload=EventPayload(type="discord.reaction_add", data=data),
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
             assert self._handle is not None
             await self._handle.publish(env)
@@ -843,13 +860,57 @@ class DiscordEndpoint:
             send_kwargs["reference"] = reference
         if files is not None:
             send_kwargs["files"] = files
-        new_msg = await ch.send(args.text, **send_kwargs)
 
-        # Clear the eyes if this was a reply to a tracked inbound.
+        if args.text is None:
+            new_msg = await ch.send(args.text, **send_kwargs)
+            if args.reply_to:
+                await self._clear_pending_ack(ch, args.reply_to)
+            mid = str(new_msg.id)
+            return {"status": "sent", "message_id": mid, "message_ids": [mid]}
+
+        try:
+            text_parts = smart_chunk_discord(args.text)
+        except ValueError as exc:
+            raise _ToolError(str(exc)) from exc
+
+        message_ids: list[str] = []
+        last_error: Exception | None = None
+        n = len(text_parts)
+        for i, part in enumerate(text_parts):
+            is_first = i == 0
+            is_last = i == n - 1
+            send_part: dict[str, Any] = {}
+            if embeds is not None and is_last:
+                send_part["embeds"] = embeds
+            if reference is not None and is_first:
+                send_part["reference"] = reference
+            if files is not None and is_first:
+                send_part["files"] = files
+            try:
+                new_msg = await ch.send(part, **send_part)
+            except Exception as exc:
+                last_error = exc
+                break
+            message_ids.append(str(new_msg.id))
+
+        if last_error is not None and message_ids:
+            if args.reply_to:
+                await self._clear_pending_ack(ch, args.reply_to)
+            return {
+                "status": "partial",
+                "message_ids": message_ids,
+                "error": str(last_error),
+            }
+        if last_error is not None:
+            raise _ToolError(f"send failed: {last_error}") from last_error
+
         if args.reply_to:
             await self._clear_pending_ack(ch, args.reply_to)
 
-        return {"status": "sent", "message_id": str(new_msg.id)}
+        out: dict[str, Any] = {"status": "sent", "message_ids": message_ids}
+        if message_ids:
+            out["message_id"] = message_ids[-1]
+        return out
 
     async def _edit(self, args: _EditArgs) -> dict:
         if args.text is None and not args.embeds:

--- a/packages/agent-core-discord/tests/test_chunking.py
+++ b/packages/agent-core-discord/tests/test_chunking.py
@@ -1,0 +1,82 @@
+"""Tests for Discord outbound message chunking."""
+
+from __future__ import annotations
+
+import pytest
+from agent_core_discord.chunking import (
+    DISCORD_CHUNK_TARGET,
+    MAX_CHUNKS,
+    smart_chunk_discord,
+)
+
+
+def _content_only(chunks: list[str]) -> str:
+    """Reassemble logical text, dropping ``(i/n)`` continuation prefixes."""
+    parts: list[str] = []
+    for i, c in enumerate(chunks):
+        if i > 0 and c.startswith("(") and ")\n" in c[:16]:
+            parts.append(c.split("\n", 1)[-1])
+        else:
+            parts.append(c)
+    return "".join(parts)
+
+
+def test_short_message_no_split():
+    text = "Hello, world!"
+    result = smart_chunk_discord(text)
+    assert result == ["Hello, world!"]
+
+
+def test_split_at_paragraph():
+    para1 = "A" * 40
+    para2 = "B" * 40
+    text = f"{para1}\n\n{para2}"
+    result = smart_chunk_discord(text, limit=50)
+    assert len(result) == 2
+    body = _content_only(result)
+    assert body.count("A") == 40 and body.count("B") == 40
+
+
+def test_split_at_newline():
+    line1 = "A" * 40
+    line2 = "B" * 40
+    text = f"{line1}\n{line2}"
+    result = smart_chunk_discord(text, limit=50)
+    assert len(result) == 2
+    body = _content_only(result)
+    assert body.count("A") == 40 and body.count("B") == 40
+
+
+def test_split_at_space():
+    text = ("word " * 20).strip()
+    result = smart_chunk_discord(text, limit=30)
+    for chunk in result:
+        assert len(chunk) <= 2000
+    assert _content_only(result) == text
+
+
+def test_hard_cut_no_boundaries():
+    text = "A" * 100
+    result = smart_chunk_discord(text, limit=30)
+    assert len(result) == 4
+    assert all(len(c) <= 2000 for c in result)
+    assert _content_only(result) == text
+
+
+def test_no_chunk_exceeds_discord_cap():
+    text = (
+        "Short paragraph.\n\n"
+        + "A" * 1500
+        + "\n\n"
+        + "Another paragraph with some words.\n"
+        + "B" * 500
+    )
+    result = smart_chunk_discord(text, limit=DISCORD_CHUNK_TARGET)
+    for chunk in result:
+        assert len(chunk) <= 2000
+
+
+def test_too_many_chunks_raises():
+    text = "x" * (DISCORD_CHUNK_TARGET * (MAX_CHUNKS + 3))
+    with pytest.raises(ValueError, match="max"):
+        smart_chunk_discord(text)

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -90,6 +90,7 @@ async def test_send_publishes_text_to_channel(monkeypatch):
         result = json.loads(ack.payload.note)
         assert result["status"] == "sent"
         assert "message_id" in result
+        assert result["message_ids"] == [result["message_id"]]
     finally:
         await ep.stop()
 
@@ -180,6 +181,7 @@ async def test_send_validation_error_returns_error_ack(monkeypatch):
         await ep.deliver(env)
         ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
         assert ack.payload.note.lower().startswith("error:")
+        assert ack.urgency == "yellow"
     finally:
         await ep.stop()
 
@@ -288,6 +290,60 @@ async def test_unknown_tool_returns_error(monkeypatch):
         await ep.deliver(env)
         ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
         assert "unknown tool" in ack.payload.note.lower()
+        assert ack.urgency == "yellow"
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_send_splits_long_text_into_multiple_messages(monkeypatch):
+    ep, handle, fake = await _started(monkeypatch)
+    ch = _FakeChannel(id="200")
+    fake.add_channel(ch)
+    long_text = "x" * 2500
+    try:
+        env = _envelope(
+            "e1",
+            "agent-test",
+            "discord-test",
+            _toolcall("send", {"channel_id": "200", "text": long_text}),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) >= 2
+        for row in ch.sent:
+            c = row.get("content") or ""
+            assert len(c) <= 2000
+        ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
+        result = json.loads(ack.payload.note)
+        assert result["status"] == "sent"
+        assert len(result["message_ids"]) == len(ch.sent)
+        assert result["message_id"] == result["message_ids"][-1]
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_textmessage_long_payload_splits(monkeypatch):
+    ep, handle, fake = await _started(monkeypatch)
+    ch = _FakeChannel(id="200")
+    fake.add_channel(ch)
+    try:
+        env = Envelope(
+            id="e",
+            correlation_id=uuid.uuid4().hex,
+            from_="agent-test",
+            to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(text="z" * 2200),
+            metadata={"discord": {"channel_id": "200"}},
+            created_at=datetime.now(timezone.utc),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) >= 2
+        ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
+        assert ack.urgency == "green"
+        result = json.loads(ack.payload.note)
+        assert len(result["message_ids"]) >= 2
     finally:
         await ep.stop()
 
@@ -317,6 +373,7 @@ async def test_textmessage_uses_discord_metadata_channel_and_replies(monkeypatch
         ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
         result = json.loads(ack.payload.note)
         assert result["status"] == "sent"
+        assert "message_ids" in result
     finally:
         await ep.stop()
 
@@ -352,6 +409,7 @@ async def test_textmessage_uses_default_outbound_channel(monkeypatch):
         ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
         result = json.loads(ack.payload.note)
         assert result["status"] == "sent"
+        assert "message_ids" in result
     finally:
         await ep.stop()
 
@@ -373,6 +431,7 @@ async def test_textmessage_without_channel_returns_error(monkeypatch):
         ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
         assert ack.payload.note.lower().startswith("error:")
         assert "channel_id" in ack.payload.note
+        assert ack.urgency == "yellow"
     finally:
         await ep.stop()
 


### PR DESCRIPTION
## Summary
- split outbound Discord text messages at a 1900-char target so each sent chunk stays within Discord's 2000-char content limit
- return `message_ids` for all posted chunks (and keep `message_id` as the last chunk for compatibility)
- mark error/partial acknowledgment urgency as `yellow`, and add tests for chunking and long TextMessage/send flows

## Test plan
- [x] `uv run pytest packages/agent-core-discord/tests -q`
- [x] `uv run ruff check packages/agent-core-discord/src/agent_core_discord/endpoint.py packages/agent-core-discord/src/agent_core_discord/chunking.py`

Fixes #20