### PR TITLE
style(agent-core-discord): satisfy ruff in test suite

### DIFF
--- a/packages/agent-core-discord/tests/test_endpoint_hardening.py
+++ b/packages/agent-core-discord/tests/test_endpoint_hardening.py
@@ -4,15 +4,15 @@ add_listener routing, args caps, embed total cap."""
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
-from pydantic import ValidationError
-
-from agent_core.bus.envelope import EndpointInfo, Envelope, ToolInvocationPayload
 from agent_core_discord import endpoint as endpoint_mod
 from agent_core_discord.args import _DownloadAttachmentsArgs, _FetchArgs
 from agent_core_discord.endpoint import DiscordEndpoint, _check_embeds_within_caps
+from pydantic import ValidationError
+
+from agent_core.bus.envelope import EndpointInfo, Envelope, ToolInvocationPayload
 from tests.conftest import _FakeChannel, _FakeDiscordClient
 
 
@@ -41,7 +41,7 @@ def _envelope(env_id: str, frm: str, to: str, payload) -> Envelope:
         to=to,
         kind="ToolInvocation",
         payload=payload,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
 

--- a/packages/agent-core-discord/tests/test_endpoint_inbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_inbound.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from agent_core_discord.endpoint import DiscordEndpoint
 
 from agent_core.bus.envelope import EndpointInfo, Envelope, EventPayload, TextMessagePayload
-from agent_core_discord.endpoint import DiscordEndpoint
 from tests.conftest import _FakeChannel, _FakeDiscordClient, _FakeMessage, _FakeUser
 
 

--- a/packages/agent-core-discord/tests/test_endpoint_lifecycle.py
+++ b/packages/agent-core-discord/tests/test_endpoint_lifecycle.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import os
+from datetime import UTC
 
 import pytest
+from agent_core_discord.endpoint import DiscordEndpoint, _active_endpoints
 
 from agent_core.bus.protocol import Endpoint
-from agent_core_discord.endpoint import DiscordEndpoint, _active_endpoints
 from tests.conftest import _FakeBusHandle
 
 
@@ -126,7 +127,7 @@ async def test_stop_deregisters_and_closes_client(monkeypatch):
 @pytest.mark.asyncio
 async def test_deliver_raises_when_not_started():
     import uuid
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     from agent_core.bus.envelope import Envelope, ToolInvocationPayload
     from agent_core.bus.protocol import EndpointUnavailable
@@ -138,7 +139,7 @@ async def test_deliver_raises_when_not_started():
         to="discord-test",
         kind="ToolInvocation",
         payload=ToolInvocationPayload(tool="send", args={}),
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     with pytest.raises(EndpointUnavailable):
         await ep.deliver(env)
@@ -208,8 +209,8 @@ async def test_start_surfaces_connect_failure_quickly(monkeypatch):
 async def test_start_failure_resets_handle_so_deliver_raises_unavailable(monkeypatch):
     """If start() fails (e.g. token missing), deliver() must still raise
     EndpointUnavailable — start() must roll back self._handle on failure."""
-    from datetime import datetime, timezone
     import uuid
+    from datetime import datetime
 
     from agent_core.bus.envelope import Envelope, ToolInvocationPayload
     from agent_core.bus.protocol import EndpointUnavailable
@@ -230,7 +231,7 @@ async def test_start_failure_resets_handle_so_deliver_raises_unavailable(monkeyp
         to="discord-rollback-test",
         kind="ToolInvocation",
         payload=ToolInvocationPayload(tool="send", args={}),
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     with pytest.raises(EndpointUnavailable):
         await ep.deliver(env)

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
+from agent_core_discord.endpoint import DiscordEndpoint
 
 from agent_core.bus.envelope import (
     EndpointInfo,
@@ -14,7 +15,6 @@ from agent_core.bus.envelope import (
     TextMessagePayload,
     ToolInvocationPayload,
 )
-from agent_core_discord.endpoint import DiscordEndpoint
 from tests.conftest import (
     _FakeChannel,
     _FakeDiscordClient,
@@ -63,7 +63,7 @@ def _envelope(env_id: str, frm: str, to: str, payload) -> Envelope:
         to=to,
         kind="ToolInvocation",
         payload=payload,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
 
@@ -336,7 +336,7 @@ async def test_textmessage_long_payload_splits(monkeypatch):
             kind="TextMessage",
             payload=TextMessagePayload(text="z" * 2200),
             metadata={"discord": {"channel_id": "200"}},
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         await ep.deliver(env)
         assert len(ch.sent) >= 2
@@ -364,7 +364,7 @@ async def test_textmessage_uses_discord_metadata_channel_and_replies(monkeypatch
             kind="TextMessage",
             payload=TextMessagePayload(text="hi"),
             metadata={"discord": {"channel_id": "200", "message_id": "m-in"}},
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         await ep.deliver(env)
         assert len(ch.sent) == 1
@@ -401,7 +401,7 @@ async def test_textmessage_uses_default_outbound_channel(monkeypatch):
             to="discord-test",
             kind="TextMessage",
             payload=TextMessagePayload(text="fallback send"),
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         await ep.deliver(env)
         assert len(ch.sent) == 1
@@ -425,7 +425,7 @@ async def test_textmessage_without_channel_returns_error(monkeypatch):
             to="discord-test",
             kind="TextMessage",
             payload=TextMessagePayload(text="hi"),
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         await ep.deliver(env)
         ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
@@ -470,7 +470,7 @@ async def test_textmessage_in_reply_to_clears_ack_without_discord_message_id(mon
             kind="TextMessage",
             payload=TextMessagePayload(text="pong"),
             metadata={},
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         await ep.deliver(out)
         assert "👀" not in user_msg.reactions
@@ -493,7 +493,7 @@ async def test_fetch_returns_recent_messages(monkeypatch):
         m.author = type(
             "A", (), {"id": "100", "name": "alice", "bot": False, "display_name": "Alice"}
         )()
-        m.created_at = datetime.now(timezone.utc)
+        m.created_at = datetime.now(UTC)
         m.embeds = []
         m.attachments = []
         ch._messages[m.id] = m

--- a/packages/agent-core-discord/tests/test_endpoint_pending_acks.py
+++ b/packages/agent-core-discord/tests/test_endpoint_pending_acks.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import time
 
 import pytest
+from agent_core_discord.endpoint import DiscordEndpoint
 
 from agent_core.bus.envelope import EndpointInfo, Envelope
-from agent_core_discord.endpoint import DiscordEndpoint
 from tests.conftest import _FakeChannel, _FakeDiscordClient, _FakeMessage
 
 

--- a/packages/agent-core-discord/tests/test_endpoint_urgency.py
+++ b/packages/agent-core-discord/tests/test_endpoint_urgency.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import json
 
 import pytest
+from agent_core_discord.endpoint import DiscordEndpoint
 
 from agent_core.bus.envelope import EndpointInfo, Envelope
-from agent_core_discord.endpoint import DiscordEndpoint
 from tests.conftest import _FakeChannel, _FakeDiscordClient, _FakeMessage, _FakeUser
 
 

--- a/packages/agent-core-discord/tests/test_integration.py
+++ b/packages/agent-core-discord/tests/test_integration.py
@@ -20,9 +20,10 @@ import asyncio
 import json
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
+from agent_core_discord.endpoint import DiscordEndpoint
 
 from agent_core.bus.core import Bus, BusConfig, EndpointSpec
 from agent_core.bus.envelope import (
@@ -30,8 +31,6 @@ from agent_core.bus.envelope import (
     Envelope,
     ToolInvocationPayload,
 )
-from agent_core_discord.endpoint import DiscordEndpoint
-
 
 REQUIRED_ENV = ("DISCORD_TEST_TOKEN", "DISCORD_TEST_CHANNEL_ID", "DISCORD_TEST_USER_ID")
 pytestmark = pytest.mark.skipif(
@@ -73,7 +72,7 @@ class _ProbeEndpoint:
             to=to,
             kind="ToolInvocation",
             payload=payload,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         await self._handle.publish(env)
         return env_id


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This completes the unchecked item from the PR #26 test plan: `uv run ruff check packages/agent-core-discord/src/agent_core_discord packages/agent-core-discord/tests` now passes.

Changes are mechanical only: `ruff check … --fix` on the Discord package tests for **I001** (import sorting) and **UP017** (`datetime.now(datetime.UTC)` instead of `timezone.utc`).

## Verification

- `uv run ruff check packages/agent-core-discord/src/agent_core_discord packages/agent-core-discord/tests`
- `uv run pytest packages/agent-core-discord/tests -q` (99 passed, 1 skipped)

## Note

Merge after or alongside #26 if you want markdown chunking plus a fully green ruff surface in one go; this PR has no overlap with `chunking.py`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed5b0cdb-4b26-4243-ad13-894d7e5a4c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed5b0cdb-4b26-4243-ad13-894d7e5a4c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

