### PR TITLE
Discord bridge: harden partial-send behavior and rate-limit reliability

### DIFF
--- a/packages/agent-core-discord/changelog.d/22.added.md
+++ b/packages/agent-core-discord/changelog.d/22.added.md
@@ -1,0 +1,6 @@
+- Outbound `send` now retries `channel.send` on Discord rate limits (HTTP 429) and
+  transient 5xx/408 errors with exponential backoff, capped attempts, and
+  `retry_after` when the API provides it. Multi-chunk sends use the same policy
+  per chunk. On partial delivery (some chunks only), inbound 👀 ack is no
+  longer cleared so the thread still signals an incomplete reply; the tool
+  result remains `status=partial` with `message_ids` and `urgency=yellow`.

--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -44,6 +44,7 @@ from agent_core_discord.args import (
     _SendArgs,
 )
 from agent_core_discord.chunking import smart_chunk_discord
+from agent_core_discord.send_retry import channel_send_with_retries
 
 if TYPE_CHECKING:
     from agent_core.bus.handle import BusHandle
@@ -862,7 +863,7 @@ class DiscordEndpoint:
             send_kwargs["files"] = files
 
         if args.text is None:
-            new_msg = await ch.send(args.text, **send_kwargs)
+            new_msg = await channel_send_with_retries(ch, args.text, **send_kwargs)
             if args.reply_to:
                 await self._clear_pending_ack(ch, args.reply_to)
             mid = str(new_msg.id)
@@ -887,15 +888,15 @@ class DiscordEndpoint:
             if files is not None and is_first:
                 send_part["files"] = files
             try:
-                new_msg = await ch.send(part, **send_part)
+                new_msg = await channel_send_with_retries(ch, part, **send_part)
             except Exception as exc:
                 last_error = exc
                 break
             message_ids.append(str(new_msg.id))
 
         if last_error is not None and message_ids:
-            if args.reply_to:
-                await self._clear_pending_ack(ch, args.reply_to)
+            # Partial delivery: do not clear inbound ack — the conversation may still
+            # be awaiting a complete reply; callers get message_ids for what landed.
             return {
                 "status": "partial",
                 "message_ids": message_ids,

--- a/packages/agent-core-discord/src/agent_core_discord/send_retry.py
+++ b/packages/agent-core-discord/src/agent_core_discord/send_retry.py
@@ -1,0 +1,92 @@
+"""Retry policy for Discord ``channel.send`` (rate limits + transient HTTP errors).
+
+discord.py surfaces failures as ``discord.HTTPException`` (and subclasses) with a
+``.status`` code. We keep this module import-light: callers pass ``HTTPException``
+from discord when available; retryability also keys off duck-typed ``.status``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+DISCORD_SEND_MAX_ATTEMPTS = 5
+DISCORD_SEND_BASE_DELAY_S = 0.5
+DISCORD_SEND_MAX_DELAY_S = 30.0
+
+
+def _http_status(exc: BaseException) -> int | None:
+    st = getattr(exc, "status", None)
+    return int(st) if isinstance(st, int) else None
+
+
+def is_retryable_discord_send_error(exc: BaseException) -> bool:
+    """Return True if a send failure is plausibly transient (worth sleeping + retry)."""
+    status = _http_status(exc)
+    if status == 429:
+        return True
+    if status is not None and 500 <= status <= 599:
+        return True
+    if status == 408:
+        return True
+    # discord.py may wrap network issues
+    if isinstance(exc, TimeoutError):
+        return True
+    if isinstance(exc, OSError):
+        import errno
+
+        if exc.errno in (errno.ECONNRESET, errno.ETIMEDOUT, errno.EPIPE):
+            return True
+    return False
+
+
+def _retry_after_seconds(exc: BaseException) -> float | None:
+    ra = getattr(exc, "retry_after", None)
+    if isinstance(ra, (int, float)) and ra >= 0:
+        return float(ra)
+    return None
+
+
+def _backoff_seconds(attempt: int) -> float:
+    """Exponential backoff, capped."""
+    return min(DISCORD_SEND_MAX_DELAY_S, DISCORD_SEND_BASE_DELAY_S * (2**attempt))
+
+
+def retry_delay_seconds(exc: BaseException, attempt: int) -> float:
+    """Sleep duration before attempt ``attempt`` (0-based) after ``exc``."""
+    ra = _retry_after_seconds(exc)
+    if ra is not None and ra > 0:
+        return min(DISCORD_SEND_MAX_DELAY_S, max(ra, _backoff_seconds(attempt)))
+    return _backoff_seconds(attempt)
+
+
+async def channel_send_with_retries(
+    channel: Any,
+    content: str | None,
+    *,
+    max_attempts: int | None = None,
+    **send_kwargs: Any,
+) -> Any:
+    """Call ``channel.send`` with retries on transient / rate-limit errors."""
+    cap = DISCORD_SEND_MAX_ATTEMPTS if max_attempts is None else max_attempts
+    for attempt in range(cap):
+        try:
+            return await channel.send(content, **send_kwargs)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if attempt >= cap - 1 or not is_retryable_discord_send_error(exc):
+                raise
+            delay = retry_delay_seconds(exc, attempt)
+            log.warning(
+                "discord send retry %s/%s after %s: sleeping %.2fs",
+                attempt + 1,
+                cap,
+                exc,
+                delay,
+            )
+            await asyncio.sleep(delay)
+    raise RuntimeError("channel_send_with_retries: unreachable")

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from datetime import UTC, datetime
 
 import pytest
+from agent_core_discord import send_retry as send_retry_mod
 from agent_core_discord.endpoint import DiscordEndpoint
 
 from agent_core.bus.envelope import (
@@ -35,6 +37,75 @@ class _Recording:
     async def nack(self, envelope_id: str, requeue: bool = True) -> None: ...
     def endpoints(self) -> list[EndpointInfo]:
         return []
+
+
+class _HTTP429Like(Exception):
+    """Minimal duck-typed stand-in for discord.HTTPException on rate limit."""
+
+    def __init__(self, *, retry_after: float = 0.0) -> None:
+        super().__init__("429")
+        self.status = 429
+        self.retry_after = retry_after
+
+
+class _Permanent429FromSecondSend(_FakeChannel):
+    """First ``send`` succeeds; every later ``send`` (including retries) raises 429."""
+
+    def __init__(
+        self,
+        *,
+        id: str,
+        name: str = "",
+        channel_type: str = "text",
+        guild_id: str | None = None,
+    ) -> None:
+        super().__init__(id=id, name=name, channel_type=channel_type, guild_id=guild_id)
+        self._send_calls = 0
+
+    async def send(  # type: ignore[override]
+        self,
+        content: str | None = None,
+        *,
+        embeds: list | None = None,
+        reference: object | None = None,
+        files: list | None = None,
+    ) -> _FakeMessage:
+        self._send_calls += 1
+        if self._send_calls >= 2:
+            raise _HTTP429Like(retry_after=0.0)
+        return await super().send(content, embeds=embeds, reference=reference, files=files)
+
+
+class _SecondSendFailsOnceChannel(_FakeChannel):
+    """The second ``send`` invocation fails once with 429; retries succeed."""
+
+    def __init__(
+        self,
+        *,
+        id: str,
+        name: str = "",
+        channel_type: str = "text",
+        guild_id: str | None = None,
+    ) -> None:
+        super().__init__(id=id, name=name, channel_type=channel_type, guild_id=guild_id)
+        self._send_calls = 0
+
+    async def send(  # type: ignore[override]
+        self,
+        content: str | None = None,
+        *,
+        embeds: list | None = None,
+        reference: object | None = None,
+        files: list | None = None,
+    ) -> _FakeMessage:
+        self._send_calls += 1
+        if self._send_calls == 2:
+            raise _HTTP429Like(retry_after=0.0)
+        return await super().send(content, embeds=embeds, reference=reference, files=files)
+
+
+async def _no_sleep(_: float) -> None:
+    return None
 
 
 async def _started(monkeypatch) -> tuple[DiscordEndpoint, _Recording, _FakeDiscordClient]:
@@ -318,6 +389,93 @@ async def test_send_splits_long_text_into_multiple_messages(monkeypatch):
         assert result["status"] == "sent"
         assert len(result["message_ids"]) == len(ch.sent)
         assert result["message_id"] == result["message_ids"][-1]
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_send_multipart_partial_after_chunk_retries_exhausted(monkeypatch):
+    """Second chunk keeps failing with retryable errors → partial, earlier chunks kept."""
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr(send_retry_mod, "DISCORD_SEND_MAX_ATTEMPTS", 2)
+    ep, handle, fake = await _started(monkeypatch)
+    ch = _Permanent429FromSecondSend(id="200")
+    fake.add_channel(ch)
+    long_text = "x" * 2500
+    try:
+        env = _envelope(
+            "e-partial",
+            "agent-test",
+            "discord-test",
+            _toolcall("send", {"channel_id": "200", "text": long_text}),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 1
+        ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
+        assert ack.urgency == "yellow"
+        result = json.loads(ack.payload.note)
+        assert result["status"] == "partial"
+        assert result["message_ids"] == [ch.sent[0]["message_id"]]
+        assert "error" in result
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_send_multipart_retries_transient_429_then_succeeds(monkeypatch):
+    """One retryable failure on a later chunk, then success → full multi-message send."""
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    ep, handle, fake = await _started(monkeypatch)
+    ch = _SecondSendFailsOnceChannel(id="200")
+    fake.add_channel(ch)
+    long_text = "x" * 2500
+    try:
+        env = _envelope(
+            "e-retry",
+            "agent-test",
+            "discord-test",
+            _toolcall("send", {"channel_id": "200", "text": long_text}),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 2
+        ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
+        assert ack.urgency == "green"
+        result = json.loads(ack.payload.note)
+        assert result["status"] == "sent"
+        assert len(result["message_ids"]) == 2
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_send_partial_with_reply_to_does_not_clear_pending_ack(monkeypatch):
+    """Partial multi-chunk send must not drop 👀 / pending ack (reply not complete)."""
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr(send_retry_mod, "DISCORD_SEND_MAX_ATTEMPTS", 2)
+    ep, handle, fake = await _started(monkeypatch)
+    ch = _Permanent429FromSecondSend(id="200")
+    original = _FakeMessage(id="m-orig", channel_id="200")
+    ch._messages["m-orig"] = original
+    await original.add_reaction("👀")
+    ep._track_pending_ack("m-orig", "👀", "200")
+    fake.add_channel(ch)
+    long_text = "x" * 2500
+    try:
+        env = _envelope(
+            "e-part-ack",
+            "agent-test",
+            "discord-test",
+            _toolcall(
+                "send",
+                {"channel_id": "200", "text": long_text, "reply_to": "m-orig"},
+            ),
+        )
+        await ep.deliver(env)
+        assert "👀" in original.reactions
+        assert "m-orig" in ep._pending_acks
+        ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
+        result = json.loads(ack.payload.note)
+        assert result["status"] == "partial"
     finally:
         await ep.stop()
 

--- a/packages/agent-core-discord/tests/test_send_retry.py
+++ b/packages/agent-core-discord/tests/test_send_retry.py
@@ -1,0 +1,77 @@
+"""Unit tests for ``send_retry`` helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from agent_core_discord.send_retry import (
+    DISCORD_SEND_MAX_ATTEMPTS,
+    is_retryable_discord_send_error,
+    retry_delay_seconds,
+)
+
+
+class _Exc(Exception):
+    def __init__(self, status: int | None = None, retry_after: float | None = None) -> None:
+        super().__init__(str(status))
+        if status is not None:
+            self.status = status
+        if retry_after is not None:
+            self.retry_after = retry_after
+
+
+def test_retryable_429_and_503() -> None:
+    assert is_retryable_discord_send_error(_Exc(429)) is True
+    assert is_retryable_discord_send_error(_Exc(503)) is True
+    assert is_retryable_discord_send_error(_Exc(408)) is True
+
+
+def test_not_retryable_4xx_client() -> None:
+    assert is_retryable_discord_send_error(_Exc(400)) is False
+    assert is_retryable_discord_send_error(_Exc(404)) is False
+
+
+def test_retry_delay_uses_retry_after_when_present() -> None:
+    d = retry_delay_seconds(_Exc(429, retry_after=2.5), attempt=0)
+    assert d >= 2.5
+
+
+@pytest.mark.asyncio
+async def test_channel_send_with_retries_exhausts(monkeypatch):
+    from agent_core_discord.send_retry import channel_send_with_retries
+
+    calls = 0
+
+    class _Ch:
+        async def send(self, content: str | None = None, **kwargs: object) -> str:
+            nonlocal calls
+            calls += 1
+            raise _Exc(429)
+
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    with pytest.raises(_Exc):
+        await channel_send_with_retries(_Ch(), "hi", max_attempts=3)
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_channel_send_with_retries_succeeds_second_try(monkeypatch):
+    from agent_core_discord.send_retry import channel_send_with_retries
+
+    calls = 0
+
+    class _Ch:
+        async def send(self, content: str | None = None, **kwargs: object) -> str:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise _Exc(429)
+            return "ok"
+
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    out = await channel_send_with_retries(_Ch(), "hi", max_attempts=DISCORD_SEND_MAX_ATTEMPTS)
+    assert out == "ok"
+    assert calls == 2


### PR DESCRIPTION
## Summary
- Wrap all outbound `channel.send` paths (embed-only and multi-chunk text) with `channel_send_with_retries`: retries on HTTP 429 (uses `retry_after` when present), 5xx, 408, plus bounded exponential backoff (cap read at **call** time so config/tests apply).
- On **partial** multi-chunk delivery, **do not** clear the inbound 👀 / pending ack — the reply is incomplete until every chunk succeeds; callers still get `status=partial`, `message_ids`, `error`, and `urgency=yellow`.
- Add deterministic tests: mid-stream permanent failure → partial; transient 429 then success → full send; partial + `reply_to` preserves ack; unit tests for `send_retry`.

Fixes #22

## Test plan
- [x] `uv run pytest packages/agent-core-discord/tests -q`
- [x] `uv run ruff check` on touched discord sources/tests