### PR TITLE
feat: move handoff generation to daemon worker

### DIFF
--- a/docs/examples/pepper-agent-core.yaml
+++ b/docs/examples/pepper-agent-core.yaml
@@ -6,15 +6,26 @@
 # How it works:
 #   1. SessionStart: TimeInjector tells Pepper what time it is,
 #      IdentityInjector loads her personality + preferences + last handoff note.
-#   2. PreCompact: Before context is compressed, HandoffWriter captures
-#      what was happening so the next session (or post-compaction) has continuity.
-#   3. SessionEnd: Same HandoffWriter runs again as a safety net —
-#      deduplication prevents writing twice if PreCompact already fired.
+#   2. PreCompact/SessionEnd: HandoffWriter enqueues a daemon job.
+#      The daemon worker generates handoff.md and writes handoff-status.json.
 #
 # .claude/settings.json hooks should point to:
 #   "command": "uv run agent-core hooks run SessionStart"
 #   "command": "uv run agent-core hooks run PreCompact"
 #   "command": "uv run agent-core hooks run SessionEnd"
+
+bus:
+  storage_path: "C:\\Users\\jeffr\\.pepper\\agent-core\\bus.sqlite"
+
+http:
+  bind_host: "127.0.0.1"
+  bind_port: 8788
+
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
 
 pipelines:
   SessionStart:
@@ -34,14 +45,16 @@ pipelines:
     - type: builtin.handoff_writer
       params:
         output_path: "C:\\Users\\jeffr\\.pepper\\Memory\\pepper\\handoff.md"
-        transcript_tail_lines: 200
-        timezone: "US/Eastern"
+        vault_root: "C:\\Users\\jeffr\\.pepper\\Memory\\pepper"
+        handoff_status_path: "C:\\Users\\jeffr\\.pepper\\Memory\\pepper\\handoff-status.json"
+        handoff_jobs_url: "http://127.0.0.1:8788/internal/handoff-jobs"
         agent_name: "Pepper"
 
   SessionEnd:
     - type: builtin.handoff_writer
       params:
         output_path: "C:\\Users\\jeffr\\.pepper\\Memory\\pepper\\handoff.md"
-        transcript_tail_lines: 200
-        timezone: "US/Eastern"
+        vault_root: "C:\\Users\\jeffr\\.pepper\\Memory\\pepper"
+        handoff_status_path: "C:\\Users\\jeffr\\.pepper\\Memory\\pepper\\handoff-status.json"
+        handoff_jobs_url: "http://127.0.0.1:8788/internal/handoff-jobs"
         agent_name: "Pepper"

--- a/docs/requirements/pepper-handoff-daemon-contract.md
+++ b/docs/requirements/pepper-handoff-daemon-contract.md
@@ -1,0 +1,242 @@
+# Pepper Handoff Daemon Contract (Hook-Minimal)
+
+**Author:** Pepper + Jeff alignment
+**Date:** 2026-05-02
+**Priority:** Critical
+**Related:** `docs/requirements/pepper-requirements.md`, `packages/core/src/agent_core/hooks/tools/handoff_writer.py`, `packages/core/src/agent_core/bus/`
+
+---
+
+## Goal
+
+Move handoff generation out of hook execution and into a daemon worker so session shutdown is reliable and hook runtime stays minimal.
+
+The hook must become enqueue-only. The daemon must own status transitions and handoff writes.
+
+---
+
+## Decisions Locked In
+
+1. **No hook-side handoff writing**
+   - Hook code must never run the actual write/generation path.
+   - Hook code must never spawn `claude -p` (or equivalent) for handoff generation.
+   - No backward-compatible fallback path that re-enables hook writing.
+
+2. **Daemon is single writer of `handoff-status.json`**
+   - Hook does not write or mutate status.
+   - Daemon transitions `pending -> ready|failed`.
+
+3. **Agent SDK in daemon worker**
+   - Generation happens via Agent SDK in daemon process.
+   - CLI subprocess generation from hooks is removed for this flow.
+
+4. **Pointer-first transcript handoff**
+   - Hook submits `transcript_path`; it does not copy transcript files by default.
+   - We assume daemon and hook can both read the same filesystem.
+   - Seeing post-enqueue edits to transcript is acceptable for v1.
+
+---
+
+## Non-Goals (for this cut)
+
+- Transcript immutability snapshotting in hook.
+- Hook fallback mode for daemon outages.
+- Multi-host distributed storage assumptions.
+- Cryptographic signing of status sidecar.
+
+---
+
+## Lifecycle Overview
+
+1. Claude lifecycle hook fires (`SessionEnd` or `PreCompact`).
+2. Hook performs minimal validation and sends one request to daemon.
+3. Daemon accepts job, records `pending` status.
+4. Worker reads transcript from `transcript_path`, runs Agent SDK extraction.
+5. Worker atomically writes `handoff.md`.
+6. Worker atomically writes `handoff-status.json` as `ready` or `failed`.
+7. Daemon publishes completion notification via bus.
+
+---
+
+## Hook Contract (enqueue-only)
+
+### Responsibilities
+
+- Validate required fields exist in incoming hook payload.
+- Submit handoff job request to daemon.
+- Return quickly with success/failure of enqueue attempt.
+
+### Hard constraints
+
+- No transcript parsing in hook.
+- No LLM calls in hook.
+- No direct `handoff.md` writes in hook.
+- No `handoff-status.json` writes in hook.
+
+### Required job payload fields
+
+- `session_id` (string, non-empty)
+- `event` (enum: `SessionEnd` or `PreCompact`)
+- `agent_name` (string)
+- `vault_root` (string path)
+- `handoff_path` (string path)
+- `handoff_status_path` (string path)
+- `transcript_path` (string path)
+- `requested_at` (RFC3339 timestamp)
+
+### Optional payload fields
+
+- `idempotency_key` (string; if omitted daemon derives one)
+- `context` (small JSON object for diagnostics only; no transcript body)
+
+---
+
+## Daemon HTTP Contract
+
+### Endpoint
+
+- `POST /internal/handoff-jobs`
+
+### Request body (JSON)
+
+```json
+{
+  "session_id": "uuid-or-session-string",
+  "event": "SessionEnd",
+  "agent_name": "pepper",
+  "vault_root": "C:/Users/jeffr/.pepper/Memory/pepper",
+  "handoff_path": "C:/Users/jeffr/.pepper/Memory/pepper/handoff.md",
+  "handoff_status_path": "C:/Users/jeffr/.pepper/Memory/pepper/handoff-status.json",
+  "transcript_path": "C:/Users/jeffr/.pepper/transcripts/abc.jsonl",
+  "requested_at": "2026-05-02T14:56:00Z",
+  "idempotency_key": "optional"
+}
+```
+
+### Success response
+
+- HTTP `202 Accepted`
+
+```json
+{
+  "job_id": "uuid",
+  "status": "accepted"
+}
+```
+
+### Failure responses
+
+- HTTP `400` invalid payload
+- HTTP `403` path outside allowed root
+- HTTP `409` duplicate idempotency key already completed (optional behavior)
+- HTTP `503` daemon cannot enqueue
+
+---
+
+## Validation + Safety Rules (daemon side)
+
+1. **Path jail**
+   - `handoff_path`, `handoff_status_path`, and `transcript_path` must resolve under `vault_root`.
+   - Reject any path traversal or unresolved outside-root target.
+
+2. **Idempotency**
+   - Default key: hash of `session_id + event + handoff_path`.
+   - Duplicate in-flight request returns same `job_id` (recommended).
+   - Duplicate completed request may return `409` or prior `job_id`; choose one behavior and keep it stable.
+
+3. **Atomic writes**
+   - Write temp file then replace for `handoff.md` and `handoff-status.json`.
+
+4. **Status ownership**
+   - Daemon writes `pending` when job accepted for execution.
+   - Daemon writes terminal status (`ready` or `failed`) exactly once per attempt.
+
+---
+
+## Status File Contract (`handoff-status.json`)
+
+### Pending
+
+```json
+{
+  "state": "pending",
+  "session_id": "<session_id>",
+  "updated_at": "<rfc3339>",
+  "job_id": "<job_id>"
+}
+```
+
+### Ready
+
+```json
+{
+  "state": "ready",
+  "session_id": "<session_id>",
+  "updated_at": "<rfc3339>",
+  "job_id": "<job_id>",
+  "content_sha256": "<sha256 of written handoff.md>"
+}
+```
+
+### Failed
+
+```json
+{
+  "state": "failed",
+  "session_id": "<session_id>",
+  "updated_at": "<rfc3339>",
+  "job_id": "<job_id>",
+  "error": "<sanitized error summary>"
+}
+```
+
+---
+
+## Bus Notification Contract
+
+After terminal status write, daemon publishes one envelope:
+
+- `HandoffReady` on success
+- `HandoffFailed` on terminal failure
+
+Minimum payload:
+
+- `job_id`
+- `session_id`
+- `agent_name`
+- `handoff_path`
+- `handoff_status_path`
+- `content_sha256` (ready only)
+- `error` (failed only)
+
+---
+
+## Retry Policy (v1)
+
+- Retry on transient worker/SDK errors with exponential backoff.
+- Do not retry on validation/path-jail errors.
+- Max attempts configured in daemon settings.
+- On final exhaustion, write `failed` and publish `HandoffFailed`.
+
+---
+
+## Implementation Notes
+
+1. Build daemon route + queue + worker stub first (no LLM text quality tuning yet).
+2. Switch hook tool to enqueue-only and remove local writer behavior in the same cut.
+3. Keep logs structured with `job_id`, `session_id`, `event`, `attempt`.
+
+---
+
+## Acceptance Criteria
+
+1. Hook execution path contains no direct handoff generation/writing logic.
+2. Hook never invokes `claude -p` for handoff generation.
+3. Daemon writes all `handoff-status.json` states.
+4. Handoff generation occurs via Agent SDK in daemon worker.
+5. End-to-end run produces:
+   - `202` enqueue response
+   - `pending` then `ready` (or `failed`) status transition
+   - bus completion notification
+6. If daemon is unavailable, hook fails enqueue fast and does not attempt local write.
+

--- a/packages/core/docs/plugins.md
+++ b/packages/core/docs/plugins.md
@@ -64,9 +64,43 @@ Core also ships an entrypoint-loaded alias plugin:
   - `builtin.discord` -> `agent_core_discord.endpoint.DiscordEndpoint`
   - `builtin.stub` -> `agent_core.endpoints.stub.StubEndpoint`
   - `builtin.scheduler` -> `agent_core.endpoints.scheduler.SchedulerEndpoint`
+  - `builtin.handoff_jobs` -> `agent_core.endpoints.handoff_jobs.HandoffJobsEndpoint`
 - hook tool aliases:
   - `builtin.handoff_writer` -> `agent_core.hooks.tools.handoff_writer.HandoffWriter`
   - `builtin.identity_injector` -> `agent_core.hooks.tools.identity_injector.IdentityInjector`
   - `builtin.time_injector` -> `agent_core.hooks.tools.time_injector.TimeInjector`
 
 Your plugin hooks run alongside these defaults.
+
+## Handoff daemon setup (default pattern)
+
+Use `builtin.handoff_jobs` to host the enqueue endpoint, then point
+`builtin.handoff_writer` at that endpoint. The hook remains enqueue-only.
+
+```yaml
+http:
+  bind_host: 127.0.0.1
+  bind_port: 8788
+
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+
+pipelines:
+  SessionEnd:
+    - type: builtin.handoff_writer
+      params:
+        output_path: "C:\\Users\\you\\Memory\\agent\\handoff.md"
+        vault_root: "C:\\Users\\you\\Memory\\agent"
+        handoff_status_path: "C:\\Users\\you\\Memory\\agent\\handoff-status.json"
+        handoff_jobs_url: "http://127.0.0.1:8788/internal/handoff-jobs"
+        agent_name: "YourAgent"
+```
+
+With this setup:
+
+- hook writes no handoff files and runs no LLM extraction
+- daemon worker writes `handoff.md`
+- daemon worker is the single writer of `handoff-status.json`

--- a/packages/core/src/agent_core/endpoints/handoff_jobs.py
+++ b/packages/core/src/agent_core/endpoints/handoff_jobs.py
@@ -1,0 +1,421 @@
+"""HandoffJobsEndpoint — daemon-owned handoff job intake and worker loop.
+
+This endpoint is both:
+- a bus Endpoint (for lifecycle start/stop and optional event publishing), and
+- an HTTPHost mount that accepts internal handoff jobs over HTTP.
+
+The hook-side caller should enqueue only. All status-file mutations happen here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, Field, ValidationError
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route, Router
+
+from agent_core.bus.envelope import Envelope, EventPayload
+
+if TYPE_CHECKING:
+    from agent_core.bus.handle import BusHandle
+
+log = logging.getLogger(__name__)
+
+
+class HandoffJobRequest(BaseModel):
+    session_id: str = Field(min_length=1)
+    event: Literal["SessionEnd", "PreCompact"]
+    agent_name: str = Field(min_length=1)
+    vault_root: str = Field(min_length=1)
+    handoff_path: str = Field(min_length=1)
+    handoff_status_path: str = Field(min_length=1)
+    transcript_path: str = Field(min_length=1)
+    requested_at: datetime
+    idempotency_key: str | None = None
+    context: dict[str, Any] = Field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class _QueuedJob:
+    job_id: str
+    request: HandoffJobRequest
+    idempotency_key: str
+
+
+class HandoffJobsEndpoint:
+    """Internal HTTP endpoint for handoff job enqueue + async execution."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        mount: str = "/internal/handoff-jobs",
+        max_attempts: int = 3,
+        retry_backoff_seconds: float = 0.25,
+    ):
+        self.name = name
+        self.mount = mount
+        self._max_attempts = max(1, max_attempts)
+        self._retry_backoff_seconds = max(0.0, retry_backoff_seconds)
+        self._handle: BusHandle | None = None
+        self._jobs: asyncio.Queue[_QueuedJob] = asyncio.Queue()
+        self._worker_task: asyncio.Task[None] | None = None
+        self._idempotency_index: dict[str, str] = {}
+
+    # ---- Bus endpoint protocol ----
+    async def start(self, bus: BusHandle) -> None:
+        self._handle = bus
+        self._worker_task = asyncio.create_task(self._worker_loop())
+        log.info("HandoffJobsEndpoint(name=%s) started at mount=%s", self.name, self.mount)
+
+    async def deliver(self, envelope: Envelope) -> None:
+        """This endpoint currently has no bus inbound contract; auto-ack."""
+        if self._handle is None:
+            raise RuntimeError(f"endpoint '{self.name}' is not started")
+        await self._handle.ack(envelope.id)
+
+    async def stop(self) -> None:
+        if self._worker_task is not None:
+            self._worker_task.cancel()
+            try:
+                await self._worker_task
+            except asyncio.CancelledError:
+                pass
+            self._worker_task = None
+        self._handle = None
+        log.info("HandoffJobsEndpoint(name=%s) stopped", self.name)
+
+    # ---- MCPHostable protocol ----
+    def asgi_app(self):
+        router = Router(
+            routes=[
+                Route("/", endpoint=self._post_job, methods=["POST"]),
+            ],
+            redirect_slashes=False,
+        )
+        return router
+
+    # ---- HTTP handlers ----
+    async def _post_job(self, request: Request) -> JSONResponse:
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError:
+            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+
+        try:
+            job_req = HandoffJobRequest.model_validate(payload)
+        except ValidationError as exc:
+            return JSONResponse({"error": "invalid request", "details": exc.errors()}, status_code=400)
+
+        try:
+            vault_root = Path(job_req.vault_root).expanduser().resolve(strict=False)
+            handoff_path = self._resolve_under_root(job_req.handoff_path, vault_root)
+            status_path = self._resolve_under_root(job_req.handoff_status_path, vault_root)
+            self._resolve_under_root(job_req.transcript_path, vault_root)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=403)
+
+        idem = job_req.idempotency_key or self._derive_idempotency_key(job_req)
+        if idem in self._idempotency_index:
+            return JSONResponse(
+                {"job_id": self._idempotency_index[idem], "status": "accepted"},
+                status_code=202,
+            )
+
+        job_id = uuid.uuid4().hex
+        self._idempotency_index[idem] = job_id
+        await self._jobs.put(_QueuedJob(job_id=job_id, request=job_req, idempotency_key=idem))
+
+        # Daemon owns status file transitions: accepted implies pending.
+        self._write_pending(
+            status_path=status_path,
+            session_id=job_req.session_id,
+            job_id=job_id,
+        )
+
+        return JSONResponse({"job_id": job_id, "status": "accepted"}, status_code=202)
+
+    # ---- Worker ----
+    async def _worker_loop(self) -> None:
+        while True:
+            job = await self._jobs.get()
+            try:
+                await self._process_job(job)
+            except Exception:
+                log.exception("handoff job %s crashed in worker loop", job.job_id)
+            finally:
+                self._jobs.task_done()
+
+    async def _process_job(self, job: _QueuedJob) -> None:
+        req = job.request
+        vault_root = Path(req.vault_root).expanduser().resolve(strict=False)
+        handoff_path = self._resolve_under_root(req.handoff_path, vault_root)
+        status_path = self._resolve_under_root(req.handoff_status_path, vault_root)
+        transcript_path = self._resolve_under_root(req.transcript_path, vault_root)
+        last_error: Exception | None = None
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                transcript_text = self._read_transcript_text(transcript_path)
+                handoff_content = await self._extract_handoff(req, transcript_text)
+                normalized_handoff = handoff_content.rstrip() + "\n"
+                self._atomic_write(handoff_path, normalized_handoff)
+                sha = hashlib.sha256(normalized_handoff.encode("utf-8")).hexdigest()
+                self._write_ready(
+                    status_path=status_path,
+                    session_id=req.session_id,
+                    job_id=job.job_id,
+                    content_sha256=sha,
+                )
+                await self._publish_result(
+                    kind="HandoffReady",
+                    req=req,
+                    job_id=job.job_id,
+                    handoff_path=handoff_path,
+                    handoff_status_path=status_path,
+                    content_sha256=sha,
+                )
+                return
+            except Exception as exc:
+                last_error = exc
+                if attempt == self._max_attempts:
+                    break
+                backoff_seconds = self._retry_backoff_seconds * attempt
+                if backoff_seconds > 0:
+                    await asyncio.sleep(backoff_seconds)
+
+        error_text = str(last_error) if last_error is not None else "unknown handoff processing error"
+        self._write_failed(
+            status_path=status_path,
+            session_id=req.session_id,
+            job_id=job.job_id,
+            error=error_text,
+        )
+        await self._publish_result(
+            kind="HandoffFailed",
+            req=req,
+            job_id=job.job_id,
+            handoff_path=handoff_path,
+            handoff_status_path=status_path,
+            error=error_text,
+        )
+
+    @staticmethod
+    def _read_transcript_text(transcript_path: Path) -> str:
+        if not transcript_path.exists():
+            raise FileNotFoundError(f"transcript does not exist: {transcript_path}")
+        return transcript_path.read_text(encoding="utf-8")
+
+    async def _extract_handoff(self, req: HandoffJobRequest, transcript_text: str) -> str:
+        try:
+            response_text = await self._call_agent_sdk(req=req, transcript_text=transcript_text)
+            if response_text.strip():
+                return response_text
+            raise RuntimeError("empty handoff extraction")
+        except Exception as exc:
+            generated_at = datetime.now(UTC).isoformat()
+            return (
+                f"# Handoff ({req.agent_name})\n\n"
+                f"- session_id: {req.session_id}\n"
+                f"- event: {req.event}\n"
+                f"- generated_at: {generated_at}\n\n"
+                f"Extraction fallback used: {exc}"
+            )
+
+    async def _call_agent_sdk(self, *, req: HandoffJobRequest, transcript_text: str) -> str:
+        from claude_agent_sdk import (
+            AssistantMessage,
+            ClaudeAgentOptions,
+            TextBlock,
+            query,
+        )
+
+        prompt = f"""You are writing a handoff note for {req.agent_name} for continuity between sessions.
+Write from {req.agent_name}'s perspective. Based on the transcript below, produce:
+
+## What We Were Working On
+- specific bullets
+
+## Decisions Made
+- specific bullets
+
+## Emotional Temperature
+- one sentence
+
+## Open Threads
+- specific bullets
+
+## Observations
+- specific bullets
+
+Rules:
+- Keep each section to 2-5 bullets where applicable.
+- Skip empty sections.
+- Be concrete: mention files, tools, errors, and decisions.
+- If truly trivial transcript, respond with exactly HANDOFF_EMPTY.
+
+Session metadata:
+- session_id: {req.session_id}
+- event: {req.event}
+
+Transcript:
+{transcript_text}
+"""
+        response_text = ""
+        async for message in query(
+            prompt=prompt,
+            options=ClaudeAgentOptions(
+                allowed_tools=[],
+                max_turns=2,
+            ),
+        ):
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        response_text += block.text
+
+        if response_text.strip() == "HANDOFF_EMPTY":
+            return (
+                f"# Handoff ({req.agent_name})\n\n"
+                f"- session_id: {req.session_id}\n"
+                f"- event: {req.event}\n\n"
+                "No significant content to hand off."
+            )
+        return response_text
+
+    async def _publish_result(
+        self,
+        *,
+        kind: Literal["HandoffReady", "HandoffFailed"],
+        req: HandoffJobRequest,
+        job_id: str,
+        handoff_path: Path,
+        handoff_status_path: Path,
+        content_sha256: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        if self._handle is None:
+            log.warning("cannot publish %s for job=%s: endpoint not started", kind, job_id)
+            return
+
+        payload_data: dict[str, Any] = {
+            "job_id": job_id,
+            "session_id": req.session_id,
+            "agent_name": req.agent_name,
+            "handoff_path": str(handoff_path),
+            "handoff_status_path": str(handoff_status_path),
+        }
+        if content_sha256 is not None:
+            payload_data["content_sha256"] = content_sha256
+        if error is not None:
+            payload_data["error"] = error
+
+        env = Envelope(
+            id=uuid.uuid4().hex,
+            correlation_id=uuid.uuid4().hex,
+            to=req.agent_name,
+            kind="Event",
+            payload=EventPayload(type=kind, data=payload_data),
+            metadata={"handoff_job_id": job_id, "handoff_event": req.event},
+            created_at=datetime.now(UTC),
+        )
+        await self._handle.publish(env)
+
+    # ---- Status + filesystem helpers ----
+    @staticmethod
+    def _resolve_under_root(path_value: str, root: Path) -> Path:
+        p = Path(path_value).expanduser().resolve(strict=False)
+        try:
+            p.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"path escapes vault_root: {path_value}") from exc
+        return p
+
+    @staticmethod
+    def _derive_idempotency_key(req: HandoffJobRequest) -> str:
+        raw = f"{req.session_id}|{req.event}|{req.handoff_path}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _atomic_write(path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(content, encoding="utf-8")
+        tmp.replace(path)
+
+    @classmethod
+    def _write_pending(cls, *, status_path: Path, session_id: str, job_id: str) -> None:
+        cls._atomic_write(
+            status_path,
+            json.dumps(
+                {
+                    "state": "pending",
+                    "session_id": session_id,
+                    "updated_at": datetime.now(UTC).isoformat(),
+                    "job_id": job_id,
+                },
+                ensure_ascii=True,
+                indent=2,
+            )
+            + "\n",
+        )
+
+    @classmethod
+    def _write_ready(
+        cls,
+        *,
+        status_path: Path,
+        session_id: str,
+        job_id: str,
+        content_sha256: str,
+    ) -> None:
+        cls._atomic_write(
+            status_path,
+            json.dumps(
+                {
+                    "state": "ready",
+                    "session_id": session_id,
+                    "updated_at": datetime.now(UTC).isoformat(),
+                    "job_id": job_id,
+                    "content_sha256": content_sha256,
+                },
+                ensure_ascii=True,
+                indent=2,
+            )
+            + "\n",
+        )
+
+    @classmethod
+    def _write_failed(
+        cls,
+        *,
+        status_path: Path,
+        session_id: str,
+        job_id: str,
+        error: str,
+    ) -> None:
+        cls._atomic_write(
+            status_path,
+            json.dumps(
+                {
+                    "state": "failed",
+                    "session_id": session_id,
+                    "updated_at": datetime.now(UTC).isoformat(),
+                    "job_id": job_id,
+                    "error": error,
+                },
+                ensure_ascii=True,
+                indent=2,
+            )
+            + "\n",
+        )
+

--- a/packages/core/src/agent_core/hooks/tools/__init__.py
+++ b/packages/core/src/agent_core/hooks/tools/__init__.py
@@ -7,5 +7,5 @@ Available tools:
     TimeInjector: Injects the current date and time into session context.
     FileInjector: Reads a list of files and injects their contents into session context.
     IdentityInjector: FileInjector preset for agent identity/personality files.
-    HandoffWriter: Writes LLM-powered continuity notes before context is lost.
+    HandoffWriter: Enqueues daemon-owned handoff jobs.
 """

--- a/packages/core/src/agent_core/hooks/tools/handoff_writer.py
+++ b/packages/core/src/agent_core/hooks/tools/handoff_writer.py
@@ -1,274 +1,94 @@
-"""HandoffWriter — spawns a detached claude CLI process to write continuity notes.
+"""HandoffWriter — enqueue-only handoff job hook.
 
-The hook itself is fast (<1 second): it reads the transcript, writes context
-to a temp file, and spawns `claude -p` as a detached background process.
-The claude process reads the context, generates a structured handoff note,
-and writes it to the output path.
-
-This uses the Claude CLI directly (subscription auth), not the Agent SDK.
-The detached process survives Ctrl+C during session exit.
-
-Register on both PreCompact and SessionEnd events to maximize coverage.
-Deduplication prevents writing the same handoff twice if both events fire.
-
-Configuration:
-    In agent_core.yaml:
-
-        pipelines:
-          PreCompact:
-            - tool: agent_core.hooks.tools.handoff_writer.HandoffWriter
-              params:
-                output_path: "C:\\Users\\jeffr\\.pepper\\Memory\\pepper\\handoff.md"
-                transcript_tail_lines: 200
-                timezone: "US/Eastern"
-                agent_name: "Pepper"
-
-    Required params:
-        output_path (str): Absolute path where the handoff note is written.
-
-    Optional params:
-        transcript_tail_lines (int): Lines from transcript end to analyze. Default: 200.
-        timezone (str): Timezone for the timestamp. Default: "US/Eastern".
-        agent_name (str): Agent name for the LLM prompt. Default: "Assistant".
-
-See Also:
-    agent_core.hooks.tools.identity_injector.IdentityInjector: Loads the handoff note.
-    agent_core.transcript.read_transcript: Shared transcript reader.
+This hook performs no handoff generation and does not write handoff files.
+It only validates minimal inputs and POSTs a job request to the daemon's
+handoff-jobs HTTP endpoint. The daemon worker owns status transitions and file
+writes.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import shutil
-import subprocess
-import sys
-import time
+import urllib.error
+import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from zoneinfo import ZoneInfo
 
 from agent_core.models import ToolResult
-from agent_core.transcript import read_transcript
 
 logger = logging.getLogger("agent_core.hooks.tools.handoff_writer")
 
-# Debug log file for diagnosing hook failures (hooks swallow stderr)
-_DEBUG_LOG = Path.home() / ".pepper" / "Memory" / "pepper" / "handoff-debug.log"
-
-
-def _debug(msg: str) -> None:
-    """Append a timestamped debug line to the debug log file."""
-    try:
-        _DEBUG_LOG.parent.mkdir(parents=True, exist_ok=True)
-        with open(_DEBUG_LOG, "a", encoding="utf-8") as f:
-            ts = datetime.now(UTC).astimezone().strftime("%Y-%m-%d %H:%M:%S")
-            f.write(f"[{ts}] {msg}\n")
-    except Exception:
-        pass
-
-
-def _state_file_for(output_path: Path) -> Path:
-    """Derive the deduplication state file path from the output path."""
-    return output_path.parent / "handoff-state.json"
-
-
-def _load_state(state_file: Path) -> dict:
-    if state_file.exists():
-        try:
-            return json.loads(state_file.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            pass
-    return {}
-
-
-def _save_state(state_file: Path, state: dict) -> None:
-    state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(json.dumps(state), encoding="utf-8")
-
-
-def _build_prompt(
-    context_file: str,
-    output_path: str,
-    agent_name: str,
-    session_id: str,
-    event: str,
-    timestamp: str,
-) -> str:
-    """Build the prompt for the detached claude process."""
-    return f"""Read the conversation transcript from the file at {context_file}.
-
-Then write a handoff note for {agent_name} to the file at {output_path}.
-
-The handoff note must start with this exact header:
-
-# Handoff Note
-**Written:** {timestamp}
-**Session:** {session_id}
-**Event:** {event}
-
-Then write from {agent_name}'s perspective covering these sections:
-
-## What We Were Working On
-[Topics and tasks in progress — a few bullet points]
-
-## Decisions Made
-[Any decisions, agreements, or commitments — bullet points]
-
-## Emotional Temperature
-[One sentence: how was the conversation going? Casual? Deep work? Tense?]
-
-## Open Threads
-[Things started but not finished, unanswered questions — bullet points]
-
-## Observations
-[Patterns noticed, hunches worth remembering — bullet points]
-
-Rules:
-- Keep each section to 2-5 bullet points.
-- Skip sections with nothing to report.
-- Be specific — name files, tools, errors, and decisions. Not vague summaries.
-- If the transcript is genuinely trivial (only greetings, no real work), write a note
-  that just says "No significant content to hand off." under the header.
-
-After writing the handoff note, delete the context file at {context_file}.
-
-Write the state file at {Path(output_path).parent / "handoff-state.json"} with this JSON:
-{{"session_id": "{session_id}", "timestamp": {int(time.time())}}}
-
-After everything is written, send a desktop notification by running this exact command:
-uv run --directory E:/workspaces/ai/agents/agent_core agent-core notify "{agent_name}" "Handoff note written"
-
-If the notify command fails, that's fine — the handoff note is the important part."""
-
 
 class HandoffWriter:
-    """Spawns a detached claude CLI process to write a continuity note."""
+    """Enqueue-only hook tool for daemon-managed handoff generation."""
 
     def execute(self, event: str, hook_input: dict, params: dict) -> ToolResult:
-        """Read transcript, write to temp file, spawn claude -p in background.
-
-        Returns immediately (<1 second). The detached claude process handles
-        the LLM generation and writes the handoff note.
-        """
+        """POST a handoff job to daemon and return quickly."""
         output_path_str = params.get("output_path")
         if not output_path_str:
             raise ValueError("Required param 'output_path' is missing")
 
         output_path = Path(output_path_str)
-        tail_lines = params.get("transcript_tail_lines", 200)
-        tz_name = params.get("timezone", "US/Eastern")
+        vault_root = Path(params.get("vault_root", str(output_path.parent)))
+        status_path = Path(params.get("handoff_status_path", str(output_path.parent / "handoff-status.json")))
+        enqueue_url = params.get("handoff_jobs_url", "http://127.0.0.1:8788/internal/handoff-jobs")
         agent_name = params.get("agent_name", "Assistant")
-        session_id = hook_input.get("session_id", "unknown")
-        transcript_path_str = hook_input.get("transcript_path", "")
-
-        _debug(f"=== HandoffWriter fired: event={event} session={session_id}")
-        _debug(f"transcript_path={transcript_path_str!r}")
-
-        # Quick deduplication check
-        state_file = _state_file_for(output_path)
-        state = _load_state(state_file)
-        if state.get("session_id") == session_id and time.time() - state.get("timestamp", 0) < 60:
-            _debug(f"skipping duplicate handoff for session {session_id}")
+        session_id = str(hook_input.get("session_id", "")).strip()
+        transcript_path_str = str(hook_input.get("transcript_path", "")).strip()
+        if not session_id:
             return ToolResult(
-                heading="Handoff Note Written",
-                content="Handoff already written for this session.",
+                heading="Handoff Job Enqueue Failed",
+                content="Missing session_id in hook payload.",
+            )
+        if not transcript_path_str:
+            return ToolResult(
+                heading="Handoff Job Enqueue Failed",
+                content="Missing transcript_path in hook payload.",
             )
 
-        # Check transcript exists
-        if not transcript_path_str or not Path(transcript_path_str).exists():
-            _debug(f"transcript not available: {transcript_path_str!r}")
-            return ToolResult(
-                heading="Handoff Note Written",
-                content="No transcript available.",
-            )
+        payload = {
+            "session_id": session_id,
+            "event": event,
+            "agent_name": agent_name,
+            "vault_root": str(vault_root),
+            "handoff_path": str(output_path),
+            "handoff_status_path": str(status_path),
+            "transcript_path": transcript_path_str,
+            "requested_at": datetime.now(UTC).isoformat(),
+            "idempotency_key": f"{session_id}:{event}:{output_path}",
+            "context": {},
+        }
 
-        # Read transcript (fast — local file I/O only)
-        transcript_context, turn_count = read_transcript(
-            Path(transcript_path_str), max_turns=tail_lines
+        req = urllib.request.Request(
+            url=enqueue_url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
         )
-        _debug(f"read_transcript: {turn_count} turns, {len(transcript_context)} chars")
-
-        if not transcript_context.strip():
-            _debug("transcript empty after read")
-            return ToolResult(
-                heading="Handoff Note Written",
-                content="Transcript empty — nothing to hand off.",
-            )
-
-        # Timestamp
         try:
-            tz = ZoneInfo(tz_name)
-        except Exception:
-            tz = ZoneInfo("US/Eastern")
-        now = datetime.now(UTC).astimezone(tz)
-        timestamp = now.strftime("%A, %B %d, %Y %I:%M %p %Z")
-
-        # Write context to temp file for the claude process
-        ts_str = datetime.now(UTC).astimezone().strftime("%Y%m%d-%H%M%S")
-        context_file = output_path.parent / f"handoff-context-{session_id[:8]}-{ts_str}.md"
-        context_file.write_text(transcript_context, encoding="utf-8")
-        _debug(f"wrote context to {context_file}")
-
-        # Build prompt
-        prompt = _build_prompt(
-            context_file=str(context_file),
-            output_path=str(output_path),
-            agent_name=agent_name,
-            session_id=session_id,
-            event=event,
-            timestamp=timestamp,
-        )
-
-        # Find claude binary
-        claude_bin = shutil.which("claude")
-        if not claude_bin:
-            _debug("claude binary not found on PATH")
+            with urllib.request.urlopen(req, timeout=2.0) as resp:
+                body = resp.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            logger.warning("handoff enqueue rejected: %s", exc)
             return ToolResult(
-                heading="Handoff Note Written",
-                content="claude CLI not found — cannot write handoff note.",
+                heading="Handoff Job Enqueue Failed",
+                content=f"Daemon rejected handoff job ({exc.code}).",
             )
-
-        # Spawn detached claude process
-        cmd = [
-            claude_bin,
-            "-p",
-            prompt,
-            "--allowedTools",
-            "Read,Write,Edit,Bash",
-            "--max-turns",
-            "5",
-        ]
-
-        # Detach from parent so it survives Ctrl+C
-        creation_flags = subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
-        kwargs: dict[str, Any] = {}
-        if sys.platform != "win32":
-            kwargs["start_new_session"] = True
+        except (urllib.error.URLError, OSError):
+            return ToolResult(
+                heading="Handoff Job Enqueue Failed",
+                content="Cannot reach handoff daemon endpoint.",
+            )
 
         try:
-            subprocess.Popen(
-                cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                creationflags=creation_flags,
-                cwd=str(output_path.parent),
-                **kwargs,
-            )
-            _debug(f"spawned claude -p for session {session_id}")
-        except Exception as e:
-            _debug(f"FAILED to spawn claude: {e}")
-            logger.error("Failed to spawn claude: %s", e)
-            return ToolResult(
-                heading="Handoff Note Written",
-                content=f"Failed to spawn claude process: {e}",
-            )
+            parsed = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            parsed = {}
 
-        # Save state immediately to prevent duplicate spawns
-        _save_state(state_file, {"session_id": session_id, "timestamp": time.time()})
-
+        job_id = parsed.get("job_id", "unknown")
         return ToolResult(
-            heading="Handoff Note Written",
-            content=f"Background handoff extraction spawned for session {session_id} ({turn_count} turns).",
+            heading="Handoff Job Enqueued",
+            content=f"Enqueued daemon handoff job {job_id} for session {session_id}.",
         )

--- a/packages/core/src/agent_core/plugins/builtin_aliases.py
+++ b/packages/core/src/agent_core/plugins/builtin_aliases.py
@@ -11,6 +11,7 @@ from typing import Any
 import pluggy
 
 from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+from agent_core.endpoints.handoff_jobs import HandoffJobsEndpoint
 from agent_core.endpoints.scheduler import SchedulerEndpoint
 from agent_core.endpoints.stub import StubEndpoint
 from agent_core.hooks.tools.handoff_writer import HandoffWriter
@@ -24,6 +25,7 @@ _ENDPOINT_TYPES: dict[str, type[Any]] = {
     "builtin.claude_code_mcp": ClaudeCodeMCPEndpoint,
     "builtin.stub": StubEndpoint,
     "builtin.scheduler": SchedulerEndpoint,
+    "builtin.handoff_jobs": HandoffJobsEndpoint,
 }
 
 _HOOK_TOOL_TYPES: dict[str, type[Any]] = {

--- a/packages/core/tests/test_handoff_enqueue_integration.py
+++ b/packages/core/tests/test_handoff_enqueue_integration.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from agent_core.bus.envelope import EventPayload
+from agent_core.bus.runner import build_bus_from_config
+from agent_core.hooks.tools.handoff_writer import HandoffWriter
+
+
+@pytest.mark.asyncio
+async def test_enqueue_hook_to_daemon_end_to_end(tmp_path):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = vault_root / "transcript.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hello"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+            async def _fake_extract(self, req, transcript_text):
+                return "# Handoff\n"
+
+            setattr(type(endpoint), "_extract_handoff", _fake_extract)
+
+            hook = HandoffWriter()
+            result = await asyncio.to_thread(
+                hook.execute,
+                event="SessionEnd",
+                hook_input={"session_id": "session-e2e", "transcript_path": str(transcript_path)},
+                params={
+                    "agent_name": "pepper",
+                    "output_path": str(handoff_path),
+                    "handoff_status_path": str(status_path),
+                    "vault_root": str(vault_root),
+                    "handoff_jobs_url": f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs",
+                },
+            )
+            assert result.heading == "Handoff Job Enqueued"
+
+            for _ in range(60):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state == "ready":
+                        break
+                await asyncio.sleep(0.05)
+
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+            assert status["state"] == "ready"
+            assert status["session_id"] == "session-e2e"
+            assert handoff_path.exists()
+
+            job_id = status["job_id"]
+            stub_ep = bus._endpoints_by_name["pepper"].endpoint
+            for _ in range(60):
+                if any(
+                    env.kind == "Event"
+                    and isinstance(env.payload, EventPayload)
+                    and env.payload.type == "HandoffReady"
+                    and env.payload.data.get("job_id") == job_id
+                    for env in stub_ep.inbox
+                ):
+                    break
+                await asyncio.sleep(0.05)
+
+            assert any(
+                env.kind == "Event"
+                and isinstance(env.payload, EventPayload)
+                and env.payload.type == "HandoffReady"
+                and env.payload.data.get("job_id") == job_id
+                for env in stub_ep.inbox
+            )
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()

--- a/packages/core/tests/test_handoff_jobs_endpoint.py
+++ b/packages/core/tests/test_handoff_jobs_endpoint.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from agent_core.bus.envelope import EventPayload
+from agent_core.bus.runner import build_bus_from_config
+from agent_core.endpoints.handoff_jobs import HandoffJobRequest, HandoffJobsEndpoint
+
+
+@pytest.mark.asyncio
+async def test_handoff_jobs_endpoint_writes_status_and_publishes_ready(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = vault_root / "transcript.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hello"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+            async def _fake_extract(self, req, transcript_text):
+                return "# Handoff\n"
+            monkeypatch.setattr(
+                type(endpoint),
+                "_extract_handoff",
+                _fake_extract,
+            )
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-123",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+            body = resp.json()
+            assert body["status"] == "accepted"
+            assert body["job_id"]
+
+            for _ in range(40):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state == "ready":
+                        break
+                await asyncio.sleep(0.05)
+
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+            assert status["state"] == "ready"
+            assert status["session_id"] == "session-123"
+            assert status["job_id"] == body["job_id"]
+            assert "content_sha256" in status
+            assert handoff_path.exists()
+
+            stub_ep = bus._endpoints_by_name["pepper"].endpoint
+            for _ in range(40):
+                if any(
+                    env.kind == "Event"
+                    and isinstance(env.payload, EventPayload)
+                    and env.payload.type == "HandoffReady"
+                    and env.payload.data.get("job_id") == body["job_id"]
+                    for env in stub_ep.inbox
+                ):
+                    break
+                await asyncio.sleep(0.05)
+            assert any(
+                env.kind == "Event"
+                and isinstance(env.payload, EventPayload)
+                and env.payload.type == "HandoffReady"
+                and env.payload.data.get("job_id") == body["job_id"]
+                for env in stub_ep.inbox
+            )
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
+
+
+@pytest.mark.asyncio
+async def test_handoff_jobs_endpoint_writes_extractor_output(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = vault_root / "transcript.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hello"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+    extracted = "# Extracted handoff\n\n- source: test\n"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+            async def _fake_extract(self, req, transcript_text):
+                return extracted
+            monkeypatch.setattr(
+                type(endpoint),
+                "_extract_handoff",
+                _fake_extract,
+            )
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-extract",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+
+            for _ in range(40):
+                if handoff_path.exists():
+                    break
+                await asyncio.sleep(0.05)
+
+            assert handoff_path.read_text(encoding="utf-8") == extracted.rstrip() + "\n"
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
+
+
+@pytest.mark.asyncio
+async def test_handoff_jobs_endpoint_rejects_path_outside_vault_root(tmp_path):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = vault_root / "transcript.jsonl"
+    transcript_path.write_text("{}", encoding="utf-8")
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-esc",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(tmp_path / "outside-handoff.md"),
+                "handoff_status_path": str(vault_root / "handoff-status.json"),
+                "transcript_path": str(transcript_path),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 403
+            assert "escapes vault_root" in resp.json()["error"]
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
+
+
+@pytest.mark.asyncio
+async def test_extract_handoff_success_uses_model_output(monkeypatch):
+    endpoint = HandoffJobsEndpoint(name="handoff-jobs")
+    req = HandoffJobRequest(
+        session_id="session-1",
+        event="SessionEnd",
+        agent_name="pepper",
+        vault_root="/vault",
+        handoff_path="/vault/handoff.md",
+        handoff_status_path="/vault/handoff-status.json",
+        transcript_path="/vault/transcript.jsonl",
+        requested_at=datetime.now(UTC),
+    )
+    expected = "# Handoff Note\n\n- extracted: yes"
+
+    async def _fake_call(self, *, req, transcript_text):
+        return expected
+
+    monkeypatch.setattr(HandoffJobsEndpoint, "_call_agent_sdk", _fake_call)
+
+    actual = await endpoint._extract_handoff(req, "transcript text")
+    assert actual == expected
+
+
+@pytest.mark.asyncio
+async def test_extract_handoff_fallback_on_exception(monkeypatch):
+    endpoint = HandoffJobsEndpoint(name="handoff-jobs")
+    req = HandoffJobRequest(
+        session_id="session-fallback",
+        event="PreCompact",
+        agent_name="pepper",
+        vault_root="/vault",
+        handoff_path="/vault/handoff.md",
+        handoff_status_path="/vault/handoff-status.json",
+        transcript_path="/vault/transcript.jsonl",
+        requested_at=datetime.now(UTC),
+    )
+
+    async def _raise(*args, **kwargs):
+        raise RuntimeError("sdk boom")
+
+    monkeypatch.setattr(HandoffJobsEndpoint, "_call_agent_sdk", _raise)
+
+    fallback = await endpoint._extract_handoff(req, "transcript text")
+    assert fallback.startswith("# Handoff (pepper)")
+    assert "- session_id: session-fallback" in fallback
+    assert "- event: PreCompact" in fallback
+    assert "Extraction fallback used: sdk boom" in fallback
+
+
+@pytest.mark.asyncio
+async def test_worker_retries_then_marks_failed(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = vault_root / "transcript.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hello"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+      max_attempts: 2
+      retry_backoff_seconds: 0
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    attempts = {"count": 0}
+
+    async def always_fail_extract(self, req, transcript_text):
+        attempts["count"] += 1
+        raise RuntimeError("forced extract failure")
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+            monkeypatch.setattr(type(endpoint), "_extract_handoff", always_fail_extract)
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-fail",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
+
+            for _ in range(40):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state == "failed":
+                        break
+                await asyncio.sleep(0.05)
+
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+            assert status["state"] == "failed"
+            assert status["session_id"] == "session-fail"
+            assert status["job_id"] == job_id
+            assert status["error"] == "forced extract failure"
+            assert attempts["count"] == 2
+
+            stub_ep = bus._endpoints_by_name["pepper"].endpoint
+            for _ in range(40):
+                if any(
+                    env.kind == "Event"
+                    and isinstance(env.payload, EventPayload)
+                    and env.payload.type == "HandoffFailed"
+                    and env.payload.data.get("job_id") == job_id
+                    for env in stub_ep.inbox
+                ):
+                    break
+                await asyncio.sleep(0.05)
+            assert any(
+                env.kind == "Event"
+                and isinstance(env.payload, EventPayload)
+                and env.payload.type == "HandoffFailed"
+                and env.payload.data.get("job_id") == job_id
+                for env in stub_ep.inbox
+            )
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
+

--- a/packages/core/tests/test_handoff_writer.py
+++ b/packages/core/tests/test_handoff_writer.py
@@ -1,201 +1,104 @@
-"""Tests for the HandoffWriter hook tool (detached claude CLI launcher)."""
+"""Tests for HandoffWriter enqueue-only behavior."""
 
 import json
-import time
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from agent_core.hooks.protocol import HookTool
-from agent_core.hooks.tools.handoff_writer import HandoffWriter, _state_file_for
+from agent_core.hooks.tools.handoff_writer import HandoffWriter
 from agent_core.models import ToolResult
 
 
-def make_transcript(path: Path, turns: list[tuple[str, str]]) -> None:
-    """Create a JSONL transcript file with the given turns."""
-    with open(path, "w", encoding="utf-8") as f:
-        for role, content in turns:
-            f.write(json.dumps({"message": {"role": role, "content": content}}) + "\n")
+class _FakeResponse:
+    def __init__(self, body: dict):
+        self._stream = BytesIO(json.dumps(body).encode("utf-8"))
+
+    def read(self) -> bytes:
+        return self._stream.read()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
 
 
 class TestHandoffWriter:
-    """Tests for HandoffWriter — detached claude CLI launcher."""
-
     def test_implements_hook_tool_protocol(self):
         assert isinstance(HandoffWriter(), HookTool)
 
-    @patch("agent_core.hooks.tools.handoff_writer.subprocess.Popen")
-    @patch("agent_core.hooks.tools.handoff_writer.shutil.which", return_value="/usr/bin/claude")
-    def test_spawns_claude_process(self, mock_which, mock_popen, tmp_path: Path):
-        """Spawns claude -p with correct arguments."""
+    @patch("agent_core.hooks.tools.handoff_writer.urllib.request.urlopen")
+    def test_enqueues_daemon_job(self, mock_urlopen, tmp_path: Path):
+        mock_urlopen.return_value = _FakeResponse({"job_id": "job-123", "status": "accepted"})
         transcript = tmp_path / "transcript.jsonl"
-        make_transcript(transcript, [("user", "Hello"), ("assistant", "Hi")])
+        transcript.write_text("{}", encoding="utf-8")
         output = tmp_path / "handoff.md"
 
         tool = HandoffWriter()
         result = tool.execute(
-            event="PreCompact",
-            hook_input={"transcript_path": str(transcript), "session_id": "test-123"},
-            params={"output_path": str(output), "agent_name": "Pepper", "timezone": "US/Eastern"},
+            event="SessionEnd",
+            hook_input={"transcript_path": str(transcript), "session_id": "session-1"},
+            params={
+                "output_path": str(output),
+                "agent_name": "Pepper",
+                "handoff_jobs_url": "http://127.0.0.1:8788/internal/handoff-jobs",
+            },
         )
 
         assert isinstance(result, ToolResult)
-        assert "spawned" in result.content.lower() or "background" in result.content.lower()
-        assert mock_popen.called
-
-        cmd = mock_popen.call_args[0][0]
-        assert cmd[0] == "/usr/bin/claude"
-        assert "-p" in cmd
-        assert "--allowedTools" in cmd
-
-    @patch("agent_core.hooks.tools.handoff_writer.subprocess.Popen")
-    @patch("agent_core.hooks.tools.handoff_writer.shutil.which", return_value="/usr/bin/claude")
-    def test_writes_context_file(self, mock_which, mock_popen, tmp_path: Path):
-        """Writes transcript context to a temp file for the claude process."""
-        transcript = tmp_path / "transcript.jsonl"
-        make_transcript(transcript, [("user", "Hello world"), ("assistant", "Hi there")])
-        output = tmp_path / "handoff.md"
-
-        tool = HandoffWriter()
-        tool.execute(
-            event="PreCompact",
-            hook_input={"transcript_path": str(transcript), "session_id": "ctx-1"},
-            params={"output_path": str(output)},
-        )
-
-        context_files = list(tmp_path.glob("handoff-context-*.md"))
-        assert len(context_files) == 1
-        content = context_files[0].read_text(encoding="utf-8")
-        assert "Hello world" in content
-
-    @patch("agent_core.hooks.tools.handoff_writer.subprocess.Popen")
-    @patch("agent_core.hooks.tools.handoff_writer.shutil.which", return_value="/usr/bin/claude")
-    def test_prompt_contains_agent_name(self, mock_which, mock_popen, tmp_path: Path):
-        """Prompt passed to claude includes the agent name."""
-        transcript = tmp_path / "transcript.jsonl"
-        make_transcript(transcript, [("user", "Hello"), ("assistant", "Hi")])
-        output = tmp_path / "handoff.md"
-
-        tool = HandoffWriter()
-        tool.execute(
-            event="PreCompact",
-            hook_input={"transcript_path": str(transcript), "session_id": "s4"},
-            params={"output_path": str(output), "agent_name": "Pepper"},
-        )
-
-        cmd = mock_popen.call_args[0][0]
-        prompt_idx = cmd.index("-p") + 1
-        prompt = cmd[prompt_idx]
-        assert "Pepper" in prompt
-
-    def test_missing_transcript_returns_immediately(self, tmp_path: Path):
-        output = tmp_path / "handoff.md"
-
-        tool = HandoffWriter()
-        result = tool.execute(
-            event="SessionEnd",
-            hook_input={"transcript_path": str(tmp_path / "missing.jsonl"), "session_id": "s1"},
-            params={"output_path": str(output)},
-        )
-        assert "No transcript" in result.content
-
-    def test_empty_transcript_returns_immediately(self, tmp_path: Path):
-        transcript = tmp_path / "transcript.jsonl"
-        transcript.write_text("", encoding="utf-8")
-        output = tmp_path / "handoff.md"
-
-        tool = HandoffWriter()
-        result = tool.execute(
-            event="SessionEnd",
-            hook_input={"transcript_path": str(transcript), "session_id": "s2"},
-            params={"output_path": str(output)},
-        )
-        assert "empty" in result.content.lower() or "No transcript" in result.content
-
-    @patch("agent_core.hooks.tools.handoff_writer.subprocess.Popen")
-    @patch("agent_core.hooks.tools.handoff_writer.shutil.which", return_value="/usr/bin/claude")
-    def test_deduplication_skips_second_call(self, mock_which, mock_popen, tmp_path: Path):
-        """Same session_id within 60 seconds is skipped."""
-        transcript = tmp_path / "transcript.jsonl"
-        make_transcript(transcript, [("user", "Hello"), ("assistant", "Hi")])
-        output = tmp_path / "handoff.md"
-
-        # Write state simulating a recent handoff
-        state_file = output.parent / "handoff-state.json"
-        state_file.write_text(
-            json.dumps({"session_id": "dedup-1", "timestamp": time.time()}),
-            encoding="utf-8",
-        )
-
-        tool = HandoffWriter()
-        result = tool.execute(
-            event="SessionEnd",
-            hook_input={"transcript_path": str(transcript), "session_id": "dedup-1"},
-            params={"output_path": str(output)},
-        )
-        assert "already written" in result.content.lower()
-        assert not mock_popen.called
-
-    @patch("agent_core.hooks.tools.handoff_writer.subprocess.Popen")
-    @patch("agent_core.hooks.tools.handoff_writer.shutil.which", return_value="/usr/bin/claude")
-    def test_saves_state_after_spawn(self, mock_which, mock_popen, tmp_path: Path):
-        """State file is written after spawning to prevent duplicate spawns."""
-        transcript = tmp_path / "transcript.jsonl"
-        make_transcript(transcript, [("user", "Hello"), ("assistant", "Hi")])
-        output = tmp_path / "handoff.md"
-
-        tool = HandoffWriter()
-        tool.execute(
-            event="PreCompact",
-            hook_input={"transcript_path": str(transcript), "session_id": "state-1"},
-            params={"output_path": str(output)},
-        )
-
-        state_file = output.parent / "handoff-state.json"
-        assert state_file.exists()
-        state = json.loads(state_file.read_text(encoding="utf-8"))
-        assert state["session_id"] == "state-1"
-
-    def test_state_file_derived_from_output_path(self, tmp_path: Path):
-        output = tmp_path / "vault" / "handoff.md"
-        state = _state_file_for(output)
-        assert state == tmp_path / "vault" / "handoff-state.json"
+        assert "Enqueued daemon handoff job job-123" in result.content
+        assert mock_urlopen.called
+        req = mock_urlopen.call_args.args[0]
+        payload = json.loads(req.data.decode("utf-8"))
+        assert payload["session_id"] == "session-1"
+        assert payload["event"] == "SessionEnd"
+        assert payload["handoff_path"] == str(output)
 
     def test_missing_output_path_raises(self):
         tool = HandoffWriter()
         with pytest.raises(ValueError, match="output_path"):
             tool.execute(event="PreCompact", hook_input={}, params={})
 
-    @patch("agent_core.hooks.tools.handoff_writer.shutil.which", return_value=None)
-    def test_missing_claude_binary(self, mock_which, tmp_path: Path):
-        """Returns error if claude CLI is not found."""
-        transcript = tmp_path / "transcript.jsonl"
-        make_transcript(transcript, [("user", "Hello"), ("assistant", "Hi")])
+    def test_missing_session_id_returns_failure(self, tmp_path: Path):
         output = tmp_path / "handoff.md"
-
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text("{}", encoding="utf-8")
         tool = HandoffWriter()
         result = tool.execute(
-            event="PreCompact",
-            hook_input={"transcript_path": str(transcript), "session_id": "no-cli"},
+            event="SessionEnd",
+            hook_input={"transcript_path": str(transcript)},
             params={"output_path": str(output)},
         )
-        assert "not found" in result.content.lower()
+        assert result.heading == "Handoff Job Enqueue Failed"
+        assert "session_id" in result.content
+
+    def test_missing_transcript_path_returns_failure(self, tmp_path: Path):
+        output = tmp_path / "handoff.md"
+        tool = HandoffWriter()
+        result = tool.execute(
+            event="SessionEnd",
+            hook_input={"session_id": "s-1"},
+            params={"output_path": str(output)},
+        )
+        assert result.heading == "Handoff Job Enqueue Failed"
+        assert "transcript_path" in result.content
 
     @patch(
-        "agent_core.hooks.tools.handoff_writer.subprocess.Popen",
-        side_effect=OSError("spawn failed"),
+        "agent_core.hooks.tools.handoff_writer.urllib.request.urlopen",
+        side_effect=OSError("down"),
     )
-    @patch("agent_core.hooks.tools.handoff_writer.shutil.which", return_value="/usr/bin/claude")
-    def test_spawn_failure_returns_error(self, mock_which, mock_popen, tmp_path: Path):
+    def test_daemon_unreachable_returns_failure(self, mock_urlopen, tmp_path: Path):
         transcript = tmp_path / "transcript.jsonl"
-        make_transcript(transcript, [("user", "Hello"), ("assistant", "Hi")])
+        transcript.write_text("{}", encoding="utf-8")
         output = tmp_path / "handoff.md"
-
         tool = HandoffWriter()
         result = tool.execute(
-            event="PreCompact",
-            hook_input={"transcript_path": str(transcript), "session_id": "fail-1"},
+            event="SessionEnd",
+            hook_input={"transcript_path": str(transcript), "session_id": "s-2"},
             params={"output_path": str(output)},
         )
-        assert "failed" in result.content.lower() or "spawn" in result.content.lower()
+        assert result.heading == "Handoff Job Enqueue Failed"
+        assert "Cannot reach handoff daemon endpoint" in result.content


### PR DESCRIPTION
## Summary
- move handoff generation out of hooks into a daemon-owned `builtin.handoff_jobs` endpoint with enqueue intake, worker retries, status lifecycle, and completion events
- switch `builtin.handoff_writer` to enqueue-only behavior (no local handoff file writes, no `claude -p` spawn path)
- wire default Pepper example/docs to run the daemon handoff flow and add endpoint/hook integration coverage

## Test plan
- [x] `uv run --directory packages/core pytest tests/test_handoff_writer.py tests/test_handoff_jobs_endpoint.py tests/test_handoff_enqueue_integration.py tests/test_plugins.py tests/test_runner_http_host.py tests/test_file_injector.py -q`

Made with [Cursor](https://cursor.com)