### PR TITLE
Cutover #01: SessionStart identity fidelity (hook context cap)

### DIFF
--- a/docs/examples/pepper-agent-core.yaml
+++ b/docs/examples/pepper-agent-core.yaml
@@ -5,9 +5,18 @@
 #
 # How it works:
 #   1. SessionStart: TimeInjector tells Pepper what time it is,
-#      IdentityInjector loads her personality + preferences + last handoff note.
+#      then IdentityInjector runs in small, ordered blocks (critical first).
 #   2. PreCompact/SessionEnd: HandoffWriter enqueues a daemon job.
 #      The daemon worker generates handoff.md and writes handoff-status.json.
+#
+# Identity split rationale:
+#   Claude Code caps each injected SessionStart context string at ~10,000
+#   characters; larger values spill to a session temp file + short preview.
+#   Running one IdentityInjector per file keeps each block bounded and preserves
+#   priority order. Put non-negotiable identity first.
+#
+#   IdentityInjector also applies an extra safety cap for likely-fresh sessions
+#   (``source`` missing or ``startup``) — see ``sessionstart_context_char_cap``.
 #
 # .claude/settings.json hooks should point to:
 #   "command": "uv run agent-core hooks run SessionStart"
@@ -38,8 +47,36 @@ pipelines:
         base_path: "C:\\Users\\jeffr\\.pepper\\Memory"
         files:
           - "SOUL.md"
+        heading: "Identity — Critical Core"
+        missing_file_behavior: "error"
+        sessionstart_context_char_cap: 9800
+
+    - type: builtin.identity_injector
+      params:
+        base_path: "C:\\Users\\jeffr\\.pepper\\Memory"
+        files:
+          - "IDENTITY.md"
+        heading: "Identity — Self-model"
+        missing_file_behavior: "warn"
+        sessionstart_context_char_cap: 9800
+
+    - type: builtin.identity_injector
+      params:
+        base_path: "C:\\Users\\jeffr\\.pepper\\Memory"
+        files:
           - "pepper/preferences.md"
+        heading: "Identity — Preferences"
+        missing_file_behavior: "warn"
+        sessionstart_context_char_cap: 9800
+
+    - type: builtin.identity_injector
+      params:
+        base_path: "C:\\Users\\jeffr\\.pepper\\Memory"
+        files:
           - "pepper/handoff.md"
+        heading: "Identity — Continuity"
+        missing_file_behavior: "warn"
+        sessionstart_context_char_cap: 9800
 
   PreCompact:
     - type: builtin.handoff_writer

--- a/packages/core/src/agent_core/hooks/tools/identity_injector.py
+++ b/packages/core/src/agent_core/hooks/tools/identity_injector.py
@@ -37,6 +37,23 @@ Configuration:
                 # Optional — override sidecar location (default: beside handoff.md)
                 # handoff_status_file: "pepper/handoff-status.json"
                 # skip_handoff_status_gate: true   # restore naive file-only read
+                #
+                # Fresh-boot size limits (SessionStart):
+                #   Claude Code caps each injected context string (including
+                #   ``additionalContext``) at ~10,000 characters; larger values are
+                #   written to a session temp file and replaced with a short preview.
+                #
+                #   ``IdentityInjector`` can enforce a smaller cap for likely-fresh
+                #   sessions (by default: ``hook_input.source`` is missing or
+                #   ``"startup"``) via:
+                #
+                #   - ``sessionstart_context_char_cap`` (default: 9800)
+                #   - ``sessionstart_cap_sources`` (optional override set)
+                #   - ``disable_sessionstart_char_cap: true`` (debug / manual runs)
+                #
+                # For truncation safety, prefer multiple ordered IdentityInjector entries
+                # with one file per entry (critical identity first) instead of one large
+                # combined list.
 
 See Also:
     agent_core.hooks.tools.file_injector.FileInjector: The base class with all logic.
@@ -49,6 +66,12 @@ from pathlib import Path
 
 from agent_core.hooks.handoff_status import path_for_handoff, read_status
 from agent_core.hooks.tools.file_injector import FileInjector
+from agent_core.models import ToolResult
+
+# Claude Code documents a hard cap on hook-injected context strings (including
+# ``additionalContext``). Staying under this avoids "write full text to a temp
+# file + preview" behavior for a *single* injected value.
+_CLAUDE_CODE_HOOK_CONTEXT_CHAR_CAP = 10_000
 
 
 class IdentityInjector(FileInjector):
@@ -63,6 +86,94 @@ class IdentityInjector(FileInjector):
 
     DEFAULT_HEADING = "Identity"
     DEFAULT_MISSING_BEHAVIOR = "skip"
+
+    def execute(self, event: str, hook_input: dict, params: dict) -> ToolResult:
+        """Run FileInjector, then enforce Claude Code hook context size limits.
+
+        Claude Code caps each injected context string (notably ``additionalContext``)
+        at ~10,000 characters; larger values are written to a session temp file and
+        replaced with a short preview + path. Fresh boots often lack the context to
+        reliably follow that pointer, so we keep SessionStart identity injections
+        under the cap for likely-fresh sources (default: ``source`` missing or
+        ``"startup"``).
+        """
+        result = super().execute(event=event, hook_input=hook_input, params=params)
+        if event != "SessionStart" or params.get("disable_sessionstart_char_cap"):
+            return result
+
+        if not self._should_cap_sessionstart_identity(hook_input, params):
+            return result
+
+        cap = int(params.get("sessionstart_context_char_cap", 9_800))
+        if cap < 1 or cap > _CLAUDE_CODE_HOOK_CONTEXT_CHAR_CAP:
+            raise ValueError(
+                "Invalid sessionstart_context_char_cap — must be between 1 and "
+                f"{_CLAUDE_CODE_HOOK_CONTEXT_CHAR_CAP} (got {cap})"
+            )
+
+        if len(result.content) <= cap:
+            return result
+
+        base_path_str = params.get("base_path") or ""
+        files = params.get("files") or []
+        anchor = self._sessionstart_identity_anchor(base_path_str, files)
+        # Reserve a small budget for truncation markers / whitespace.
+        max_original = max(0, cap - len(anchor) - 200)
+        original_prefix = result.content[:max_original] if max_original else ""
+        truncated = (
+            f"{anchor}\n\n"
+            "## Identity files (partial excerpt)\n\n"
+            "The excerpt below is truncated to satisfy the Claude Code SessionStart "
+            f"context cap (~{_CLAUDE_CODE_HOOK_CONTEXT_CHAR_CAP} characters) for fresh "
+            "sessions. The on-disk files listed above remain the source of truth.\n\n"
+            f"{original_prefix}"
+        )
+        if len(truncated) > cap:
+            truncated = truncated[:cap]
+        return ToolResult(heading=result.heading, content=truncated)
+
+    def _should_cap_sessionstart_identity(self, hook_input: dict, params: dict) -> bool:
+        sources = params.get("sessionstart_cap_sources")
+        if sources is None:
+            sources = {"startup", None, ""}
+
+        if not isinstance(sources, (list, tuple, set)):
+            raise ValueError("sessionstart_cap_sources must be a list/tuple/set of strings")
+
+        source = hook_input.get("source")
+        return source in set(sources)
+
+    def _sessionstart_identity_anchor(self, base_path_str: str, files: object) -> str:
+        rel_files: list[str]
+        if isinstance(files, (list, tuple)):
+            rel_files = [str(f) for f in files]
+        else:
+            rel_files = []
+
+        file_lines = "\n".join(f"- `{p}`" for p in rel_files) if rel_files else "- (none listed)"
+
+        # Phrased as factual environment state (per Claude Code hook guidance), not
+        # imperative remote-control instructions.
+        return "\n".join(
+            [
+                "## Identity boot anchor (non-negotiables)",
+                "",
+                "Session environment facts for this agent:",
+                "",
+                f"- Vault root (`base_path`): `{base_path_str}`",
+                "- Identity-relative files configured for this SessionStart tool:",
+                file_lines,
+                "",
+                "Continuity / autonomy facts:",
+                "",
+                "- Name / role: Pepper — Jeff Richley's EA + second brain partner (not a generic assistant persona).",
+                "- Voice: warm substrate, direct, human — not dry or corporate.",
+                "- Person: first person (`I`) when speaking as Pepper — not third-person biography mode.",
+                "- Messaging / spend: no outbound messages and no spending/charging without explicit Jeff approval.",
+                "- EA execution: decide-within-policy for routine EA operations that are already in Jeff-approved scope.",
+                "- Continuity: additional identity material exists on disk under `base_path` (see list above).",
+            ]
+        )
 
     def _status_path(self, base_path: Path, handoff_rel: str, params: dict) -> Path:
         override = params.get("handoff_status_file")

--- a/packages/core/tests/test_file_injector.py
+++ b/packages/core/tests/test_file_injector.py
@@ -329,3 +329,63 @@ class TestIdentityInjector:
         )
         assert "BODY" in result.content
         assert "pending" not in result.content
+
+    def test_sessionstart_startup_caps_oversized_identity(self, tmp_path: Path):
+        """Fresh SessionStart sources must not exceed Claude Code hook context caps."""
+        huge = "A" * 20_000
+        base = make_files(tmp_path, {"soul.md": huge})
+        tool = IdentityInjector()
+        result = tool.execute(
+            event="SessionStart",
+            hook_input={"source": "startup"},
+            params={
+                "base_path": str(base),
+                "files": ["soul.md"],
+                "sessionstart_context_char_cap": 1200,
+            },
+        )
+        assert len(result.content) <= 1200
+        assert "Identity boot anchor" in result.content
+        assert "Claude Code SessionStart" in result.content
+
+    def test_sessionstart_missing_source_caps_by_default(self, tmp_path: Path):
+        huge = "Z" * 20_000
+        base = make_files(tmp_path, {"soul.md": huge})
+        tool = IdentityInjector()
+        result = tool.execute(
+            event="SessionStart",
+            hook_input={},
+            params={
+                "base_path": str(base),
+                "files": ["soul.md"],
+                "sessionstart_context_char_cap": 900,
+            },
+        )
+        assert len(result.content) <= 900
+
+    def test_sessionstart_resume_does_not_cap_by_default(self, tmp_path: Path):
+        huge = "B" * 20_000
+        base = make_files(tmp_path, {"soul.md": huge})
+        tool = IdentityInjector()
+        result = tool.execute(
+            event="SessionStart",
+            hook_input={"source": "resume"},
+            params={"base_path": str(base), "files": ["soul.md"]},
+        )
+        assert len(result.content) == len(huge) + len("## soul.md\n\n")
+
+    def test_sessionstart_cap_can_include_resume(self, tmp_path: Path):
+        huge = "C" * 20_000
+        base = make_files(tmp_path, {"soul.md": huge})
+        tool = IdentityInjector()
+        result = tool.execute(
+            event="SessionStart",
+            hook_input={"source": "resume"},
+            params={
+                "base_path": str(base),
+                "files": ["soul.md"],
+                "sessionstart_context_char_cap": 900,
+                "sessionstart_cap_sources": ["startup", "resume"],
+            },
+        )
+        assert len(result.content) <= 900

--- a/packages/core/tests/test_handoff_enqueue_integration.py
+++ b/packages/core/tests/test_handoff_enqueue_integration.py
@@ -11,7 +11,7 @@ from agent_core.hooks.tools.handoff_writer import HandoffWriter
 
 
 @pytest.mark.asyncio
-async def test_enqueue_hook_to_daemon_end_to_end(tmp_path):
+async def test_enqueue_hook_to_daemon_end_to_end(tmp_path, monkeypatch):
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
     transcript_path = vault_root / "transcript.jsonl"
@@ -48,7 +48,9 @@ endpoints:
             async def _fake_extract(self, req, transcript_text):
                 return "# Handoff\n"
 
-            setattr(type(endpoint), "_extract_handoff", _fake_extract)
+            # Must restore after the test — ``setattr`` on the class leaks across the
+            # whole suite and breaks unrelated ``HandoffJobsEndpoint`` tests.
+            monkeypatch.setattr(type(endpoint), "_extract_handoff", _fake_extract)
 
             hook = HandoffWriter()
             result = await asyncio.to_thread(


### PR DESCRIPTION
Ticket: Cutover #01 (identity fidelity on fresh boot)\nBranch: feat/cutover-01-identity-fidelity\nWorktree: .worktrees/cutover-01-identity-fidelity\n\n## What\n- Enforce Claude Code SessionStart hook injected-context sizing for likely-fresh sessions (default: hook_input.source missing or startup) via IdentityInjector.\n- Add factual boot anchor + truncated excerpt instead of relying on temp-file preview behavior.\n- Update docs/examples/pepper-agent-core.yaml to split identity across ordered injectors (SOUL, IDENTITY, preferences, handoff) and set sessionstart_context_char_cap.\n\n## Why\nClaude Code documents ~10,000 character caps for hook-injected context strings; larger payloads spill to a session temp file + short preview, which fresh sessions may not reliably act on.\n\n## Verify\n- uv run pytest packages/core/tests/test_file_injector.py\n- uv run ruff check packages/core/src/agent_core/hooks/tools/identity_injector.py packages/core/tests/test_file_injector.py\n\n## Cadence\nOpen PR (draft) — please review/merge when green.\n\nDepends on: none\n

Made with [Cursor](https://cursor.com)