### PR TITLE
Discord bridge: make outbound chunking markdown-safe (fences/code/links)

### DIFF
--- a/packages/agent-core-discord/src/agent_core_discord/chunking.py
+++ b/packages/agent-core-discord/src/agent_core_discord/chunking.py
@@ -10,6 +10,9 @@ See GitHub issue #20 for rationale (2000-char API reject, bus-level ack).
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
+
 # Discord HTTP API maximum for message ``content``.
 DISCORD_CONTENT_LIMIT = 2000
 # Target size before continuation markers / headroom.
@@ -18,6 +21,166 @@ DISCORD_CHUNK_TARGET = 1900
 TAIL_SEARCH = 200
 # Safety valve — avoid spamming the channel on pathological payloads.
 MAX_CHUNKS = 25
+
+_LINK_OR_IMAGE_RE = re.compile(r"!\[[^\]]*]\([^)\n]*\)|\[[^\]]+]\([^)\n]*\)")
+
+
+@dataclass(frozen=True)
+class _MarkdownState:
+    in_fence: bool = False
+    fence_delim: str = "```"
+    fence_lang: str = ""
+    in_inline_code: bool = False
+
+
+def _scan_markdown_states(text: str) -> list[_MarkdownState]:
+    """Return parser state at every split boundary in ``text``."""
+    states: list[_MarkdownState] = []
+    in_fence = False
+    fence_delim = "```"
+    fence_lang = ""
+    inline_ticks = 0
+    line_start = True
+    n = len(text)
+
+    for i, ch in enumerate(text):
+        states.append(
+            _MarkdownState(
+                in_fence=in_fence,
+                fence_delim=fence_delim,
+                fence_lang=fence_lang,
+                in_inline_code=inline_ticks > 0,
+            )
+        )
+
+        if line_start and inline_ticks == 0:
+            j = i
+            indent = 0
+            while j < n and text[j] in (" ", "\t") and indent < 3:
+                j += 1
+                indent += 1
+            if j + 2 < n and text[j] == text[j + 1] == text[j + 2] and text[j] in ("`", "~"):
+                run_char = text[j]
+                k = j
+                while k < n and text[k] == run_char:
+                    k += 1
+                delim = text[j:k]
+                line_end = text.find("\n", k)
+                if line_end == -1:
+                    line_end = n
+                trailer = text[k:line_end]
+                if not in_fence:
+                    in_fence = True
+                    fence_delim = delim
+                    fence_lang = trailer.strip()
+                elif run_char == fence_delim[0] and len(delim) >= len(fence_delim):
+                    in_fence = False
+                    fence_lang = ""
+
+        if not in_fence and ch == "`" and (i == 0 or text[i - 1] != "`"):
+            k = i
+            while k < n and text[k] == "`":
+                k += 1
+            run = k - i
+            if inline_ticks == 0:
+                inline_ticks = run
+            elif run == inline_ticks:
+                inline_ticks = 0
+
+        line_start = ch == "\n"
+
+    states.append(
+        _MarkdownState(
+            in_fence=in_fence,
+            fence_delim=fence_delim,
+            fence_lang=fence_lang,
+            in_inline_code=inline_ticks > 0,
+        )
+    )
+    return states
+
+
+def _link_boundary_mask(text: str) -> list[bool]:
+    """Boundary mask of positions that fall inside markdown link/image tokens."""
+    mask = [False] * (len(text) + 1)
+    for match in _LINK_OR_IMAGE_RE.finditer(text):
+        for idx in range(match.start() + 1, match.end()):
+            mask[idx] = True
+    return mask
+
+
+def _fence_opening(state: _MarkdownState) -> str:
+    if not state.in_fence:
+        return ""
+    lang = f" {state.fence_lang}" if state.fence_lang else ""
+    return f"{state.fence_delim}{lang}\n"
+
+
+def _fence_closing(state: _MarkdownState) -> str:
+    if not state.in_fence:
+        return ""
+    return f"\n{state.fence_delim}"
+
+
+def _is_safe_boundary(
+    abs_idx: int,
+    states: list[_MarkdownState],
+    in_link_mask: list[bool],
+) -> bool:
+    st = states[abs_idx]
+    if st.in_inline_code:
+        return False
+    if in_link_mask[abs_idx]:
+        return False
+    return True
+
+
+def _find_soft_split_with_markdown(
+    text: str,
+    start: int,
+    limit: int,
+    states: list[_MarkdownState],
+    in_link_mask: list[bool],
+) -> int:
+    """Markdown-aware split index in absolute coordinates."""
+    end = min(len(text), start + limit)
+    if end >= len(text):
+        return len(text)
+
+    window = text[start:end]
+    lo = max(0, len(window) - TAIL_SEARCH)
+
+    def boundary_ok(rel_idx: int) -> bool:
+        if rel_idx <= 0:
+            return False
+        return _is_safe_boundary(start + rel_idx, states, in_link_mask)
+
+    def find_rfind(needle: str, start_rel: int, end_rel: int, add: int) -> int:
+        scan = end_rel
+        while True:
+            pos = window.rfind(needle, start_rel, scan)
+            if pos == -1:
+                return -1
+            candidate = pos + add
+            if boundary_ok(candidate):
+                return candidate
+            scan = pos
+
+    checks: list[tuple[str, int]] = [("\n\n", 1), ("\n", 1), (". ", 2), ("! ", 2), ("? ", 2), (" ", 1)]
+
+    for sep, add in checks:
+        pos = find_rfind(sep, lo, len(window), add)
+        if pos != -1:
+            return start + pos
+    for sep, add in checks:
+        pos = find_rfind(sep, 0, len(window), add)
+        if pos != -1:
+            return start + pos
+
+    hard = end
+    while hard > start and not boundary_ok(hard - start):
+        hard -= 1
+    return hard if hard > start else end
 
 
 def _find_soft_split(text: str, limit: int) -> int:
@@ -83,25 +246,60 @@ def smart_chunk_discord(text: str, *, limit: int = DISCORD_CHUNK_TARGET) -> list
         _validate_chunks(out)
         return out
 
+    states = _scan_markdown_states(text)
+    in_link_mask = _link_boundary_mask(text)
     chunks: list[str] = []
-    remaining = text
+    pos = 0
+    n = len(text)
 
-    while remaining:
-        if len(remaining) <= limit:
-            chunks.append(remaining)
-            break
+    while pos < n:
+        if n - pos <= limit:
+            split_at = n
+        else:
+            split_at = _find_soft_split_with_markdown(text, pos, limit, states, in_link_mask)
+            if split_at <= pos:
+                split_at = min(pos + limit, n)
 
-        split_at = _find_soft_split(remaining, limit)
-        if split_at <= 0:
-            split_at = min(limit, len(remaining))
-        # Only trim newlines so spaces at soft boundaries (e.g. word splits) are
-        # not dropped across chunks.
-        piece = remaining[:split_at].rstrip("\n")
+        start_state = states[pos]
+        end_state = states[split_at]
+        prefix = _fence_opening(start_state)
+        suffix = _fence_closing(end_state)
+        piece = text[pos:split_at]
+
+        if not start_state.in_fence and not end_state.in_fence:
+            trimmed = piece.rstrip("\n")
+            trim_delta = len(piece) - len(trimmed)
+            piece = trimmed or piece
+            split_at -= trim_delta
+
+        rendered = f"{prefix}{piece}{suffix}"
+        if len(rendered) > DISCORD_CONTENT_LIMIT and split_at - pos > 1:
+            # Last-resort shrink for pathological cases (long markdown token).
+            fallback = split_at - 1
+            while fallback > pos:
+                if _is_safe_boundary(fallback, states, in_link_mask):
+                    trial = f"{prefix}{text[pos:fallback]}{_fence_closing(states[fallback])}"
+                    if len(trial) <= DISCORD_CONTENT_LIMIT:
+                        split_at = fallback
+                        end_state = states[split_at]
+                        suffix = _fence_closing(end_state)
+                        piece = text[pos:split_at]
+                        rendered = f"{prefix}{piece}{suffix}"
+                        break
+                fallback -= 1
+
         if not piece:
-            split_at = min(limit, len(remaining))
-            piece = remaining[:split_at]
-        chunks.append(piece)
-        remaining = remaining[split_at:].lstrip("\n")
+            split_at = min(pos + limit, n)
+            end_state = states[split_at]
+            suffix = _fence_closing(end_state)
+            piece = text[pos:split_at]
+            rendered = f"{prefix}{piece}{suffix}"
+
+        chunks.append(rendered)
+        pos = split_at
+        if not end_state.in_fence:
+            while pos < n and text[pos] == "\n":
+                pos += 1
 
     if len(chunks) <= 1:
         _validate_chunks(chunks)

--- a/packages/agent-core-discord/tests/test_chunking.py
+++ b/packages/agent-core-discord/tests/test_chunking.py
@@ -21,6 +21,12 @@ def _content_only(chunks: list[str]) -> str:
     return "".join(parts)
 
 
+def _without_marker(chunk: str) -> str:
+    if chunk.startswith("(") and ")\n" in chunk[:16]:
+        return chunk.split("\n", 1)[-1]
+    return chunk
+
+
 def test_short_message_no_split():
     text = "Hello, world!"
     result = smart_chunk_discord(text)
@@ -80,3 +86,37 @@ def test_too_many_chunks_raises():
     text = "x" * (DISCORD_CHUNK_TARGET * (MAX_CHUNKS + 3))
     with pytest.raises(ValueError, match="max"):
         smart_chunk_discord(text)
+
+
+def test_fenced_block_cross_boundary_closes_and_reopens():
+    text = "before\n```python\n" + ("print('hi')\n" * 120) + "```\nafter"
+    chunks = smart_chunk_discord(text, limit=240)
+    assert len(chunks) > 1
+    assert all(len(c) <= 2000 for c in chunks)
+    for i, chunk in enumerate(chunks):
+        body = _without_marker(chunk)
+        if i < len(chunks) - 1 and "```python" in chunk and "print('hi')" in chunk:
+            assert chunk.rstrip().endswith("```")
+        if i > 0 and "print('hi')" in body:
+            assert body.startswith("``` python\n") or body.startswith("```python\n")
+
+
+def test_inline_code_span_not_split():
+    inline = "`" + ("x" * 220) + "`"
+    text = f"start {inline} end"
+    chunks = smart_chunk_discord(text, limit=60)
+    assert len(chunks) > 1
+    assert all(len(c) <= 2000 for c in chunks)
+    assert sum(chunk.count("`") for chunk in chunks) == 2
+    assert _content_only(chunks).replace("\n```", "").replace("```", "") == text
+
+
+def test_markdown_link_and_image_not_split():
+    link = "[example link text](https://example.com/very/long/path)"
+    image = "![alt text](https://example.com/static/image.png)"
+    text = ("prefix " * 20) + link + " middle " + image + (" suffix" * 20)
+    chunks = smart_chunk_discord(text, limit=120)
+    assert len(chunks) > 1
+    assert all(len(c) <= 2000 for c in chunks)
+    assert sum(c.count(link) for c in chunks) == 1
+    assert sum(c.count(image) for c in chunks) == 1


### PR DESCRIPTION
## Summary
- make outbound Discord chunking markdown-safe by avoiding split points inside fenced code, inline code spans, and markdown links/images
- when a fenced code block crosses chunk boundaries, close the fence at the end of the previous chunk and reopen the next chunk with the same language tag
- add regression tests for fence-boundary behavior, inline code, links/images near boundaries, and <=2000 chunk cap guarantees

Fixes #21

## Test plan
- [x] `uv run pytest packages/agent-core-discord/tests -q`
- [x] `uv run ruff check packages/agent-core-discord/src/agent_core_discord/chunking.py packages/agent-core-discord/tests/test_chunking.py`
- [ ] `uv run ruff check packages/agent-core-discord/src/agent_core_discord packages/agent-core-discord/tests` (fails today due to pre-existing lint issues outside this change)