### PR TITLE
Cutover #03: Discord verb parity (briefing, poll, events, thread, typing)

### DIFF
--- a/packages/agent-core-discord/src/agent_core_discord/args.py
+++ b/packages/agent-core-discord/src/agent_core_discord/args.py
@@ -7,9 +7,9 @@ the Acknowledgment reply.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal, Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class _SendArgs(BaseModel):
@@ -54,3 +54,63 @@ class _ListChannelsArgs(BaseModel):
 
 class _GetChannelInfoArgs(BaseModel):
     channel_id: str = Field(min_length=1)
+
+
+class _SendBriefingArgs(BaseModel):
+    channel_id: str = Field(min_length=1)
+    date_line: str = Field(min_length=1)
+    focus: str = ""
+    calendar: str = ""
+    critical_items: list[str] = Field(default_factory=list)
+    warning_items: list[str] = Field(default_factory=list)
+
+
+class _CreatePollArgs(BaseModel):
+    channel_id: str = Field(min_length=1)
+    question: str = Field(min_length=1, max_length=300)
+    answers: list[str] = Field(min_length=2, max_length=10)
+    duration_hours: int = Field(default=24, ge=1, le=168)
+    multiple: bool = False
+
+
+class _CreateScheduledEventArgs(BaseModel):
+    guild_id: str = Field(min_length=1)
+    name: str = Field(min_length=1, max_length=100)
+    start_time: str = Field(min_length=1)
+    end_time: str | None = None
+    description: str = ""
+    entity_type: Literal["stage", "voice", "external"] = "external"
+    channel_id: str | None = None
+    location: str = ""
+
+    @model_validator(mode="after")
+    def _entity_fields(self) -> Self:
+        if self.entity_type == "external":
+            if not (self.location or "").strip():
+                raise ValueError("external events require non-empty location")
+            if not (self.end_time or "").strip():
+                raise ValueError("external events require end_time (ISO 8601)")
+        elif self.entity_type in ("stage", "voice"):
+            if not self.channel_id:
+                raise ValueError("stage and voice events require channel_id")
+        return self
+
+
+class _CancelScheduledEventArgs(BaseModel):
+    guild_id: str = Field(min_length=1)
+    event_id: str = Field(min_length=1)
+
+
+class _ListScheduledEventsArgs(BaseModel):
+    guild_id: str = Field(min_length=1)
+
+
+class _CreateThreadArgs(BaseModel):
+    channel_id: str = Field(min_length=1)
+    name: str = Field(min_length=1, max_length=100)
+    message_id: str | None = None
+
+
+class _SendTypingArgs(BaseModel):
+    channel_id: str = Field(min_length=1)
+    duration_seconds: float = Field(default=5.0, ge=0.5, le=10.0)

--- a/packages/agent-core-discord/src/agent_core_discord/briefing.py
+++ b/packages/agent-core-discord/src/agent_core_discord/briefing.py
@@ -1,0 +1,70 @@
+"""Canonical daily briefing embed dicts for Discord (cutover #03).
+
+When Pepper's legacy ``send_briefing`` is not vendored in this repo, this module
+is the **canonical** shape: field order inside the header embed is ``Focus`` then
+``Calendar``; severity colors follow the ticket (15548997 critical, 16776960
+warning). Any drift from Pepper should be reconciled in a follow-up parity pass.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Discord embed integer colors (Pepper cutover #03 conventions).
+BRIEFING_COLOR_CRITICAL = 15548997
+BRIEFING_COLOR_WARNING = 16776960
+
+
+def build_briefing_embeds(
+    *,
+    date_line: str,
+    focus: str = "",
+    calendar: str = "",
+    critical_items: list[str] | None = None,
+    warning_items: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Return raw embed dicts ready for :meth:`discord.Embed.from_dict`.
+
+    Order is stable: one header embed, then optional Critical (red), then
+    optional Attention (yellow).
+    """
+    critical_items = list(critical_items or [])
+    warning_items = list(warning_items or [])
+
+    fields: list[dict[str, Any]] = []
+    if focus.strip():
+        fields.append({"name": "Focus", "value": focus.strip()[:1024], "inline": False})
+    if calendar.strip():
+        fields.append({"name": "Calendar", "value": calendar.strip()[:1024], "inline": False})
+
+    header: dict[str, Any] = {
+        "title": "Daily briefing",
+        "description": date_line.strip()[:4096],
+        "fields": fields,
+    }
+
+    out: list[dict[str, Any]] = [header]
+
+    if critical_items:
+        body = "\n".join(f"- {line.strip()[:500]}" for line in critical_items if line.strip())
+        body = body[:4096] if body else "—"
+        out.append(
+            {
+                "title": "Critical",
+                "description": body,
+                "color": BRIEFING_COLOR_CRITICAL,
+            }
+        )
+
+    if warning_items:
+        body = "\n".join(f"- {line.strip()[:500]}" for line in warning_items if line.strip())
+        body = body[:4096] if body else "—"
+        out.append(
+            {
+                "title": "Attention",
+                "description": body,
+                "color": BRIEFING_COLOR_WARNING,
+            }
+        )
+
+    return out

--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -21,10 +21,12 @@ import time
 import uuid
 from collections import OrderedDict
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import unquote, urlparse
+
+from pydantic import ValidationError
 
 from agent_core.bus.envelope import (
     AcknowledgmentPayload,
@@ -35,14 +37,22 @@ from agent_core.bus.envelope import (
 from agent_core.bus.protocol import EndpointUnavailable
 from agent_core_discord.access import AccessConfig, InboundContext, gate_message, load_access_config
 from agent_core_discord.args import (
+    _CancelScheduledEventArgs,
+    _CreatePollArgs,
+    _CreateScheduledEventArgs,
+    _CreateThreadArgs,
     _DownloadAttachmentsArgs,
     _EditArgs,
     _FetchArgs,
     _GetChannelInfoArgs,
     _ListChannelsArgs,
+    _ListScheduledEventsArgs,
     _ReactArgs,
     _SendArgs,
+    _SendBriefingArgs,
+    _SendTypingArgs,
 )
+from agent_core_discord.briefing import build_briefing_embeds
 from agent_core_discord.chunking import smart_chunk_discord
 from agent_core_discord.send_retry import channel_send_with_retries
 
@@ -50,6 +60,29 @@ if TYPE_CHECKING:
     from agent_core.bus.handle import BusHandle
 
 log = logging.getLogger(__name__)
+
+# Pepper-facing tool names from cutover #03 map to the internal dispatcher keys.
+_TOOL_ALIASES: dict[str, str] = {
+    "send_discord_message": "send",
+    "edit_message": "edit",
+    "add_reaction": "react",
+    "fetch_messages": "fetch",
+}
+
+
+def _canonical_tool(tool: str) -> str:
+    return _TOOL_ALIASES.get(tool, tool)
+
+
+def _parse_iso_datetime(label: str, value: str) -> datetime:
+    raw = (value or "").strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise _ToolError(f"{label}: invalid datetime {value!r}") from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
 
 
 # Module-level registry. Lets discord.py event handlers look up the live
@@ -168,6 +201,7 @@ class DiscordEndpoint:
         # Discord message ids we published to the bus and have not "finished"
         # yet (cleared when ack reaction is removed or TTL/LRU evicts).
         self._awaiting_reply_ids: set[str] = set()
+        self._typing_tasks: set[asyncio.Task] = set()
 
     def _add_listener(self, handler: Callable[..., Any], event_name: str) -> None:
         """Register an event handler against the discord.py client.
@@ -467,20 +501,42 @@ class DiscordEndpoint:
         return await self._send(args)
 
     async def _dispatch(self, tool: str, args: dict) -> Any:
+        tool = _canonical_tool(tool)
+
+        def _v(model: Any, raw: dict) -> Any:
+            try:
+                return model(**raw)
+            except ValidationError as exc:
+                raise _ToolError(f"{tool}: {exc}") from exc
+
         if tool == "send":
-            return await self._send(_SendArgs(**args))
+            return await self._send(_v(_SendArgs, args))
         if tool == "edit":
-            return await self._edit(_EditArgs(**args))
+            return await self._edit(_v(_EditArgs, args))
         if tool == "react":
-            return await self._react(_ReactArgs(**args))
+            return await self._react(_v(_ReactArgs, args))
         if tool == "fetch":
-            return await self._fetch(_FetchArgs(**args))
+            return await self._fetch(_v(_FetchArgs, args))
         if tool == "download_attachments":
-            return await self._download_attachments(_DownloadAttachmentsArgs(**args))
+            return await self._download_attachments(_v(_DownloadAttachmentsArgs, args))
         if tool == "list_channels":
-            return await self._list_channels(_ListChannelsArgs(**args))
+            return await self._list_channels(_v(_ListChannelsArgs, args))
         if tool == "get_channel_info":
-            return await self._get_channel_info(_GetChannelInfoArgs(**args))
+            return await self._get_channel_info(_v(_GetChannelInfoArgs, args))
+        if tool == "send_briefing":
+            return await self._send_briefing(_v(_SendBriefingArgs, args))
+        if tool == "create_poll":
+            return await self._create_poll(_v(_CreatePollArgs, args))
+        if tool == "create_scheduled_event":
+            return await self._create_scheduled_event(_v(_CreateScheduledEventArgs, args))
+        if tool == "cancel_scheduled_event":
+            return await self._cancel_scheduled_event(_v(_CancelScheduledEventArgs, args))
+        if tool == "list_scheduled_events":
+            return await self._list_scheduled_events(_v(_ListScheduledEventsArgs, args))
+        if tool == "create_thread":
+            return await self._create_thread(_v(_CreateThreadArgs, args))
+        if tool == "send_typing":
+            return await self._send_typing(_v(_SendTypingArgs, args))
         raise _ToolError(f"unknown tool '{tool}'")
 
     async def _reply(
@@ -509,6 +565,9 @@ class DiscordEndpoint:
     async def stop(self) -> None:
         if _active_endpoints.get(self.name) is self:
             _active_endpoints.pop(self.name, None)
+        for t in list(self._typing_tasks):
+            t.cancel()
+        self._typing_tasks.clear()
         # Drop typing / threading state so background typing tasks exit promptly.
         self._awaiting_reply_ids.clear()
         self._inbound_envelope_discord.clear()
@@ -642,9 +701,7 @@ class DiscordEndpoint:
                 created_at=datetime.now(UTC),
             )
             assert self._handle is not None
-            self._remember_inbound_mapping(
-                env.id, str(message.id), str(message.channel.id)
-            )
+            self._remember_inbound_mapping(env.id, str(message.id), str(message.channel.id))
             mid = str(message.id)
             self._awaiting_reply_ids.add(mid)
             try:
@@ -1086,6 +1143,184 @@ class DiscordEndpoint:
             "topic": getattr(ch, "topic", "") or "",
             "nsfw": bool(getattr(ch, "nsfw", False)),
         }
+
+    async def _resolve_guild(self, guild_id: str) -> Any:
+        if self._client is None:
+            raise _ToolError("guild lookup: client not ready")
+        get_guild = getattr(self._client, "get_guild", None)
+        if get_guild is None:
+            raise _ToolError("client has no get_guild")
+        keys: list[Any] = [guild_id, str(guild_id)]
+        if guild_id.isdigit():
+            keys.insert(0, int(guild_id))
+        seen: set[Any] = set()
+        for key in keys:
+            if key in seen:
+                continue
+            seen.add(key)
+            try:
+                g = get_guild(key)
+            except TypeError:
+                continue
+            if g is not None:
+                return g
+        raise _ToolError(f"guild '{guild_id}' not found")
+
+    async def _send_briefing(self, args: _SendBriefingArgs) -> dict:
+        embeds = build_briefing_embeds(
+            date_line=args.date_line,
+            focus=args.focus,
+            calendar=args.calendar,
+            critical_items=list(args.critical_items),
+            warning_items=list(args.warning_items),
+        )
+        return await self._send(_SendArgs(channel_id=args.channel_id, text=None, embeds=embeds))
+
+    async def _create_poll(self, args: _CreatePollArgs) -> dict:
+        try:
+            import discord  # type: ignore
+        except ImportError as exc:
+            raise _ToolError("create_poll requires discord.py") from exc
+        ch = await self._resolve_channel(args.channel_id)
+        poll = discord.Poll(
+            args.question,
+            timedelta(hours=args.duration_hours),
+            multiple=args.multiple,
+        )
+        for ans in args.answers:
+            text = (ans or "").strip()
+            if not text:
+                raise _ToolError("create_poll: empty answer text")
+            poll = poll.add_answer(text=text[:300])
+        new_msg = await channel_send_with_retries(ch, None, poll=poll)
+        mid = str(new_msg.id)
+        return {"status": "sent", "message_id": mid, "message_ids": [mid]}
+
+    async def _create_scheduled_event(self, args: _CreateScheduledEventArgs) -> dict:
+        try:
+            import discord  # type: ignore
+        except ImportError as exc:
+            raise _ToolError("create_scheduled_event requires discord.py") from exc
+        guild = await self._resolve_guild(args.guild_id)
+        start = _parse_iso_datetime("start_time", args.start_time)
+        entity_map = {
+            "stage": discord.EntityType.stage_instance,
+            "voice": discord.EntityType.voice,
+            "external": discord.EntityType.external,
+        }
+        kwargs: dict[str, Any] = {
+            "name": args.name[:100],
+            "start_time": start,
+            "entity_type": entity_map[args.entity_type],
+            "privacy_level": discord.PrivacyLevel.guild_only,
+        }
+        if args.description:
+            kwargs["description"] = args.description[:1000]
+        if args.entity_type == "external":
+            kwargs["location"] = args.location.strip()
+            kwargs["end_time"] = _parse_iso_datetime("end_time", args.end_time or "")
+        else:
+            ch = await self._resolve_channel(args.channel_id or "")
+            kwargs["channel"] = ch
+            if args.end_time:
+                kwargs["end_time"] = _parse_iso_datetime("end_time", args.end_time)
+        ev = await guild.create_scheduled_event(**kwargs)
+        return {"status": "created", "event_id": str(ev.id), "name": ev.name}
+
+    async def _cancel_scheduled_event(self, args: _CancelScheduledEventArgs) -> dict:
+        guild = await self._resolve_guild(args.guild_id)
+        ev = None
+        if hasattr(guild, "get_scheduled_event"):
+            keys: list[Any] = [args.event_id, str(args.event_id)]
+            if args.event_id.isdigit():
+                keys.insert(0, int(args.event_id))
+            seen: set[Any] = set()
+            for key in keys:
+                if key in seen:
+                    continue
+                seen.add(key)
+                try:
+                    ev = guild.get_scheduled_event(key)  # type: ignore[arg-type]
+                except Exception:
+                    ev = None
+                if ev is not None:
+                    break
+        if ev is None and hasattr(guild, "fetch_scheduled_event"):
+            try:
+                lookup = int(args.event_id) if args.event_id.isdigit() else args.event_id
+                ev = await guild.fetch_scheduled_event(lookup)
+            except Exception:
+                ev = None
+        if ev is None:
+            raise _ToolError(f"cancel_scheduled_event: event '{args.event_id}' not found")
+        await ev.cancel()
+        return {"status": "cancelled", "event_id": str(args.event_id)}
+
+    async def _list_scheduled_events(self, args: _ListScheduledEventsArgs) -> list[dict[str, Any]]:
+        guild = await self._resolve_guild(args.guild_id)
+        if not hasattr(guild, "fetch_scheduled_events"):
+            return []
+        events = await guild.fetch_scheduled_events()
+        out: list[dict[str, Any]] = []
+        for ev in events:
+            st = getattr(ev, "start_time", None)
+            et = getattr(ev, "entity_type", None)
+            et_s = str(getattr(et, "name", et) or "")
+            out.append(
+                {
+                    "id": str(getattr(ev, "id", "")),
+                    "name": getattr(ev, "name", ""),
+                    "status": getattr(ev, "status", ""),
+                    "entity_type": et_s,
+                    "start_time": st.isoformat() if st is not None else "",
+                }
+            )
+        return out
+
+    async def _create_thread(self, args: _CreateThreadArgs) -> dict:
+        ch = await self._resolve_channel(args.channel_id)
+        create = getattr(ch, "create_thread", None)
+        if create is None:
+            raise _ToolError("create_thread: channel does not support threads")
+        msg = None
+        if args.message_id:
+            try:
+                msg = await ch.fetch_message(args.message_id)
+            except Exception as exc:
+                raise _ToolError(f"create_thread: message not found: {exc}") from exc
+            if msg is None:
+                raise _ToolError(f"create_thread: message '{args.message_id}' not found")
+        th = await create(name=args.name[:100], message=msg)
+        return {
+            "status": "created",
+            "thread_id": str(getattr(th, "id", "")),
+            "name": getattr(th, "name", args.name),
+        }
+
+    async def _send_typing(self, args: _SendTypingArgs) -> dict:
+        ch = await self._resolve_channel(args.channel_id)
+        seconds = float(args.duration_seconds)
+        typing_factory = getattr(ch, "typing", None)
+        if typing_factory is None:
+            raise _ToolError("send_typing: channel has no typing()")
+
+        async def _pulse() -> None:
+            try:
+                async with typing_factory():
+                    await asyncio.sleep(seconds)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.debug("send_typing: pulse failed", exc_info=True)
+
+        task = asyncio.create_task(_pulse())
+        self._typing_tasks.add(task)
+
+        def _done(t: asyncio.Task) -> None:
+            self._typing_tasks.discard(task)
+
+        task.add_done_callback(_done)
+        return {"status": "typing_started", "duration_seconds": seconds}
 
 
 class _ToolError(Exception):

--- a/packages/agent-core-discord/tests/conftest.py
+++ b/packages/agent-core-discord/tests/conftest.py
@@ -6,6 +6,7 @@ event dispatch, and outbound tool calls without a network."""
 from __future__ import annotations
 
 import asyncio
+import uuid
 from collections.abc import Callable
 from typing import Any
 
@@ -54,6 +55,8 @@ class _FakeChannel:
         self.sent: list[dict[str, Any]] = []
         self._messages: dict[str, _FakeMessage] = {}
         self._typing_count = 0
+        self.threads_created: list[dict[str, Any]] = []
+        self._fake_client: _FakeDiscordClient | None = None
 
     def typing(self):
         ch = self
@@ -76,6 +79,7 @@ class _FakeChannel:
         embeds: list | None = None,
         reference: Any = None,
         files: list | None = None,
+        poll: Any = None,
     ) -> _FakeMessage:
         new_id = f"new-{len(self.sent) + 1}"
         msg = _FakeMessage(id=new_id, channel_id=self.id, content=content or "")
@@ -86,10 +90,36 @@ class _FakeChannel:
                 "embeds": embeds,
                 "reference": reference,
                 "files": files,
+                "poll": poll,
                 "message_id": new_id,
             }
         )
         return msg
+
+    async def create_thread(
+        self,
+        *,
+        name: str,
+        message: Any = None,
+        auto_archive_duration: Any = None,
+        type: Any = None,
+        reason: str | None = None,
+        invitable: bool = True,
+        slowmode_delay: int | None = None,
+    ) -> _FakeChannel:
+        tid = f"th-{uuid.uuid4().hex[:10]}"
+        th = _FakeChannel(
+            id=tid,
+            name=name,
+            channel_type="public_thread",
+            guild_id=self.guild_id,
+        )
+        th._fake_client = self._fake_client
+        if self._fake_client is not None:
+            self._fake_client.add_channel(th)
+        mid = str(getattr(message, "id", "") or "") or None
+        self.threads_created.append({"name": name, "message_id": mid})
+        return th
 
     async def fetch_message(self, message_id: str) -> _FakeMessage | None:
         return self._messages.get(message_id)
@@ -106,6 +136,77 @@ class _FakeGuild:
     def __init__(self, *, id: str, channels: list[_FakeChannel]):
         self.id = id
         self.channels = channels
+        self._scheduled: dict[str, _FakeScheduledEvent] = {}
+        self._sched_seq = 0
+
+    async def create_scheduled_event(
+        self,
+        *,
+        name: str,
+        start_time: Any,
+        entity_type: Any = None,
+        privacy_level: Any = None,
+        channel: Any = None,
+        location: str = "",
+        end_time: Any = None,
+        description: str = "",
+        image: bytes = b"",
+        reason: str | None = None,
+        **_: Any,
+    ) -> _FakeScheduledEvent:
+        self._sched_seq += 1
+        sid = f"se-{self._sched_seq}"
+        et_name = getattr(entity_type, "name", str(entity_type))
+        ev = _FakeScheduledEvent(
+            id=sid,
+            name=name,
+            guild=self,
+            start_time=start_time,
+            end_time=end_time,
+            entity_type=et_name,
+        )
+        self._scheduled[sid] = ev
+        return ev
+
+    def get_scheduled_event(self, event_id: int | str) -> _FakeScheduledEvent | None:
+        key = str(event_id)
+        return self._scheduled.get(key)
+
+    async def fetch_scheduled_event(self, event_id: int | str) -> _FakeScheduledEvent:
+        ev = self.get_scheduled_event(event_id)
+        if ev is None:
+            raise LookupError(f"scheduled event {event_id!r} not found")
+        return ev
+
+    async def fetch_scheduled_events(self) -> list[_FakeScheduledEvent]:
+        return list(self._scheduled.values())
+
+
+class _FakeScheduledEvent:
+    def __init__(
+        self,
+        *,
+        id: str,
+        name: str,
+        guild: _FakeGuild,
+        start_time: Any = None,
+        end_time: Any = None,
+        entity_type: str = "external",
+    ) -> None:
+        self.id = id
+        self.name = name
+        self.guild = guild
+        self.start_time = start_time
+        self.end_time = end_time
+        self.entity_type = entity_type
+        self.status = "scheduled"
+        self._cancelled = False
+
+    async def cancel(self, *, reason: str | None = None) -> _FakeScheduledEvent:
+        self._cancelled = True
+        self.status = "cancelled"
+        self.guild._scheduled.pop(str(self.id), None)
+        return self
 
 
 class _FakeUser:
@@ -153,6 +254,9 @@ class _FakeDiscordClient:
     def get_channel(self, channel_id: int | str) -> _FakeChannel | None:
         return self._channels.get(str(channel_id))
 
+    def get_guild(self, guild_id: int | str) -> _FakeGuild | None:
+        return self._guilds.get(str(guild_id))
+
     async def fetch_channel(self, channel_id: int | str) -> _FakeChannel | None:
         return self._channels.get(str(channel_id))
 
@@ -196,11 +300,13 @@ class _FakeDiscordClient:
             await self._handlers["on_ready"]()
 
     def add_channel(self, ch: _FakeChannel) -> None:
+        ch._fake_client = self
         self._channels[ch.id] = ch
 
     def add_guild(self, g: _FakeGuild) -> None:
         self._guilds[g.id] = g
         for ch in g.channels:
+            ch._fake_client = self
             self._channels[ch.id] = ch
 
 

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -1,4 +1,4 @@
-"""Tests for DiscordEndpoint outbound tool surface (8 tools)."""
+"""Tests for DiscordEndpoint outbound tool surface."""
 
 from __future__ import annotations
 
@@ -9,6 +9,11 @@ from datetime import UTC, datetime
 
 import pytest
 from agent_core_discord import send_retry as send_retry_mod
+from agent_core_discord.briefing import (
+    BRIEFING_COLOR_CRITICAL,
+    BRIEFING_COLOR_WARNING,
+    build_briefing_embeds,
+)
 from agent_core_discord.endpoint import DiscordEndpoint
 
 from agent_core.bus.envelope import (
@@ -69,11 +74,14 @@ class _Permanent429FromSecondSend(_FakeChannel):
         embeds: list | None = None,
         reference: object | None = None,
         files: list | None = None,
+        poll: object | None = None,
     ) -> _FakeMessage:
         self._send_calls += 1
         if self._send_calls >= 2:
             raise _HTTP429Like(retry_after=0.0)
-        return await super().send(content, embeds=embeds, reference=reference, files=files)
+        return await super().send(
+            content, embeds=embeds, reference=reference, files=files, poll=poll
+        )
 
 
 class _SecondSendFailsOnceChannel(_FakeChannel):
@@ -97,11 +105,14 @@ class _SecondSendFailsOnceChannel(_FakeChannel):
         embeds: list | None = None,
         reference: object | None = None,
         files: list | None = None,
+        poll: object | None = None,
     ) -> _FakeMessage:
         self._send_calls += 1
         if self._send_calls == 2:
             raise _HTTP429Like(retry_after=0.0)
-        return await super().send(content, embeds=embeds, reference=reference, files=files)
+        return await super().send(
+            content, embeds=embeds, reference=reference, files=files, poll=poll
+        )
 
 
 async def _no_sleep(_: float) -> None:
@@ -1061,5 +1072,206 @@ async def test_get_channel_info_unknown_returns_error(monkeypatch):
         await ep.deliver(env)
         ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
         assert "not found" in ack.payload.note.lower()
+    finally:
+        await ep.stop()
+
+
+# --- cutover #03: Pepper verb aliases + extra tools ---
+
+
+@pytest.mark.asyncio
+async def test_send_discord_message_alias(monkeypatch):
+    ep, handle, fake = await _started(monkeypatch)
+    ch = _FakeChannel(id="200")
+    fake.add_channel(ch)
+    try:
+        env = _envelope(
+            "e1",
+            "agent-test",
+            "discord-test",
+            _toolcall("send_discord_message", {"channel_id": "200", "text": "hi"}),
+        )
+        await ep.deliver(env)
+        assert ch.sent[0]["content"] == "hi"
+    finally:
+        await ep.stop()
+
+
+def test_build_briefing_embeds_order_and_colors():
+    embeds = build_briefing_embeds(
+        date_line="2026-05-02",
+        focus="Ship the cutover",
+        calendar="1:1 with Jeff",
+        critical_items=["Prod is down"],
+        warning_items=["Flaky test"],
+    )
+    assert embeds[0]["title"] == "Daily briefing"
+    names = [f["name"] for f in embeds[0]["fields"]]
+    assert names == ["Focus", "Calendar"]
+    assert embeds[1]["color"] == BRIEFING_COLOR_CRITICAL
+    assert embeds[2]["color"] == BRIEFING_COLOR_WARNING
+
+
+@pytest.mark.asyncio
+async def test_send_briefing_sends_embeds(monkeypatch):
+    ep, handle, fake = await _started(monkeypatch)
+    ch = _FakeChannel(id="200")
+    fake.add_channel(ch)
+    try:
+        env = _envelope(
+            "e1",
+            "agent-test",
+            "discord-test",
+            _toolcall(
+                "send_briefing",
+                {
+                    "channel_id": "200",
+                    "date_line": "Saturday — test",
+                    "focus": "A",
+                    "calendar": "B",
+                    "critical_items": ["c1"],
+                    "warning_items": ["w1"],
+                },
+            ),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 1
+        emb = ch.sent[0]["embeds"]
+        assert emb is not None and len(emb) == 3
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_create_poll_passes_poll_to_send(monkeypatch):
+    ep, handle, fake = await _started(monkeypatch)
+    ch = _FakeChannel(id="200")
+    fake.add_channel(ch)
+    try:
+        env = _envelope(
+            "e1",
+            "agent-test",
+            "discord-test",
+            _toolcall(
+                "create_poll",
+                {
+                    "channel_id": "200",
+                    "question": "Pick one?",
+                    "answers": ["A", "B"],
+                    "duration_hours": 24,
+                },
+            ),
+        )
+        await ep.deliver(env)
+        assert ch.sent[0]["poll"] is not None
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_create_thread_invokes_channel(monkeypatch):
+    ep, handle, fake = await _started(monkeypatch)
+    ch = _FakeChannel(id="200", guild_id="g1")
+    fake.add_channel(ch)
+    m = _FakeMessage(id="m1", channel_id="200", content="root")
+    ch._messages["m1"] = m
+    try:
+        env = _envelope(
+            "e1",
+            "agent-test",
+            "discord-test",
+            _toolcall(
+                "create_thread",
+                {"channel_id": "200", "name": "side-topic", "message_id": "m1"},
+            ),
+        )
+        await ep.deliver(env)
+        assert len(ch.threads_created) == 1
+        assert ch.threads_created[0]["name"] == "side-topic"
+        assert ch.threads_created[0]["message_id"] == "m1"
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_send_typing_ack(monkeypatch):
+    ep, handle, fake = await _started(monkeypatch)
+    ch = _FakeChannel(id="200")
+    fake.add_channel(ch)
+    try:
+        env = _envelope(
+            "e1",
+            "agent-test",
+            "discord-test",
+            _toolcall("send_typing", {"channel_id": "200", "duration_seconds": 0.5}),
+        )
+        await ep.deliver(env)
+        ack = [e for e in handle.published if e.kind == "Acknowledgment"][-1]
+        body = json.loads(ack.payload.note)
+        assert body["status"] == "typing_started"
+        assert body["duration_seconds"] == 0.5
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_scheduled_event_create_list_cancel(monkeypatch):
+    ep, handle, fake = await _started(monkeypatch)
+    ch = _FakeChannel(id="200", guild_id="g1")
+    g = _FakeGuild(id="g1", channels=[ch])
+    fake.add_guild(g)
+    try:
+        start = "2026-06-01T15:00:00+00:00"
+        end = "2026-06-01T16:00:00+00:00"
+        env = _envelope(
+            "e1",
+            "agent-test",
+            "discord-test",
+            _toolcall(
+                "create_scheduled_event",
+                {
+                    "guild_id": "g1",
+                    "name": "Standup",
+                    "start_time": start,
+                    "end_time": end,
+                    "entity_type": "external",
+                    "location": "https://example.com/meet",
+                },
+            ),
+        )
+        await ep.deliver(env)
+        ack = [e for e in handle.published if e.kind == "Acknowledgment"][-1]
+        created = json.loads(ack.payload.note)
+        eid = created["event_id"]
+
+        env2 = _envelope(
+            "e2",
+            "agent-test",
+            "discord-test",
+            _toolcall("list_scheduled_events", {"guild_id": "g1"}),
+        )
+        await ep.deliver(env2)
+        ack2 = [e for e in handle.published if e.kind == "Acknowledgment"][-1]
+        listed = json.loads(ack2.payload.note)
+        assert len(listed) == 1
+        assert listed[0]["id"] == eid
+
+        env3 = _envelope(
+            "e3",
+            "agent-test",
+            "discord-test",
+            _toolcall("cancel_scheduled_event", {"guild_id": "g1", "event_id": eid}),
+        )
+        await ep.deliver(env3)
+
+        env4 = _envelope(
+            "e4",
+            "agent-test",
+            "discord-test",
+            _toolcall("list_scheduled_events", {"guild_id": "g1"}),
+        )
+        await ep.deliver(env4)
+        ack4 = [e for e in handle.published if e.kind == "Acknowledgment"][-1]
+        assert json.loads(ack4.payload.note) == []
     finally:
         await ep.stop()


### PR DESCRIPTION
## Summary
Implements \docs/requirements/pepper-cutover-03-discord-verb-parity.md\ for \gent-core-discord\: Pepper-facing tool aliases, \send_briefing\ (canonical embed builder), \create_poll\, scheduled event create/list/cancel, \create_thread\, \send_typing\, plus fakes and tests.

## §3b evidence matrix
| Requirement | Status |
|-------------|--------|
| \send_discord_message\ / embeds (via \send\) | Met (existing + alias) |
| \send_briefing\ | Partial — canonical embed shape + colors in \riefing.py\; not byte-for-byte vs Pepper repo |
| \create_poll\ | Met (unit + discord.Poll) |
| Scheduled events CRUD | Met (fake guild + unit) |
| \create_thread\ | Met (fake) |
| \send_typing\ | Met (fake) |
| Other verbs from #03 | Met / aliased |
| Real-guild smoke (\#pepper-chat\, etc.) | Missing — follow-up or manual |

## For Cadence
Implementer (Folio) handoff — please use PR-comments-only coordination per playbook.

Folio

Made with [Cursor](https://cursor.com)