### PR TITLE
feat(cutover-06): vault continuity dry-run plan + runbook

### DIFF
--- a/docs/migrations/pepper-vault-continuity-runbook.md
+++ b/docs/migrations/pepper-vault-continuity-runbook.md
@@ -1,0 +1,41 @@
+# Pepper vault continuity (cutover #06)
+
+This runbook supports [`pepper-cutover-06-vault-continuity.md`](../../requirements/pepper-cutover-06-vault-continuity.md): keep curated Memory paths and config cross-references coherent across a home-directory rename or machine move.
+
+## Dry-run path audit
+
+From the `agent_core` repo (with `uv sync` applied):
+
+```bash
+uv run agent-core vault plan-dry-run --vault "C:/Users/you/.pepper/Memory" --config ./docs/examples/pepper-agent-core.yaml
+```
+
+- Repeat `--config` for every `agent_core.yaml` (or copy) that embeds absolute paths.
+- Add `--json-out ./reports/vault-plan.json` to persist the report next to snapshots in CI or migration tickets.
+
+The command is read-only except for the optional JSON output file.
+
+## What the report contains
+
+- **vault_layout**: full file manifest under `--vault`, counts, and whether recommended top-level files / directories from the ticket are present.
+- **daily_summaries**: notes whether `daily/summaries/` exists (session-start summaries per spec).
+- **configs**: each `--config` file plus deduplicated absolute paths found anywhere in the parsed YAML (Windows `D:\…`, UNC `\\server\…`, POSIX `/home/…` style strings).
+
+Use the path list to plan atomic search-and-replace when the vault root or Claude project path changes.
+
+## Claude Code auto-memory directory
+
+The canonical risk is documented in the ticket: the path under `.claude/projects/.../memory/` is tied to the **encoded project path**. Mitigations (pick one with Jeff before cutover):
+
+1. **Keep the working-directory path stable** so Claude Code keeps writing the same auto-memory folder, or  
+2. **Copy** the old auto-memory tree into the new location and verify Claude Code reads/writes there after the move, or  
+3. **Replace** reliance on auto-memory with an agent-core-native injector that reads the migrated files (larger product change).
+
+None of these are automated here; the dry-run tool focuses on the **Pepper Memory vault** plus **YAML configs shipped or owned by the agent** (for example `docs/examples/pepper-agent-core.yaml`).
+
+## Done checklist (operator)
+
+1. Run `plan-dry-run` against a snapshot of production `Memory/`.
+2. Confirm `missing_recommended_*` is empty or intentionally waived.
+3. Resolve every `absolute_paths` entry after a rename (including skills and non-repo configs not passed to `--config`).
+4. Re-run hooks / SessionStart in a staging profile and confirm IdentityInjector + HandoffWriter paths resolve.

--- a/packages/core/src/agent_core/cli.py
+++ b/packages/core/src/agent_core/cli.py
@@ -3,6 +3,7 @@
 Commands:
     agent-core hooks run <event>    Execute all tools registered for a hook event.
     agent-core notify <title> <msg> Send a desktop toast notification.
+    agent-core vault plan-dry-run …  Dry-run vault + YAML path audit (cutover #06).
 
 See Also:
     agent_core.hooks.pipeline.Pipeline: The engine that runs the tools.
@@ -18,6 +19,7 @@ from agent_core.bus.cli import app as bus_app
 from agent_core.daemon.cli import app as daemon_app
 from agent_core.email.cli import email_app
 from agent_core.hooks.pipeline import Pipeline
+from agent_core.vault_migration_plan import vault_app
 
 app = typer.Typer(
     name="agent-core",
@@ -34,6 +36,7 @@ app.add_typer(hooks_app, name="hooks")
 app.add_typer(email_app, name="email")
 app.add_typer(bus_app, name="bus")
 app.add_typer(daemon_app, name="daemon")
+app.add_typer(vault_app, name="vault")
 
 _HOOK_CONFIG_OPTION = typer.Option(
     "agent_core.yaml",

--- a/packages/core/src/agent_core/vault_migration_plan.py
+++ b/packages/core/src/agent_core/vault_migration_plan.py
@@ -1,0 +1,147 @@
+"""Dry-run helpers for Pepper / agent vault cutover (cutover #06).
+
+Walks the on-disk Memory vault, checks for recommended layout markers, and
+collects absolute paths embedded in YAML configs (for example ``base_path`` in
+``agent_core.yaml``). Nothing writes outside an optional ``--json-out`` report.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+import yaml
+
+vault_app = typer.Typer(
+    name="vault",
+    help="Vault continuity helpers (Pepper cutover #06).",
+    no_args_is_help=True,
+)
+
+RECOMMENDED_ROOT_FILES = (
+    "IDENTITY.md",
+    "SOUL.md",
+    "USER.md",
+    "MEMORY.md",
+    "OPERATIONS.md",
+    "TASKS.md",
+)
+RECOMMENDED_DIRS = ("projects", "daily", "ideas", "playbooks", "pepper")
+
+
+def iter_string_values(node: Any) -> Iterator[str]:
+    if isinstance(node, str):
+        yield node
+    elif isinstance(node, dict):
+        for v in node.values():
+            yield from iter_string_values(v)
+    elif isinstance(node, list):
+        for item in node:
+            yield from iter_string_values(item)
+
+
+def is_probable_absolute_path(s: str) -> bool:
+    t = s.strip().strip("'\"")
+    if len(t) < 3:
+        return False
+    if t[0].isalpha() and t[1] == ":" and t[2] in "\\/":
+        return True
+    if t.startswith("\\\\"):
+        return True
+    if t.startswith("/") and len(t) >= 2 and t[1] != "/":
+        return True
+    return False
+
+
+def absolute_paths_in_yaml(text: str) -> list[str]:
+    try:
+        data = yaml.safe_load(text) or {}
+    except yaml.YAMLError:
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for s in iter_string_values(data):
+        if not isinstance(s, str) or not is_probable_absolute_path(s):
+            continue
+        t = s.strip()
+        if t not in seen:
+            seen.add(t)
+            out.append(t)
+    return sorted(out)
+
+
+def scan_config_file(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8-sig")
+    return {"config": str(path.resolve()), "absolute_paths": absolute_paths_in_yaml(text)}
+
+
+def vault_layout_report(vault: Path) -> dict[str, Any]:
+    root = vault.resolve()
+    missing_files = [n for n in RECOMMENDED_ROOT_FILES if not (root / n).is_file()]
+    missing_dirs = [n for n in RECOMMENDED_DIRS if not (root / n).is_dir()]
+    files: list[dict[str, Any]] = []
+    for p in sorted(root.rglob("*")):
+        if p.is_file():
+            try:
+                rel = p.relative_to(root).as_posix()
+            except ValueError:
+                rel = Path(p).as_posix()
+            files.append({"path": rel, "size_bytes": p.stat().st_size})
+    summaries = root / "daily" / "summaries"
+    summaries_note: str | None = None
+    if summaries.is_dir():
+        n = sum(1 for _ in summaries.iterdir())
+        summaries_note = f"daily/summaries exists ({n} top-level entries)"
+    elif (root / "daily").is_dir():
+        summaries_note = "daily/ exists but daily/summaries/ missing (optional per cutover #06)"
+    return {
+        "vault": str(root),
+        "file_count": len(files),
+        "files": files,
+        "missing_recommended_files": missing_files,
+        "missing_recommended_dirs": missing_dirs,
+        "daily_summaries": summaries_note,
+    }
+
+
+def build_plan(vault: Path, config_files: list[Path]) -> dict[str, Any]:
+    layout = vault_layout_report(vault)
+    cfg_scans = [scan_config_file(p.resolve()) for p in config_files]
+    return {"vault_layout": layout, "configs": cfg_scans}
+
+
+@vault_app.command("plan-dry-run")
+def plan_dry_run_cmd(
+    vault: Annotated[
+        Path,
+        typer.Option(
+            "--vault",
+            exists=True,
+            file_okay=False,
+            help="Memory vault root (e.g. …/.pepper/Memory).",
+        ),
+    ],
+    config: Annotated[
+        list[Path] | None,
+        typer.Option(
+            "--config",
+            exists=True,
+            dir_okay=False,
+            help="YAML file to scan for absolute paths (repeatable).",
+        ),
+    ] = None,
+    json_out: Annotated[
+        Path | None,
+        typer.Option("--json-out", help="Write the same JSON payload to this path."),
+    ] = None,
+) -> None:
+    """Print a JSON dry-run report; no vault files are modified."""
+    plan = build_plan(vault, list(config or []))
+    payload = json.dumps(plan, indent=2)
+    if json_out is not None:
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(payload, encoding="utf-8")
+    typer.echo(payload)

--- a/packages/core/tests/test_vault_migration_plan.py
+++ b/packages/core/tests/test_vault_migration_plan.py
@@ -1,0 +1,74 @@
+"""Tests for agent_core.vault_migration_plan (cutover #06)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from agent_core.vault_migration_plan import (
+    absolute_paths_in_yaml,
+    build_plan,
+    is_probable_absolute_path,
+    vault_layout_report,
+)
+
+
+def test_is_probable_absolute_path() -> None:
+    assert is_probable_absolute_path(r"C:\Users\me\.pepper\Memory")
+    assert is_probable_absolute_path("C:/Users/me/x")
+    assert is_probable_absolute_path(r"\\server\share\vault")
+    assert is_probable_absolute_path("/home/me/vault")
+    assert not is_probable_absolute_path("relative/path")
+    assert not is_probable_absolute_path("SOUL.md")
+
+
+def test_absolute_paths_in_yaml_finds_base_path() -> None:
+    doc = {
+        "pipelines": {
+            "SessionStart": [
+                {
+                    "params": {
+                        "base_path": r"C:\Users\jeffr\.pepper\Memory",
+                        "output_path": r"D:\other\out.md",
+                    }
+                }
+            ]
+        }
+    }
+    paths = absolute_paths_in_yaml(yaml.safe_dump(doc))
+    assert r"C:\Users\jeffr\.pepper\Memory" in paths
+    assert r"D:\other\out.md" in paths
+
+
+def test_vault_layout_report_counts_files(tmp_path: Path) -> None:
+    vault = tmp_path / "Memory"
+    vault.mkdir()
+    (vault / "SOUL.md").write_text("x", encoding="utf-8")
+    (vault / "pepper").mkdir()
+    (vault / "pepper" / "handoff.md").write_text("h", encoding="utf-8")
+    rep = vault_layout_report(vault)
+    assert rep["file_count"] == 2
+    assert "SOUL.md" not in rep["missing_recommended_files"]
+    assert "IDENTITY.md" in rep["missing_recommended_files"]
+    names = {e["path"] for e in rep["files"]}
+    assert "SOUL.md" in names
+    assert "pepper/handoff.md" in names
+
+
+def test_build_plan_merges_layout_and_configs(tmp_path: Path) -> None:
+    vault = tmp_path / "Memory"
+    vault.mkdir()
+    (vault / "MEMORY.md").write_text("m", encoding="utf-8")
+    for d in ("projects", "daily", "ideas", "playbooks", "pepper"):
+        (vault / d).mkdir()
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        yaml.safe_dump({"bus": {"storage_path": r"C:\data\bus.sqlite"}}),
+        encoding="utf-8",
+    )
+    plan = build_plan(vault, [cfg])
+    assert plan["vault_layout"]["file_count"] >= 1
+    assert plan["configs"][0]["absolute_paths"] == [r"C:\data\bus.sqlite"]
+    json.dumps(plan)  # serializable


### PR DESCRIPTION
## Ticket
Cutover **#06** — vault continuity (spec: \docs/requirements/pepper-cutover-06-vault-continuity.md\).

## What changed
- \gent-core vault plan-dry-run\: JSON report of vault layout (recommended files/dirs, file list with POSIX paths), plus scan of \--config\ YAML files for probable absolute path strings.
- Runbook: \docs/migrations/pepper-vault-continuity-runbook.md\.
- Tests: \packages/core/tests/test_vault_migration_plan.py\.

## Verify
\\\ash
cd packages/core && uv run pytest tests/test_vault_migration_plan.py -q
uv run agent-core vault plan-dry-run --help
\\\

## Dependencies
Independent of cutover #03; can merge after review when green.

## Notes
This is an auditable slice (CLI + tests + doc). Full epic may still need live vault dry-runs and live \gent_core.yaml\ outside this repo.

Made with [Cursor](https://cursor.com)