### PR TITLE
fix(handoff): bounded tail-read + loud failure (#44)

### DIFF
--- a/docs/superpowers/plans/2026-05-07-issue-44-handoff-worker-tail-fail-loud-plan.md
+++ b/docs/superpowers/plans/2026-05-07-issue-44-handoff-worker-tail-fail-loud-plan.md
@@ -1,0 +1,1211 @@
+# Issue #44 — Handoff Worker Tail + Loud Failure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the handoff worker from silently writing 268-byte stub handoffs marked `state: "ready"` when the bundled Claude SDK fails on oversized transcripts. Read only the tail of the transcript; let summarization failures propagate to the existing `_write_failed` path; capture subprocess stderr to status, daemon log, and per-job log file.
+
+**Architecture:** All changes are in `packages/core/src/agent_core/endpoints/handoff_jobs.py` and its test file. New helpers (`_read_transcript_tail`, `_summarize_stderr`, `_capture_subprocess_stderr`); modified methods (`_call_agent_sdk` wraps stderr capture, `_extract_handoff` loses its silent fallback); two new constructor params for tail bounds plus one for the per-job log dir. The consumer side (`HandoffInjector`) already handles `state: "failed"` correctly — no changes needed there.
+
+**Tech Stack:** Python 3.12+, pytest with `pytest.mark.asyncio`, `httpx`, `claude_agent_sdk`. Existing test patterns in `packages/core/tests/test_handoff_jobs_endpoint.py` use config-driven bus setup with `tmp_path` and `monkeypatch` fixtures.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-issue-44-handoff-worker-tail-fail-loud-design.md`
+
+**Branch:** `fix/issue-44-handoff-worker-tail-fail-loud` (already created)
+
+---
+
+## File Structure
+
+**Modified:**
+- `packages/core/src/agent_core/endpoints/handoff_jobs.py`
+  - Add module-level helper: `_read_transcript_tail`
+  - Add static helpers on `HandoffJobsEndpoint`: `_summarize_stderr`, `_capture_subprocess_stderr`
+  - Add constructor params: `transcript_tail_max_bytes`, `transcript_tail_max_messages`, `jobs_log_dir`
+  - Modify `_process_job` call site to use the tail helper
+  - Split SDK invocation: `_call_agent_sdk` (outer wrapper, stderr capture on failure) + new `_run_sdk_query` (inner, the actual `claude_agent_sdk.query()` call). Failure tests monkeypatch the inner so the outer wrapper runs.
+  - Simplify `_extract_handoff` (remove silent stub)
+  - Remove obsolete `_read_transcript_text`
+
+**Modified:**
+- `packages/core/tests/test_handoff_jobs_endpoint.py`
+  - Add unit tests for the new helpers
+  - Add integration tests for tail behavior, failure handling, and stderr capture
+
+No other files touched. No schema changes. No new dependencies.
+
+---
+
+## Task 1: Tail-read helper (pure function)
+
+**Why first:** Pure function, no async, no bus state. Establishes the tail semantics in isolation before wiring.
+
+**Files:**
+- Modify: `packages/core/src/agent_core/endpoints/handoff_jobs.py` (add module-level function near the top, after the imports and before the `HandoffJobRequest` class)
+- Modify: `packages/core/tests/test_handoff_jobs_endpoint.py` (add tests at the end of the file)
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Add to `packages/core/tests/test_handoff_jobs_endpoint.py`:
+
+```python
+import json as _json  # alias to avoid shadowing the existing top-level `json`
+
+from agent_core.endpoints.handoff_jobs import _read_transcript_tail
+
+
+def test_read_transcript_tail_returns_whole_file_when_small(tmp_path):
+    f = tmp_path / "small.jsonl"
+    content = '{"a":1}\n{"b":2}\n'
+    f.write_text(content, encoding="utf-8")
+
+    result = _read_transcript_tail(f, max_bytes=1024, max_messages=100)
+    assert result == content
+
+
+def test_read_transcript_tail_caps_by_bytes_aligned_to_newline(tmp_path):
+    f = tmp_path / "big.jsonl"
+    lines = [f'{{"i":{i:06d},"data":"{"x" * 80}"}}' for i in range(100)]
+    content = "\n".join(lines) + "\n"
+    f.write_text(content, encoding="utf-8")
+    assert len(content.encode("utf-8")) > 1024
+
+    result = _read_transcript_tail(f, max_bytes=1024, max_messages=10000)
+
+    assert len(result.encode("utf-8")) <= 1024
+    first_line = result.split("\n", 1)[0]
+    parsed = _json.loads(first_line)
+    assert "i" in parsed
+    assert result.endswith("\n")
+
+
+def test_read_transcript_tail_caps_by_message_count(tmp_path):
+    f = tmp_path / "many.jsonl"
+    lines = [f'{{"i":{i}}}' for i in range(50)]
+    content = "\n".join(lines) + "\n"
+    f.write_text(content, encoding="utf-8")
+
+    result = _read_transcript_tail(f, max_bytes=10**9, max_messages=10)
+    result_lines = [ln for ln in result.split("\n") if ln]
+    assert len(result_lines) == 10
+    assert _json.loads(result_lines[0]) == {"i": 40}
+    assert _json.loads(result_lines[-1]) == {"i": 49}
+
+
+def test_read_transcript_tail_drops_partial_first_line_after_byte_seek(tmp_path):
+    f = tmp_path / "big.jsonl"
+    lines = [f'{{"line":{i},"x":"{"a" * 100}"}}' for i in range(20)]
+    content = "\n".join(lines) + "\n"
+    f.write_text(content, encoding="utf-8")
+
+    result = _read_transcript_tail(f, max_bytes=250, max_messages=10000)
+
+    for line in result.split("\n"):
+        if line:
+            _json.loads(line)  # raises ValueError on partial JSON
+
+
+def test_read_transcript_tail_handles_empty_file(tmp_path):
+    f = tmp_path / "empty.jsonl"
+    f.write_text("", encoding="utf-8")
+    result = _read_transcript_tail(f, max_bytes=1024, max_messages=100)
+    assert result == ""
+
+
+def test_read_transcript_tail_handles_file_with_no_trailing_newline(tmp_path):
+    f = tmp_path / "no_trail.jsonl"
+    content = '{"a":1}\n{"b":2}'
+    f.write_text(content, encoding="utf-8")
+    result = _read_transcript_tail(f, max_bytes=1024, max_messages=100)
+    assert '{"a":1}' in result
+    assert '{"b":2}' in result
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `uv run pytest packages/core/tests/test_handoff_jobs_endpoint.py -k "read_transcript_tail" -v`
+
+Expected: FAIL with `ImportError` on `_read_transcript_tail` (function doesn't exist yet).
+
+- [ ] **Step 1.3: Implement the helper**
+
+Add to `packages/core/src/agent_core/endpoints/handoff_jobs.py` after the `_default_transcript_root` function and before the `HandoffJobRequest` class:
+
+```python
+def _read_transcript_tail(
+    transcript_path: Path,
+    *,
+    max_bytes: int = 256 * 1024,
+    max_messages: int = 200,
+) -> str:
+    """Return the tail of a jsonl transcript, line-aligned and capped both ways.
+
+    For files at or below ``max_bytes`` returns the full file. For larger
+    files seeks ``max_bytes`` from the end, drops the first (potentially
+    partial) line, and additionally caps to the last ``max_messages`` lines
+    if the byte tail still exceeds that count.
+    """
+    if not transcript_path.exists():
+        raise FileNotFoundError(f"transcript does not exist: {transcript_path}")
+
+    file_size = transcript_path.stat().st_size
+    if file_size == 0:
+        return ""
+
+    if file_size <= max_bytes:
+        text = transcript_path.read_text(encoding="utf-8")
+    else:
+        with transcript_path.open("rb") as fh:
+            fh.seek(file_size - max_bytes)
+            tail_bytes = fh.read()
+        # Drop the partial first line (always — even if the seek happened to
+        # land on a newline, the next byte starts a new line cleanly).
+        nl_index = tail_bytes.find(b"\n")
+        if nl_index >= 0:
+            tail_bytes = tail_bytes[nl_index + 1:]
+        text = tail_bytes.decode("utf-8", errors="replace")
+
+    # Cap by message count (line count) if needed.
+    lines = text.split("\n")
+    # ``split`` produces a trailing empty string when text ends with newline;
+    # treat empty trailing entry as a sentinel rather than a message.
+    has_trailing_newline = text.endswith("\n")
+    if has_trailing_newline:
+        lines = lines[:-1]
+
+    if len(lines) > max_messages:
+        lines = lines[-max_messages:]
+
+    result = "\n".join(lines)
+    if has_trailing_newline and result:
+        result += "\n"
+    return result
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+Run: `uv run pytest packages/core/tests/test_handoff_jobs_endpoint.py -k "read_transcript_tail" -v`
+
+Expected: 6 passed.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add packages/core/src/agent_core/endpoints/handoff_jobs.py packages/core/tests/test_handoff_jobs_endpoint.py
+git commit -m "feat(handoff): add bounded tail-read helper for transcripts
+
+Adds _read_transcript_tail with both byte and message bounds. File-size <=
+max_bytes returns whole file; larger files seek from end, drop the first
+partial line for jsonl validity, then cap by message count.
+
+Refs #44"
+```
+
+---
+
+## Task 2: Wire tail helper into the endpoint
+
+**Why next:** Now that the helper is proven, swap the call site and add constructor params. Existing endpoint integration tests must still pass.
+
+**Files:**
+- Modify: `packages/core/src/agent_core/endpoints/handoff_jobs.py`
+  - `__init__` adds two new params
+  - `_process_job` swaps `_read_transcript_text` for `_read_transcript_tail`
+  - Remove the now-unused `_read_transcript_text` static method
+- Modify: `packages/core/tests/test_handoff_jobs_endpoint.py` (one new integration test)
+
+- [ ] **Step 2.1: Write the failing test**
+
+Add this test to `packages/core/tests/test_handoff_jobs_endpoint.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_handoff_worker_uses_tail_for_oversized_transcripts(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_root = tmp_path / "claude_projects"
+    transcript_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = transcript_root / "session-tail.jsonl"
+
+    # Build a transcript larger than the tail bound so we can see truncation.
+    lines = [f'{{"i":{i},"data":"{"x" * 200}"}}\n' for i in range(2000)]
+    transcript_path.write_text("".join(lines), encoding="utf-8")
+
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+      transcript_tail_max_bytes: 4096
+      transcript_tail_max_messages: 50
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    received_lengths: list[int] = []
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+
+            async def _capture_extract(self, req, transcript_text, *args, **kwargs):
+                received_lengths.append(len(transcript_text.encode("utf-8")))
+                return "# Handoff\n"
+
+            monkeypatch.setattr(type(endpoint), "_extract_handoff", _capture_extract)
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-tail",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "transcript_root": str(transcript_root),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+
+            for _ in range(40):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state == "ready":
+                        break
+                await asyncio.sleep(0.05)
+
+            assert received_lengths, "_extract_handoff was not called"
+            assert received_lengths[0] <= 4096
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+Run: `uv run pytest packages/core/tests/test_handoff_jobs_endpoint.py::test_handoff_worker_uses_tail_for_oversized_transcripts -v`
+
+Expected: FAIL — config rejects unknown params or worker still reads whole file (received_lengths[0] > 4096).
+
+- [ ] **Step 2.3: Add constructor params**
+
+Edit `HandoffJobsEndpoint.__init__` in `packages/core/src/agent_core/endpoints/handoff_jobs.py`:
+
+```python
+def __init__(
+    self,
+    *,
+    name: str,
+    mount: str = "/internal/handoff-jobs",
+    max_attempts: int = 3,
+    retry_backoff_seconds: float = 0.25,
+    transcript_tail_max_bytes: int = 256 * 1024,
+    transcript_tail_max_messages: int = 200,
+    jobs_log_dir: Path | None = None,
+):
+    self.name = name
+    self.mount = mount
+    self._max_attempts = max(1, max_attempts)
+    self._retry_backoff_seconds = max(0.0, retry_backoff_seconds)
+    self._transcript_tail_max_bytes = max(1, transcript_tail_max_bytes)
+    self._transcript_tail_max_messages = max(1, transcript_tail_max_messages)
+    self._jobs_log_dir = (
+        jobs_log_dir
+        if jobs_log_dir is not None
+        else Path("~/.agent-core/handoffs/jobs").expanduser()
+    )
+    self._handle: BusHandle | None = None
+    self._jobs: asyncio.Queue[_QueuedJob] = asyncio.Queue()
+    self._worker_task: asyncio.Task[None] | None = None
+    self._idempotency_index: dict[str, str] = {}
+```
+
+- [ ] **Step 2.4: Swap the call site in `_process_job`**
+
+In `_process_job`, replace this block (currently around lines 191-194):
+
+```python
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                transcript_text = self._read_transcript_text(transcript_path)
+                handoff_content = await self._extract_handoff(req, transcript_text)
+```
+
+With:
+
+```python
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                transcript_text = _read_transcript_tail(
+                    transcript_path,
+                    max_bytes=self._transcript_tail_max_bytes,
+                    max_messages=self._transcript_tail_max_messages,
+                )
+                handoff_content = await self._extract_handoff(req, transcript_text)
+```
+
+- [ ] **Step 2.5: Remove the obsolete `_read_transcript_text` method**
+
+Delete this static method (currently around lines 237-241):
+
+```python
+    @staticmethod
+    def _read_transcript_text(transcript_path: Path) -> str:
+        if not transcript_path.exists():
+            raise FileNotFoundError(f"transcript does not exist: {transcript_path}")
+        return transcript_path.read_text(encoding="utf-8")
+```
+
+- [ ] **Step 2.6: Run the new test and the full handoff-jobs test file**
+
+Run: `uv run pytest packages/core/tests/test_handoff_jobs_endpoint.py -v`
+
+Expected: all tests pass, including `test_handoff_worker_uses_tail_for_oversized_transcripts`. Existing tests should be unaffected — they use small transcripts that fit under the default 256 KB.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add packages/core/src/agent_core/endpoints/handoff_jobs.py packages/core/tests/test_handoff_jobs_endpoint.py
+git commit -m "feat(handoff): wire tail-read into worker, add constructor params
+
+Adds transcript_tail_max_bytes / transcript_tail_max_messages / jobs_log_dir
+constructor params to HandoffJobsEndpoint. _process_job now reads only the
+bounded tail of the transcript instead of the whole file. Removes the
+obsolete _read_transcript_text helper.
+
+Refs #44"
+```
+
+---
+
+## Task 3: Stderr summary helpers (pure functions)
+
+**Why next:** Need both helpers in place before wiring stderr capture into `_call_agent_sdk`. Pure functions, easy to TDD.
+
+**Files:**
+- Modify: `packages/core/src/agent_core/endpoints/handoff_jobs.py` (add two static methods on `HandoffJobsEndpoint`)
+- Modify: `packages/core/tests/test_handoff_jobs_endpoint.py` (add unit tests)
+
+- [ ] **Step 3.1: Write the failing tests**
+
+Add to `packages/core/tests/test_handoff_jobs_endpoint.py`:
+
+```python
+def test_summarize_stderr_returns_full_text_when_short():
+    text = "first line\nlast line"
+    result = HandoffJobsEndpoint._summarize_stderr(text, max_chars=500)
+    assert "first line" in result
+    assert "last line" in result
+
+
+def test_summarize_stderr_truncates_with_ellipsis_when_long():
+    long_middle = "middle\n" * 1000
+    text = f"first line\n{long_middle}last line"
+    result = HandoffJobsEndpoint._summarize_stderr(text, max_chars=80)
+    assert len(result) <= 80
+    assert "first line" in result
+    assert "last line" in result
+    assert "..." in result
+
+
+def test_summarize_stderr_skips_empty_lines():
+    text = "\n\nfirst real line\n\n\nlast real line\n\n"
+    result = HandoffJobsEndpoint._summarize_stderr(text, max_chars=500)
+    assert "first real line" in result
+    assert "last real line" in result
+
+
+def test_summarize_stderr_handles_empty_input():
+    result = HandoffJobsEndpoint._summarize_stderr("", max_chars=500)
+    assert result == ""
+
+
+def test_capture_subprocess_stderr_extracts_from_chained_exception():
+    inner = RuntimeError("subprocess died: file too large")
+    outer = RuntimeError("Command failed with exit code 1")
+    outer.__cause__ = inner
+    result = HandoffJobsEndpoint._capture_subprocess_stderr(outer)
+    assert "file too large" in result or "subprocess died" in result
+
+
+def test_capture_subprocess_stderr_falls_back_to_repr_when_no_chain():
+    exc = ValueError("nothing structured here")
+    result = HandoffJobsEndpoint._capture_subprocess_stderr(exc)
+    assert result
+    assert "nothing structured here" in result
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+Run: `uv run pytest packages/core/tests/test_handoff_jobs_endpoint.py -k "summarize_stderr or capture_subprocess_stderr" -v`
+
+Expected: FAIL with `AttributeError` — methods don't exist.
+
+- [ ] **Step 3.3: Implement the helpers**
+
+Add to `HandoffJobsEndpoint` class in `packages/core/src/agent_core/endpoints/handoff_jobs.py` (place near the other static helpers, e.g. before `_resolve_under_root`):
+
+```python
+    @staticmethod
+    def _summarize_stderr(text: str, *, max_chars: int = 500) -> str:
+        """Return a short summary of stderr text capped at ``max_chars``.
+
+        Uses the first and last non-empty lines, joined with " ... " when the
+        full text would exceed the cap. Returns the full text untruncated when
+        it already fits.
+        """
+        if not text:
+            return ""
+        non_empty = [ln.strip() for ln in text.split("\n") if ln.strip()]
+        if not non_empty:
+            return text[:max_chars]
+        if len(text) <= max_chars:
+            return text
+        first = non_empty[0]
+        last = non_empty[-1] if len(non_empty) > 1 else ""
+        if not last or first == last:
+            return first[:max_chars]
+        sep = " ... "
+        # Reserve room for separator and last line; truncate first if needed.
+        budget = max_chars - len(sep) - len(last)
+        if budget <= 0:
+            # last line alone is too long; fall back to truncated first line
+            return first[:max_chars]
+        return f"{first[:budget]}{sep}{last}"
+
+    @staticmethod
+    def _capture_subprocess_stderr(exc: BaseException) -> str:
+        """Best-effort extraction of subprocess stderr from an exception.
+
+        Walks the ``__cause__`` chain looking for messages that mention stderr
+        or subprocess exit. Falls back to ``repr(exc)`` when nothing structured
+        is found.
+        """
+        parts: list[str] = []
+        seen: set[int] = set()
+        current: BaseException | None = exc
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            msg = str(current)
+            if msg:
+                parts.append(msg)
+            current = current.__cause__ or current.__context__
+
+        if parts:
+            return "\n".join(parts)
+        return repr(exc)
+```
+
+- [ ] **Step 3.4: Run tests to verify they pass**
+
+Run: `uv run pytest packages/core/tests/test_handoff_jobs_endpoint.py -k "summarize_stderr or capture_subprocess_stderr" -v`
+
+Expected: 6 passed.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add packages/core/src/agent_core/endpoints/handoff_jobs.py packages/core/tests/test_handoff_jobs_endpoint.py
+git commit -m "feat(handoff): add stderr summary + capture helpers
+
+_summarize_stderr returns a bounded first-line + last-line summary for
+the status file's error field. _capture_subprocess_stderr walks the
+exception cause chain looking for subprocess output, falling back to
+repr(exc) when nothing structured is available.
+
+Refs #44"
+```
+
+---
+
+## Task 4: Wire stderr capture into `_call_agent_sdk`
+
+**Why next:** Helpers are ready. This task adds the per-job log file write + daemon log line on SDK failure, and threads `job_id` through the call signatures. No behavior change to status yet — that comes in Task 5.
+
+**Files:**
+- Modify: `packages/core/src/agent_core/endpoints/handoff_jobs.py`
+  - `_extract_handoff` signature gains `job_id`
+  - `_call_agent_sdk` signature gains `job_id` and wraps body in try/except
+  - `_process_job` passes `job.job_id` through
+- Modify: `packages/core/tests/test_handoff_jobs_endpoint.py` (add test for per-job log)
+
+- [ ] **Step 4.1: Write the failing test**
+
+Add to `packages/core/tests/test_handoff_jobs_endpoint.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_handoff_worker_writes_per_job_log_on_sdk_failure(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_root = tmp_path / "claude_projects"
+    transcript_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = transcript_root / "session-fail.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hello"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+    jobs_log_dir = tmp_path / "jobs_logs"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+      jobs_log_dir: {jobs_log_dir}
+      retry_backoff_seconds: 0.0
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+
+            async def _failing_inner(self, *, req, transcript_text):
+                inner = RuntimeError("subprocess stderr: transcript too large")
+                outer = RuntimeError("Command failed with exit code 1")
+                outer.__cause__ = inner
+                raise outer
+
+            monkeypatch.setattr(type(endpoint), "_run_sdk_query", _failing_inner)
+
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-fail",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "transcript_root": str(transcript_root),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
+
+            for _ in range(40):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state in ("ready", "failed"):
+                        break
+                await asyncio.sleep(0.05)
+
+            log_file = jobs_log_dir / f"{job_id}.log"
+            assert log_file.exists(), f"per-job log not written at {log_file}"
+            log_content = log_file.read_text(encoding="utf-8")
+            assert "transcript too large" in log_content or "exit code 1" in log_content
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
+```
+
+- [ ] **Step 4.2: Run test to verify it fails**
+
+Run: `uv run pytest packages/core/tests/test_handoff_jobs_endpoint.py::test_handoff_worker_writes_per_job_log_on_sdk_failure -v`
+
+Expected: FAIL — `_call_agent_sdk` doesn't accept `job_id` kwarg yet, OR no log file written.
+
+- [ ] **Step 4.3: Thread `job_id` and split SDK invocation**
+
+Edit `_extract_handoff` in `packages/core/src/agent_core/endpoints/handoff_jobs.py`. Replace the existing body (currently lines 243-257) with:
+
+```python
+    async def _extract_handoff(
+        self, req: HandoffJobRequest, transcript_text: str, job_id: str
+    ) -> str:
+        try:
+            response_text = await self._call_agent_sdk(
+                req=req, transcript_text=transcript_text, job_id=job_id,
+            )
+            if response_text.strip():
+                return response_text
+            raise RuntimeError("empty handoff extraction")
+        except Exception as exc:
+            generated_at = datetime.now(UTC).isoformat()
+            return (
+                f"# Handoff ({req.agent_name})\n\n"
+                f"- session_id: {req.session_id}\n"
+                f"- event: {req.event}\n"
+                f"- generated_at: {generated_at}\n\n"
+                f"Extraction fallback used: {exc}"
+            )
+```
+
+> Note: The silent fallback in `_extract_handoff` is *kept* in this task. Task 5 removes it. Splitting like this lets us test stderr capture independently from the behavior change.
+
+Now split the existing `_call_agent_sdk` (currently lines 259-318) into two methods. The outer wrapper handles stderr capture; the inner runs the actual SDK call. **Tests can monkeypatch the inner so the outer wrapper still runs.** Replace the entire `_call_agent_sdk` method with these two methods:
+
+```python
+    async def _call_agent_sdk(
+        self, *, req: HandoffJobRequest, transcript_text: str, job_id: str
+    ) -> str:
+        """Run the SDK summarizer; capture stderr to per-job log on failure."""
+        try:
+            return await self._run_sdk_query(req=req, transcript_text=transcript_text)
+        except Exception as exc:
+            stderr_text = self._capture_subprocess_stderr(exc)
+            job_log_path = self._jobs_log_dir / f"{job_id}.log"
+            try:
+                job_log_path.parent.mkdir(parents=True, exist_ok=True)
+                job_log_path.write_text(stderr_text, encoding="utf-8")
+            except OSError:
+                log.exception(
+                    "failed to write per-job log for handoff job %s at %s",
+                    job_id, job_log_path,
+                )
+            log.error(
+                "handoff job %s SDK call failed; full stderr at %s: %s",
+                job_id, job_log_path, str(exc)[:500],
+            )
+            summary = self._summarize_stderr(stderr_text, max_chars=500)
+            raise RuntimeError(f"summarizer failed: {summary}") from exc
+
+    async def _run_sdk_query(
+        self, *, req: HandoffJobRequest, transcript_text: str
+    ) -> str:
+        """Inner SDK invocation. Tests monkeypatch this; the outer wrapper still runs."""
+        from claude_agent_sdk import (
+            AssistantMessage,
+            ClaudeAgentOptions,
+            TextBlock,
+            query,
+        )
+
+        prompt = f"""You are writing a handoff note for {req.agent_name} for continuity between sessions.
+Write from {req.agent_name}'s perspective. Based on the transcript below, produce:
+
+## What We Were Working On
+- specific bullets
+
+## Decisions Made
+- specific bullets
+
+## Emotional Temperature
+- one sentence
+
+## Open Threads
+- specific bullets
+
+## Observations
+- specific bullets
+
+Rules:
+- Keep each section to 2-5 bullets where applicable.
+- Skip empty sections.
+- Be concrete: mention files, tools, errors, and decisions.
+- If truly trivial transcript, respond with exactly HANDOFF_EMPTY.
+
+Session metadata:
+- session_id: {req.session_id}
+- event: {req.event}
+
+Transcript:
+{transcript_text}
+"""
+        response_text = ""
+        async for message in query(
+            prompt=prompt,
+            options=ClaudeAgentOptions(
+                allowed_tools=[],
+                max_turns=2,
+            ),
+        ):
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        response_text += block.text
+
+        if response_text.strip() == "HANDOFF_EMPTY":
+            return (
+                f"# Handoff ({req.agent_name})\n\n"
+                f"- session_id: {req.session_id}\n"
+                f"- event: {req.event}\n\n"
+                "No significant content to hand off."
+            )
+        return response_text
+```
+
+- [ ] **Step 4.4: Update `_process_job` call site**
+
+In `_process_job`, change the call to `_extract_handoff` (around line 194) from:
+
+```python
+                handoff_content = await self._extract_handoff(req, transcript_text)
+```
+
+To:
+
+```python
+                handoff_content = await self._extract_handoff(
+                    req, transcript_text, job.job_id,
+                )
+```
+
+- [ ] **Step 4.5: Run the targeted test and the full file**
+
+Run: `uv run pytest packages/core/tests/test_handoff_jobs_endpoint.py::test_handoff_worker_writes_per_job_log_on_sdk_failure -v`
+
+Expected: PASS — log file exists with stderr content.
+
+Then: `uv run pytest packages/core/tests/test_handoff_jobs_endpoint.py -v`
+
+Expected: all tests pass. Existing tests still pass because the `_extract_handoff` fallback stub is still in place (it's removed in Task 5).
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add packages/core/src/agent_core/endpoints/handoff_jobs.py packages/core/tests/test_handoff_jobs_endpoint.py
+git commit -m "feat(handoff): capture SDK subprocess stderr to per-job log on failure
+
+When _call_agent_sdk raises, capture whatever stderr we can extract from
+the exception chain to ~/.agent-core/handoffs/jobs/<job_id>.log, log a
+daemon line pointing at it, and re-raise with a short summary. Threads
+job_id through _extract_handoff and _call_agent_sdk signatures.
+
+The silent fallback in _extract_handoff is still in place and is removed
+in the next commit. This split lets us test stderr capture independent
+of the behavior change.
+
+Refs #44"
+```
+
+---
+
+## Task 5: Remove the silent stub fallback (the load-bearing behavior change)
+
+**Why next:** Stderr capture is in place; per-job log is being written. Now make summarization failures actually fail loudly: status `state: "failed"`, `handoff.md` untouched.
+
+**Files:**
+- Modify: `packages/core/src/agent_core/endpoints/handoff_jobs.py` (remove try/except in `_extract_handoff`)
+- Modify: `packages/core/tests/test_handoff_jobs_endpoint.py` (three new tests for the loud-failure behavior)
+
+- [ ] **Step 5.1: Write the failing tests**
+
+Add to `packages/core/tests/test_handoff_jobs_endpoint.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_handoff_worker_marks_failed_when_sdk_raises(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_root = tmp_path / "claude_projects"
+    transcript_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = transcript_root / "session-marked.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hi"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+      retry_backoff_seconds: 0.0
+      jobs_log_dir: {tmp_path / "jobs_logs"}
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+
+            async def _always_fail(self, *, req, transcript_text):
+                raise RuntimeError("subprocess stderr: kaboom")
+
+            monkeypatch.setattr(type(endpoint), "_run_sdk_query", _always_fail)
+
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-marked",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "transcript_root": str(transcript_root),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+
+            for _ in range(60):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state in ("ready", "failed"):
+                        break
+                await asyncio.sleep(0.05)
+
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+            assert status["state"] == "failed"
+            assert status.get("error")
+            assert "kaboom" in status["error"] or "summarizer failed" in status["error"]
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
+
+
+@pytest.mark.asyncio
+async def test_handoff_worker_does_not_overwrite_handoff_md_when_failed(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_root = tmp_path / "claude_projects"
+    transcript_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = transcript_root / "session-preserve.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hi"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+
+    pre_existing = "# Last good handoff\n\n- session: prior\n- decision: keep this content\n"
+    handoff_path.write_text(pre_existing, encoding="utf-8")
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+      retry_backoff_seconds: 0.0
+      jobs_log_dir: {tmp_path / "jobs_logs"}
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+
+            async def _always_fail(self, *, req, transcript_text):
+                raise RuntimeError("subprocess stderr: kaboom")
+
+            monkeypatch.setattr(type(endpoint), "_run_sdk_query", _always_fail)
+
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-preserve",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "transcript_root": str(transcript_root),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+
+            for _ in range(60):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state in ("ready", "failed"):
+                        break
+                await asyncio.sleep(0.05)
+
+            assert handoff_path.read_text(encoding="utf-8") == pre_existing
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
+
+
+@pytest.mark.asyncio
+async def test_handoff_worker_truncates_stderr_in_status_error_field(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_root = tmp_path / "claude_projects"
+    transcript_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = transcript_root / "session-trunc.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hi"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+      retry_backoff_seconds: 0.0
+      jobs_log_dir: {tmp_path / "jobs_logs"}
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+
+            huge_msg = "first line of error\n" + ("noise " * 5000) + "\nlast line of error"
+
+            async def _huge_fail(self, *, req, transcript_text):
+                raise RuntimeError(huge_msg)
+
+            monkeypatch.setattr(type(endpoint), "_run_sdk_query", _huge_fail)
+
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-trunc",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "transcript_root": str(transcript_root),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+
+            for _ in range(60):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state in ("ready", "failed"):
+                        break
+                await asyncio.sleep(0.05)
+
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+            assert status["state"] == "failed"
+            err = status["error"]
+            # Status error must be bounded — allow generous slack for outer wrapping.
+            assert len(err) <= 700
+```
+
+- [ ] **Step 5.2: Run tests to verify they fail**
+
+Run: `uv run pytest packages/core/tests/test_handoff_jobs_endpoint.py -k "marks_failed or does_not_overwrite or truncates_stderr" -v`
+
+Expected: FAIL — silent fallback still in place writes a stub and marks status `ready`, so the assertions on `state == "failed"` fail.
+
+- [ ] **Step 5.3: Remove the silent stub fallback**
+
+Edit `_extract_handoff` in `packages/core/src/agent_core/endpoints/handoff_jobs.py`. Replace the body (just modified in Task 4) with the simplified version:
+
+```python
+    async def _extract_handoff(
+        self, req: HandoffJobRequest, transcript_text: str, job_id: str
+    ) -> str:
+        response_text = await self._call_agent_sdk(
+            req=req, transcript_text=transcript_text, job_id=job_id,
+        )
+        if response_text.strip():
+            return response_text
+        raise RuntimeError("empty handoff extraction")
+```
+
+The try/except + fallback stub is gone. Exceptions from `_call_agent_sdk` (which already capture stderr to the per-job log and wrap in a `RuntimeError("summarizer failed: ...")`) propagate to `_process_job`'s `for attempt in range(...)` loop, which already retries up to `_max_attempts` then calls `_write_failed`.
+
+- [ ] **Step 5.4: Run all targeted tests + full file**
+
+Run: `uv run pytest packages/core/tests/test_handoff_jobs_endpoint.py -v`
+
+Expected: all tests pass. The three new failure-behavior tests pass; existing success-path tests still pass (their mocked `_extract_handoff` returns content directly, so the removed fallback is never exercised).
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add packages/core/src/agent_core/endpoints/handoff_jobs.py packages/core/tests/test_handoff_jobs_endpoint.py
+git commit -m "fix(handoff): remove silent stub fallback; surface failures loudly
+
+When summarization fails, exceptions now propagate to _process_job's
+existing retry + _write_failed path. Status reflects state=failed with
+the actual error; handoff.md is left untouched (HandoffInjector already
+treats this as 'last-known-good from earlier successful cycle').
+
+Closes #44"
+```
+
+---
+
+## Task 6: Full suite + manual verification
+
+**Why last:** Final regression sweep across the whole core package, then a smoke test against a real Pepper transcript to validate the change end-to-end.
+
+**Files:**
+- None modified.
+
+- [ ] **Step 6.1: Run the full core test suite**
+
+Run: `uv run pytest packages/core/tests/ -v`
+
+Expected: all tests pass. Investigate any unrelated failures before declaring victory — they may indicate accidental side effects.
+
+- [ ] **Step 6.2: Run the linter on the modified file**
+
+Run: `uv run ruff check packages/core/src/agent_core/endpoints/handoff_jobs.py packages/core/tests/test_handoff_jobs_endpoint.py`
+
+Expected: no violations. Fix any that surface (likely import order or line length).
+
+- [ ] **Step 6.3: Manual verification — small transcript golden path**
+
+In a Python REPL or a quick scratch script, instantiate `HandoffJobsEndpoint` with default tail bounds, point it at a small handcrafted transcript jsonl, and confirm:
+
+- The worker reads the whole file (file size < 256 KB).
+- A successful mock SDK response produces a real handoff.md.
+- Status file shows `state: "ready"` with a `content_sha256`.
+
+This validates that small-transcript behavior is unchanged from before the fix.
+
+- [ ] **Step 6.4: Manual verification — Pepper's real transcript**
+
+Locate Pepper's current session jsonl (likely under `~/.claude/projects/C--Users-jeffr--pepper/<uuid>.jsonl`). Note the file size — if > 256 KB, this validates the tail path.
+
+Construct a job request payload that points at it (do NOT use Pepper's real vault paths — write to a scratch dir to avoid clobbering her live handoff.md). Submit to a locally-running daemon or directly invoke the worker with a real config.
+
+Confirm:
+
+- Worker completes (does not OOM, does not hang).
+- If SDK succeeds: `handoff.md` is real and based on the tail of the transcript.
+- If SDK fails: status is `failed`, error is informative (not "Check stderr output for details"), `~/.agent-core/handoffs/jobs/<job_id>.log` exists with subprocess stderr.
+
+If the SDK fails on the tail too, that's the legitimate "transcript still too large" case and the fix is correct — agent reads the `failed` injector branch and uses MEMORY.md / dailies.
+
+- [ ] **Step 6.5: Push and open PR**
+
+```bash
+git push -u origin fix/issue-44-handoff-worker-tail-fail-loud
+gh pr create --base main --title "fix(handoff): bounded tail-read + loud failure (#44)" --body "$(cat <<'EOF'
+## Summary
+
+Stops the handoff worker from silently writing stub handoffs marked
+\`state: "ready"\` when the bundled Claude SDK fails on oversized
+transcripts. Worker now reads only the bounded tail
+(\`min(256 KB, 200 messages)\`); summarization failures propagate to
+the existing \`_write_failed\` path; subprocess stderr is captured to
+a per-job log file.
+
+The \`HandoffInjector\` consumer already handles \`state: "failed"\`
+correctly — labels existing \`handoff.md\` as last-known-good from an
+earlier successful cycle and points the agent at MEMORY.md / dailies.
+
+Closes #44.
+
+## Spec + Plan
+
+- Spec: \`docs/superpowers/specs/2026-05-07-issue-44-handoff-worker-tail-fail-loud-design.md\`
+- Plan: \`docs/superpowers/plans/2026-05-07-issue-44-handoff-worker-tail-fail-loud-plan.md\`
+
+## Test plan
+
+- [x] New unit tests for \`_read_transcript_tail\`, \`_summarize_stderr\`, \`_capture_subprocess_stderr\`
+- [x] New integration tests for tail bound, loud-failure status, no-overwrite, truncated error, per-job log
+- [x] Existing \`HandoffJobsEndpoint\` tests still pass
+- [x] Manual verification on Pepper's real transcript
+
+## After merge
+
+Unblocks #45 (SessionEnd-on-\`--continue\` investigation). A clean
+\`/exit\` test will tell us whether the originally suspected "Bug 1"
+was a real Claude Code behavior gap or a measurement artifact.
+EOF
+)"
+```
+
+- [ ] **Step 6.6: Update the open-issues roadmap**
+
+After the PR merges, mark Phase 1 as partially complete in `docs/superpowers/plans/2026-05-07-open-issues-cleanup-roadmap.md`'s status table. Note that #44 is closed; #42 / #43 / #45 remain.
+
+---
+
+## Self-review checklist (run after writing this plan)
+
+**Spec coverage:** Each spec section has a corresponding task.
+- Tail-read helper → Task 1
+- Worker simplification → Task 4 (signature change) + Task 5 (silent stub removal)
+- Stderr capture → Task 3 (helpers) + Task 4 (wiring)
+- Three stderr destinations → Task 4 (per-job + daemon log) + Task 5 (status field via existing `_write_failed` path)
+- Constructor params → Task 2 (`tail_max_bytes`, `tail_max_messages`) + Task 4 (`jobs_log_dir`)
+- All 12 tests from spec → covered across Tasks 1, 2, 4, 5
+
+**Placeholder scan:** No TBDs, no "implement appropriately," no "similar to Task N." Code blocks are concrete.
+
+**Type consistency:** `_extract_handoff(req, transcript_text, job_id)` signature is consistent across Task 4 and Task 5. `_call_agent_sdk` keyword-only signature `(*, req, transcript_text, job_id)` is consistent. `_run_sdk_query` keyword-only signature `(*, req, transcript_text)` (no `job_id` — that's handled by the outer wrapper) is consistent across Task 4 introduction and Task 5 failure tests' monkeypatches. `_jobs_log_dir` attribute name is consistent. `_summarize_stderr` and `_capture_subprocess_stderr` static methods used identically across tasks.
+
+**Granularity:** Each step is 2-5 minutes (write test, run test, write code, run test, commit). Six tasks total. Each task ends in a commit.

--- a/docs/superpowers/plans/2026-05-07-open-issues-cleanup-roadmap.md
+++ b/docs/superpowers/plans/2026-05-07-open-issues-cleanup-roadmap.md
@@ -1,0 +1,417 @@
+# Open Issues Cleanup Roadmap (2026-05-07)
+
+> **Scope:** Sequencing plan to close all 15 open issues on `jeffrichley/agent_core` as of 2026-05-07.
+>
+> **Shape:** This is a *roadmap*, not a per-feature implementation plan. Each issue (or cluster) gets its own implementation plan via the `superpowers:writing-plans` skill when it's picked up. This document orders the work, explains the rationale, names dependencies, and gives realistic effort estimates so Jeff can decide where to spend the next chunks of time.
+>
+> **Living document.** Update phase status as work lands. Re-rank if priorities shift.
+
+---
+
+## Context
+
+The webcam endpoint shipped to `main` on 2026-05-07 (PR #40), closing the active development branch. The issue tracker has 15 open items, most filed during the Pepper cutover (2026-05-06) when Jeff and the agent walked through the runbook together and surfaced architectural gaps.
+
+The 15 issues fall into four broad categories:
+
+- **Pepper reliability bugs** that affect day-to-day use (2 issues, both tagged `bug`)
+- **Foundational gaps** the cutover exposed but didn't block (5 issues — observability, ACLs, expiry, etc.)
+- **Future-feature scaffolding** that was always planned but is now well-scoped (5 issues — typed envelope kinds, DLQ, heartbeats, etc.)
+- **Polish + docs** (3 issues)
+
+The natural order: **fix what's broken now → close the visibility gaps → build the future-feature scaffolding → polish.** That's what this roadmap proposes.
+
+---
+
+## At-a-glance summary
+
+| Phase | Theme | Issues | Effort | Order |
+|---|---|---|---|---|
+| 0 | Quick wins (small, mostly independent) | #37, #36, #34, #18 | ~3-5 days | Any time, parallelizable |
+| 1 | Pepper reliability bugs | #35, #33 | ~7-10 days | Do first; sequential |
+| 2 | Observability foundation | #39, #16 | ~6-8 days | After Phase 1 |
+| 3 | User-facing UX (typing + bursts + typed kinds) | #19 → #13 → #14 | ~10-15 days | Sequential within phase |
+| 4 | Bus reliability foundation | #17, #15 | ~6-8 days | After Phase 2 (uses observability) |
+| 5 | Urgency redesign | #38 | 1-2 weeks (full) or 1 day (sigil-only MVP) | Standalone; defer if Pepper isn't getting false-positives |
+| 6 | Documentation hygiene | #23 | 0.5 day | Last; fast |
+| **Total** | | **15 issues** | **~10-12 work-weeks if sequential** | |
+
+Effort assumes one focused developer; can compress with parallel workstreams in phases 0, 4, and 6.
+
+---
+
+## Phase 0 — Quick wins (1-day issues, mostly independent)
+
+These are small, well-scoped issues whose fixes are mostly mechanical. They can land any time bandwidth allows; some can run in parallel because they touch unrelated files. **Recommended to land before Phase 1's heavier reliability work** so Jeff can see steady progress while the bug investigations spin up.
+
+### #37 — Bus HTTP MCP host doesn't emit `notifications/tools/list_changed`
+
+**What:** When the bus daemon restarts, connected MCP clients keep their stale tool cache. Currently the workaround is `/exit + relaunch` per agent. Bit us during the 2026-05-06 cutover ("the briefs framework looks broken!" was actually a stale-cache moment).
+
+**Cost:** 0.5-1 day. Touches `packages/core/src/agent_core/bus/http_host.py` + the FastMCP server wrapper.
+
+**Tests to add:**
+- `test_http_mcp_host_emits_tools_list_changed_after_wire_endpoints`
+- `test_http_mcp_host_no_spurious_tools_list_changed_on_static_registry`
+- `test_streamable_http_client_re_enumerates_on_tools_list_changed`
+
+**Branch:** `feat/issue-37-tools-list-changed`
+
+### #34 — Scheduler ACL: ownership check on delete/update/pause
+
+**What:** Currently any caller can mutate any scheduler job. Single-operator setup masks the issue, but it's a security footgun for multi-agent.
+
+**Cost:** 0.5-1 day. Add `created_by` to job records, enforce at the mutation tools.
+
+**Tests to add:**
+- `test_scheduler_delete_rejects_when_caller_not_owner`
+- `test_scheduler_update_rejects_when_caller_not_owner`
+- `test_scheduler_pause_resume_rejects_when_caller_not_owner`
+- `test_scheduler_list_jobs_filters_to_caller_by_default`
+
+**Branch:** `feat/issue-34-scheduler-ownership-acl`
+
+### #36 — Discord `AccessConfig`: add `deny_channels` blocklist
+
+**What:** Currently `AccessConfig.channels` is allowlist-only. To make Pepper "respond everywhere except #test" requires enumerating every other channel (or kludging Discord server permissions, as we did 2026-05-06). Add a `deny_channels` field that's checked first.
+
+**Cost:** 0.5 day. Single field addition + gate logic + tests.
+
+**Tests to add:**
+- `test_gate_denies_channel_in_deny_list_when_allowlist_empty`
+- `test_gate_denies_channel_in_deny_list_when_in_allowlist_too` (deny wins)
+- `test_gate_allows_when_in_allowlist_and_not_in_deny_list`
+- `test_load_access_config_parses_deny_channels`
+- `test_load_access_config_handles_missing_deny_channels` (back-compat)
+
+**Branch:** `feat/issue-36-discord-deny-channels`
+
+### #18 — Bus: enforce `expires_at` on envelopes
+
+**What:** The schema already accepts `expires_at` but the bus doesn't filter on pickup. Stale messages get delivered hours later — confusing-bot moment for any time-sensitive flow.
+
+**Cost:** 1-2 days. Filter at `list_pending`, mark expired envelopes, optional `Expired` envelope back to sender.
+
+**Tests to add:**
+- `test_list_pending_filters_expired_envelopes`
+- `test_expired_envelopes_state_transitions_to_expired`
+- `test_expired_in_flight_envelope_is_not_retroactively_expired`
+- `test_optional_expired_notification_to_sender`
+
+**Branch:** `feat/issue-18-enforce-expires-at`
+
+### Phase 0 sequencing
+
+These four can ship as **four separate small PRs** in any order, or batched into a "Phase 0 quick wins" branch. Recommend separate PRs — keeps each fix reviewable on its own, and each closes a discrete issue.
+
+**Phase 0 deliverable:** 4 issues closed, ~3-5 days of work.
+
+---
+
+## Phase 1 — Pepper reliability bugs (do first)
+
+Both bugs in this phase directly affect Pepper's day-to-day reliability. Neither is a one-line fix — each involves investigation before the implementation lands.
+
+### #35 — Handoff pipeline: 4 compounding bugs
+
+**What:** During the cutover, the post-cutover handoff workflow surfaced four interacting bugs that make handoffs unreliable:
+
+1. **Coarse idempotency key** — `f"{session_id}:{event}:{output_path}"` collides across `--continue` resumes, returning stale `job_id`s.
+2. **In-memory `_idempotency_index`** — wiped on daemon restart, so identical jobs re-execute after restart.
+3. **Worker silent fallback on oversized transcripts** — 18MB transcript causes the bundled Claude SDK summarizer to fail, writes a 268-byte stub, marks state ready.
+4. **In-memory state silently lost on daemon restart** — compounds with #2 above.
+
+**Cost:** 5-7 days. Each bug needs investigation + fix + regression test. The four are interleaved enough that fixing them sequentially in a single branch is more efficient than one PR per bug.
+
+**Approach:**
+1. Spike: reproduce each bug in isolation with a failing test. Land all four failing tests as the first commit so the regression coverage is locked in before any fix.
+2. Fix the idempotency key (richer key, e.g. include transcript hash or content fingerprint).
+3. Persist `_idempotency_index` (sqlite-backed) so daemon restart doesn't reset it.
+4. Fix the silent fallback (chunk + summarize, or fail loudly with a clear error).
+5. Audit other in-memory state for the same restart-fragility pattern (briefs `_sessions`, scheduler dedupe).
+
+**Tests to add:** at least one regression test per bug, plus an end-to-end test that simulates the cutover flow (PreCompact → daemon restart → SessionEnd → resume) and asserts the handoff lands correctly.
+
+**Branch:** `fix/issue-35-handoff-pipeline-reliability`
+
+**Risk:** This branch is the longest pole in Phase 1. Recommend a daily check-in to make sure each of the 4 bugs is actually being addressed (not just one fixed and the others forgotten).
+
+### #33 — Bus wake-builder count + `urgency_max` snapshot lag
+
+**What:** Bug. The wake-notification's `count` and `urgency_max` reflect the queue state at notification-build time, not at delivery time. Pepper can miss red-urgency items or get repeated wakes for the same envelope.
+
+**Cost:** 1-2 days. Re-snapshot at delivery time, or attach the wake metadata to envelope groups instead of single envelopes.
+
+**Tests to add:**
+- `test_wake_count_reflects_actual_pending_at_delivery_time`
+- `test_urgency_max_reflects_pending_red_envelope`
+- `test_wake_does_not_duplicate_for_same_pending_set`
+
+**Branch:** `fix/issue-33-wake-builder-snapshot-lag`
+
+### Phase 1 sequencing
+
+**Recommended:** #35 first (longer, has the worse blast radius), then #33 (smaller, depends on no shared code). Two separate PRs.
+
+**Phase 1 deliverable:** 2 issues closed, ~7-10 days of work.
+
+---
+
+## Phase 2 — Observability foundation (after Phase 1)
+
+Both issues here address the same underlying gap: today, the bus is a black box from outside any single endpoint. Phase 2 makes it inspectable.
+
+**Why after Phase 1:** Once the handoff pipeline is solid, observability lets us catch the *next* round of bugs faster. Doing this before Phase 1 doesn't help fix the known bugs (we already know what they are).
+
+### #39 — Bus HTTP MCP host: log every `tools/call` invocation
+
+**What:** Daemon-wide audit JSONL covering every MCP tool invocation across every endpoint. The webcam endpoint shipped its own local audit log as a stop-gap; this generalizes the pattern.
+
+**Cost:** 2-3 days. Add a hook in `http_host.py`'s `tools/call` dispatch that emits an `AuditEvent` to `~/.agent-core/mcp-audit/<YYYY-MM-DD>.jsonl`. Per-tool args summarizer registry (so sensitive payloads don't leak verbatim).
+
+**Tests to add:**
+- `test_http_host_logs_tool_call_invocation`
+- `test_http_host_logs_tool_call_error`
+- `test_http_host_uses_args_summary_when_registered`
+- `test_http_host_uses_default_summary_when_no_summarizer`
+- `test_http_host_skip_tools_excludes_named_tools`
+- `test_http_host_disabled_emits_nothing`
+- `test_http_host_daily_rotation`
+
+**Migration:** Webcam's local audit log can stay (finer-grained domain record) or be removed (now redundant). Decide when this lands.
+
+**Branch:** `feat/issue-39-mcp-tool-call-audit`
+
+### #16 — Read-only bus tail / audit feed for debugging
+
+**What:** A `tail` MCP tool (or HTTP endpoint) that returns recent envelope metadata across all endpoints — for cross-endpoint debugging that today requires log-grep across multiple files.
+
+**Cost:** 4-5 days. Auth-gated (per-endpoint vs admin scope), filterable, optional streaming. Companion: lightweight metrics (counts by kind, queue depth per endpoint, ack latency).
+
+**Tests to add:**
+- `test_tail_returns_recent_envelopes_with_metadata`
+- `test_tail_filters_by_from_to_kind_urgency`
+- `test_tail_payload_redacted_by_default`
+- `test_tail_full_payload_admin_only`
+- `test_tail_streaming_emits_envelopes_live`
+- `test_metrics_count_by_kind_is_accurate`
+
+**Branch:** `feat/issue-16-bus-tail-audit-feed`
+
+### Phase 2 sequencing
+
+#39 first (smaller, more foundational — every other observability tool benefits from having tool-call records). #16 second (uses the same persistence patterns; can reference the `daily_raw_jsonl` design).
+
+**Phase 2 deliverable:** 2 issues closed, ~6-8 days of work.
+
+---
+
+## Phase 3 — User-facing UX (typing + bursts + typed kinds)
+
+These three issues are tightly coupled. #19 establishes the typed-envelope vocabulary; #13 uses one of those types (`Status`) to fix the typing-indicator UX; #14 collapses bursts using the same notification surface.
+
+### #19 — Define typed command envelope kinds: `Reaction`, `Edit`, `DeleteMessage`, `DM`, `Status`
+
+**What:** Define typed payload schemas for richer agent → bridge interactions beyond `TextMessage`. Each kind has a JSON schema; bridges register handlers per-kind they support.
+
+**Cost:** 1-2 weeks. Multi-kind schema design + bridge dispatch routing + per-bridge registration. The schema design is the long pole — payload shapes need to work cross-platform (Discord, Slack, email) without leaking platform specifics into the agent layer.
+
+**Sub-tasks:**
+1. Schema design for each of the 5 kinds (1-2 days, design pass)
+2. Bridge dispatch + per-kind handler registration (2 days)
+3. `Reaction` end-to-end on Discord (1-2 days; reactions are well-defined)
+4. `Edit` end-to-end on Discord (1 day; pairs with #13)
+5. `DM` end-to-end on Discord (1 day)
+6. `DeleteMessage` (1 day)
+7. `Status` (1 day; minimal — actual UX uses are in #13 and #14)
+8. `describe_endpoint` extension to advertise `supported_kinds` (0.5 day)
+
+**Tests to add:** per-kind acceptance/rejection tests, bridge dispatch tests, end-to-end Discord tests using a fake Discord client.
+
+**Branch:** `feat/issue-19-typed-envelope-kinds`
+
+### #13 — Typing indicator TTL + placeholder + edit pattern
+
+**What:** Cap the "X is typing…" indicator (currently stays up indefinitely on long composes). Better UX: typing → placeholder message → edit with final reply. Uses `Status` envelopes from #19.
+
+**Cost:** 2-3 days *after #19 lands*. Without #19's `Status` and `Edit` kinds, the cost would be ~5 days because the typing logic would have to invent a private convention.
+
+**Tests to add:**
+- `test_typing_indicator_clears_after_ttl`
+- `test_placeholder_posted_after_typing_ttl_expires`
+- `test_placeholder_edited_to_final_reply_when_ready`
+- `test_placeholder_edited_to_failure_message_on_timeout`
+- `test_status_envelope_drives_placeholder_text`
+
+**Branch:** `feat/issue-13-typing-placeholder-edit`
+
+### #14 — Bus/bridge: collapse rapid same-sender envelope bursts
+
+**What:** Two messages from the same user 2 seconds apart currently fire two wake notifications. Fold same-sender same-kind envelopes within a short window into one notification.
+
+**Cost:** 1-2 days. Independent of #19 / #13 — but pairs naturally because all three are about wake-volume / chat-paced UX.
+
+**Tests to add:**
+- `test_burst_window_collapses_two_envelopes_into_one_notification`
+- `test_red_urgency_bypasses_burst_collapse`
+- `test_window_resets_after_quiet_period`
+- `test_per_endpoint_window_configuration`
+
+**Branch:** `feat/issue-14-collapse-burst-notifications`
+
+### Phase 3 sequencing
+
+**Recommended:** #19 first (its `Status` and `Edit` kinds are dependencies for #13's full version). Then #13. #14 can be done in parallel with #13 since it doesn't share files.
+
+**Phase 3 deliverable:** 3 issues closed, ~10-15 days of work.
+
+---
+
+## Phase 4 — Bus reliability foundation
+
+These two issues address bus-layer reliability that hasn't bitten loudly yet but is structural debt. They're also good candidates for the new observability tools from Phase 2 — the audit feed makes it easier to *see* whether DLQ and heartbeats are doing their job.
+
+### #17 — Bus: dead-letter queue + retry policy + poison-message handling
+
+**What:** Today, `nack(envelope_id, requeue=True)` puts an envelope back forever — no retry limit, no backoff, no DLQ. Add standard message-bus DLQ semantics: counter, max retries, dead-letter table, replay tooling.
+
+**Cost:** 4-5 days. Schema additions + DLQ table + replay/inspect/purge tools + per-kind retry config.
+
+**Tests to add:**
+- `test_envelope_moves_to_dead_letter_after_max_retries`
+- `test_exponential_backoff_between_requeues`
+- `test_per_kind_retry_limits_respected`
+- `test_dead_letter_replay_resets_attempts`
+- `test_dead_letter_purge_removes_envelope`
+- `test_dead_letter_visible_in_audit_feed` (Phase 2 dependency)
+
+**Branch:** `feat/issue-17-bus-dlq-retry-policy`
+
+### #15 — Bus: endpoint heartbeats + liveness for `list_endpoints`
+
+**What:** Today `list_endpoints()` returns who's *registered*, not who's *alive*. Add `last_seen` + derived `status: live | stale | dead` based on activity timestamps.
+
+**Cost:** 2-3 days. Activity-based heartbeats (passive — every send/list/handle marks the endpoint live), threshold config, optional `require_live=true` on `send`, optional `Undelivered` envelope when sending to a dead endpoint.
+
+**Tests to add:**
+- `test_endpoint_marked_live_on_send`
+- `test_endpoint_marked_live_on_list_pending`
+- `test_endpoint_status_transitions_to_stale_then_dead`
+- `test_send_to_dead_endpoint_with_require_live_fails_fast`
+- `test_undelivered_envelope_back_to_sender_after_ttl`
+
+**Branch:** `feat/issue-15-endpoint-heartbeats-liveness`
+
+### Phase 4 sequencing
+
+**Recommended:** parallel — neither depends on the other. Two separate PRs.
+
+**Phase 4 deliverable:** 2 issues closed, ~6-8 days of work.
+
+---
+
+## Phase 5 — Urgency detection redesign
+
+### #38 — Discord adapter urgency detection: replace 3-word regex with layered signals
+
+**What:** Current regex (`urgent|now|stop`) produces false positives ("right now we are looking at..." → red). Replace with layered signals: explicit sigil prefix, sender-map defaults, channel-of-origin defaults.
+
+**Cost:**
+- **MVP (sigil only):** 1 day. `!` prefix → red, `?` → yellow, `~` → green. Parse on inbound; strip from message body before delivery.
+- **Full layered design:** 1-2 weeks. Sigil + sender map + channel map + (optionally) embedding-similarity classifier.
+
+**Recommendation:** Ship MVP first (closes the immediate annoyance), defer the full layered design until usage shows the MVP isn't enough.
+
+**Tests to add (MVP):**
+- `test_sigil_prefix_promotes_urgency`
+- `test_sigil_prefix_strips_from_message_content`
+- `test_no_sigil_falls_through_to_green`
+
+**Tests to add (full):** the above plus sender-floor + channel-default + max-of-signals composition tests, listed in the issue body.
+
+**Branch:** `feat/issue-38-urgency-redesign-mvp` (MVP) or `feat/issue-38-urgency-layered` (full).
+
+### Phase 5 deliverable: 1 issue closed, 1 day (MVP) or 1-2 weeks (full).
+
+**Decision point for Jeff:** MVP-only or full layered? If Pepper isn't getting pinged on false-positives often, MVP is fine. If false positives are frequent, full design earns its cost.
+
+---
+
+## Phase 6 — Documentation hygiene
+
+### #23 — Discord bridge: document ack contract + chunk-limit edge semantics
+
+**What:** Recent send-reliability PR (#26/#28) introduced `message_id` vs `message_ids`, `status=sent|partial`, urgency on errors, and `MAX_CHUNKS` refusal — none of which are documented for agent consumers. Pure docs work.
+
+**Cost:** 0.5 day. Add a `## Ack contract` section to `packages/agent-core-discord/README.md` (or wherever endpoint docs live), tests with explicit assertions, regression tests.
+
+**Branch:** `docs/issue-23-discord-ack-contract`
+
+### Phase 6 deliverable: 1 issue closed, 0.5 day.
+
+---
+
+## Execution conventions
+
+For each branch:
+
+1. **One issue per branch.** Branch names follow `feat/issue-NN-<slug>` or `fix/issue-NN-<slug>` per category.
+2. **Implementation plan per branch.** Use the `superpowers:writing-plans` skill before starting code on each issue. The per-issue plan goes in `docs/superpowers/plans/` next to this roadmap.
+3. **Subagent-driven implementation.** Use `superpowers:subagent-driven-development` for execution per the validated 2026-05-06 webcam pattern.
+4. **PR per issue.** Standard `gh pr create --base main` flow. CI is currently no-op for this repo, so the gate is the test suite + spec compliance review + code quality review.
+5. **Close the issue from the PR body.** Use `Fixes #NN` so GitHub auto-closes on merge.
+6. **Update this roadmap as work lands.** Mark phase status (✅ done / 🚧 in progress / ⬜ not started) and add the merged PR number next to each issue.
+
+## Effort + timeline summary
+
+| Phase | Effort (sequential) | Effort (with parallelism) |
+|---|---|---|
+| Phase 0 — Quick wins | 3-5 days | 2 days |
+| Phase 1 — Reliability bugs | 7-10 days | 7-10 days (sequential by design) |
+| Phase 2 — Observability | 6-8 days | 5-6 days |
+| Phase 3 — UX (typed kinds + typing + bursts) | 10-15 days | 8-12 days |
+| Phase 4 — Bus reliability | 6-8 days | 4-5 days |
+| Phase 5 — Urgency redesign | 1 day (MVP) or 1-2 weeks (full) | same |
+| Phase 6 — Docs | 0.5 day | 0.5 day |
+| **Total** | **~35-50 days sequential** | **~28-40 days with parallel branches** |
+
+Calling it ~10-12 work-weeks if executed full-time without context switches. Realistic timeline if Pepper-driven priorities continue to interleave: 3-4 calendar months.
+
+## Decision points for Jeff
+
+These are places where this roadmap takes a position that you may want to override:
+
+1. **Phase 0 first or Phase 1 first?** This roadmap puts Phase 0 first because the wins are immediate and the cost is small. If you'd rather see the user-facing bugs (#35, #33) addressed before any other work, swap Phase 0 and Phase 1.
+2. **Phase 5 MVP vs full.** Defer the call until you see how often Pepper hits the urgency false-positive. If once a month, MVP. If once a week, full.
+3. **#19's depth.** Do all 5 envelope kinds at once, or ship them one at a time? Doing them all at once means a longer branch but a single review pass for the dispatch architecture; one-at-a-time means earlier shipping but multiple bridge-routing rewrites.
+4. **Webcam audit log retention after #39.** Once daemon-wide MCP audit lands, decide whether to drop the per-endpoint webcam audit (redundant) or keep it (finer-grained domain record). No urgency.
+5. **Parallel vs sequential phases.** Phases 0, 4, and 6 contain naturally parallel work. If a second contributor (or a second focused work block from you) is available, those compress meaningfully. Phases 1, 3, and 5 are sequential by their dependency graph.
+
+## Risks + contingency
+
+- **#35 might surface a fifth bug during investigation.** The handoff pipeline is the most fragile area; the 4 known bugs may not be exhaustive. Budget for a 5-7 day branch with a +2 day buffer. If a fifth bug is found, file a new issue and either bundle into the same PR (if related) or a follow-up PR (if independent).
+- **#19's schema design might bog down.** Cross-platform payload design (Discord vs Slack vs email) is a real rabbit hole. If schema review takes more than 2 days, ship `Reaction` + `Edit` + `Status` first (the three needed to unblock #13) and defer `DM` + `DeleteMessage` to a follow-up.
+- **Phase 2's audit infrastructure might surface unrelated bugs.** Once `tools/call` is logged, expect to find at least one "wait, that tool is being called way more than it should be" finding. Treat as bonus discoveries, file new issues, don't let them derail the audit work.
+- **Pepper-driven priorities will interleave.** The roadmap assumes focused work blocks. In reality, Pepper using the system day-to-day will surface new issues that take precedence. Build in a 20% buffer for that.
+
+## Status tracking
+
+Each phase's status is tracked here. Update as work lands.
+
+| Phase | Status | Started | Completed | Notes |
+|---|---|---|---|---|
+| 0 — Quick wins | ⬜ Not started | — | — | |
+| 1 — Reliability bugs | ⬜ Not started | — | — | |
+| 2 — Observability | ⬜ Not started | — | — | |
+| 3 — UX | ⬜ Not started | — | — | |
+| 4 — Bus reliability | ⬜ Not started | — | — | |
+| 5 — Urgency redesign | ⬜ Not started | — | — | |
+| 6 — Docs | ⬜ Not started | — | — | |
+
+## Related
+
+- Repo issue tracker: https://github.com/jeffrichley/agent_core/issues (open issues as of 2026-05-07)
+- Strategic vision: `docs/ROADMAP.md`
+- Deferred design items: `docs/BACKLOG.md`
+- Per-feature plans: `docs/superpowers/plans/`
+- Recent shipped work: 2026-05-06 cutover (`docs/cutover/pepper-flip-2026-05-06.md`), 2026-05-07 webcam (PR #40)

--- a/docs/superpowers/specs/2026-05-07-issue-44-handoff-worker-tail-fail-loud-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-44-handoff-worker-tail-fail-loud-design.md
@@ -1,0 +1,191 @@
+# Issue #44 — Handoff worker: bounded tail read + loud failure (Design)
+
+> **Status:** Approved 2026-05-07. Ready for implementation plan.
+>
+> **Issue:** [#44](https://github.com/jeffrichley/agent_core/issues/44) — Handoff worker silent fallback stub on oversized transcripts.
+>
+> **Parent:** [#35](https://github.com/jeffrichley/agent_core/issues/35) — handoff pipeline reliability tracker.
+>
+> **Roadmap:** Phase 1 of `docs/superpowers/plans/2026-05-07-open-issues-cleanup-roadmap.md`.
+
+## Problem
+
+`HandoffJobsEndpoint`'s worker (`packages/core/src/agent_core/endpoints/handoff_jobs.py`) has two coupled defects:
+
+1. `_read_transcript_text()` reads the entire transcript file unconditionally. Pepper's 18 MB transcript (≈4-5M tokens) caused the bundled `claude_agent_sdk.query()` subprocess to exit code 1.
+2. `_extract_handoff()` catches every exception, generates a 268-byte fallback stub, and the worker writes status `state: "ready"` with the stub. Status consumers see "ready" but content is meaningless.
+
+Net effect: every long-running agent silently produces stub handoffs presented as fresh.
+
+The `HandoffInjector` consumer (`hooks/tools/handoff_injector.py:125-152`) already handles `state: "failed"` correctly — it labels the existing `handoff.md` as "last-known-good from an earlier successful cycle" and points the agent at `MEMORY.md` / dailies as ground truth. The architecture is sound; only the worker lies about status.
+
+## Out of scope
+
+- Idempotency-key fix (separate issue: [#42](https://github.com/jeffrichley/agent_core/issues/42)).
+- Persisting `_idempotency_index` (separate issue: [#43](https://github.com/jeffrichley/agent_core/issues/43)).
+- SessionEnd hook investigation (separate issue: [#45](https://github.com/jeffrichley/agent_core/issues/45)).
+- Changing the summarization prompt or SDK / model.
+- Cost tracking, rate limiting, queue throttling.
+- User-configurable tail sizes via yaml. Defaults baked in via constructor params; override possible but no schema work.
+
+## Design
+
+### Tail-read helper
+
+New module-level function in `handoff_jobs.py`:
+
+```python
+def _read_transcript_tail(
+    transcript_path: Path,
+    *,
+    max_bytes: int = 256 * 1024,
+    max_messages: int = 200,
+) -> str:
+    """Return the tail of a jsonl transcript, line-aligned, capped both ways."""
+```
+
+Behavior:
+- File ≤ `max_bytes` → return whole file.
+- File > `max_bytes` → seek to `file_size - max_bytes`, read to end, drop the first partial line (always — guarantees jsonl validity at the seam).
+- After byte tail, if line count > `max_messages`, drop earliest lines until at threshold.
+
+Constructor adds two params:
+
+```python
+def __init__(
+    self,
+    *,
+    name: str,
+    mount: str = "/internal/handoff-jobs",
+    max_attempts: int = 3,
+    retry_backoff_seconds: float = 0.25,
+    transcript_tail_max_bytes: int = 256 * 1024,
+    transcript_tail_max_messages: int = 200,
+    jobs_log_dir: Path | None = None,  # see Stderr capture
+):
+```
+
+### Worker simplification
+
+`_extract_handoff()` collapses to:
+
+```python
+async def _extract_handoff(
+    self, req: HandoffJobRequest, transcript_text: str, job_id: str
+) -> str:
+    response_text = await self._call_agent_sdk(
+        req=req, transcript_text=transcript_text, job_id=job_id,
+    )
+    if response_text.strip():
+        return response_text
+    raise RuntimeError("empty handoff extraction")
+```
+
+The outer `try/except` and fallback stub generation are gone. Exceptions propagate to `_process_job`'s `for attempt in range(...)` retry loop (current line 191-219), which already retries up to `_max_attempts` then calls `_write_failed(...)` with the captured error text. **No change to `_process_job`'s control flow.**
+
+`_process_job`'s call to `_read_transcript_text` swaps to `_read_transcript_tail` with the new constructor params threaded through.
+
+### Stderr capture
+
+Wrap `_call_agent_sdk()` so the SDK's exception is captured *with* whatever stderr we can extract before re-raising:
+
+```python
+async def _call_agent_sdk(
+    self, *, req: HandoffJobRequest, transcript_text: str, job_id: str,
+) -> str:
+    try:
+        # existing query logic unchanged
+        ...
+        return response_text
+    except Exception as exc:
+        stderr_text = self._capture_subprocess_stderr(exc)  # best-effort
+        job_log_path = self._jobs_log_dir / f"{job_id}.log"
+        job_log_path.parent.mkdir(parents=True, exist_ok=True)
+        job_log_path.write_text(stderr_text, encoding="utf-8")
+        log.error(
+            "handoff job %s SDK call failed; full stderr at %s: %s",
+            job_id, job_log_path, str(exc)[:500],
+        )
+        summary = self._summarize_stderr(stderr_text, max_chars=500)
+        raise RuntimeError(f"summarizer failed: {summary}") from exc
+```
+
+Two helpers:
+
+- **`_capture_subprocess_stderr(exc)`** — best-effort. Walks `exc.__cause__` chain and `str(exc)` for subprocess output. The bundled SDK's exception type may carry it; we extract what we can. Falls back to `repr(exc)` if nothing structured.
+- **`_summarize_stderr(text, max_chars)`** — first non-empty line + last non-empty line, joined with `" ... "` if truncation needed, capped at `max_chars` (default 500).
+
+`_jobs_log_dir`: new instance attribute, defaults to `Path("~/.agent-core/handoffs/jobs").expanduser()`. Constructor param so tests can inject a temp dir.
+
+### Three stderr destinations
+
+| Destination | Content | Lifetime |
+|---|---|---|
+| Status file's `error` field | Truncated summary (≤ 500 chars) | Survives daemon restart; visible to injector → agent |
+| Daemon log | One-line `log.error(...)` with path to per-job log | Ephemeral (rotates with logs) |
+| `~/.agent-core/handoffs/jobs/<job_id>.log` | Full captured stderr | Survives daemon restart; debuggable later |
+
+## Tests
+
+All new tests in `packages/core/tests/test_handoff_jobs_endpoint.py` (existing file).
+
+### Tail-read helper
+
+- `test_read_transcript_tail_returns_whole_file_when_small`
+- `test_read_transcript_tail_caps_by_bytes_aligned_to_newline`
+- `test_read_transcript_tail_caps_by_message_count`
+- `test_read_transcript_tail_drops_partial_first_line_after_byte_seek`
+- `test_read_transcript_tail_handles_empty_file`
+- `test_read_transcript_tail_handles_file_with_no_trailing_newline`
+
+### Worker behavior
+
+- `test_handoff_worker_uses_tail_for_oversized_transcripts` — 50 MB fake transcript; assert SDK receives ≤ tail size.
+- `test_handoff_worker_marks_failed_when_sdk_raises` — mock SDK raises; status `state: "failed"`, never `ready`.
+- `test_handoff_worker_does_not_overwrite_handoff_md_when_failed` — pre-write a real `handoff.md`; SDK fails; assert `handoff.md` unchanged byte-for-byte.
+- `test_handoff_worker_writes_per_job_log_on_sdk_failure` — `<jobs_dir>/<job_id>.log` exists with captured stderr.
+- `test_handoff_worker_truncates_stderr_in_status_error_field` — status `error` ≤ 500 chars.
+- `test_handoff_worker_succeeds_on_small_transcript` — golden-path regression coverage.
+
+### Test discipline
+
+TDD — failing tests as the first commit, fixes in subsequent commits. Matches the roadmap's recommendation for Phase 1.
+
+## Files touched
+
+- `packages/core/src/agent_core/endpoints/handoff_jobs.py` — primary changes.
+- `packages/core/tests/test_handoff_jobs_endpoint.py` — new tests.
+
+No schema changes. No yaml changes. No new dependencies.
+
+## Acceptance criteria
+
+1. Worker reads at most `transcript_tail_max_bytes` / `transcript_tail_max_messages` from transcript regardless of file size.
+2. SDK summarization failure → status `state: "failed"`, never `ready`.
+3. `handoff.md` is never overwritten when summarization fails.
+4. Per-job log file lands at `~/.agent-core/handoffs/jobs/<job_id>.log` with subprocess stderr.
+5. Status file's `error` field is informative (not "Check stderr output for details") and ≤ 500 chars.
+6. Daemon log line includes path to per-job log file for live debugging.
+7. All new tests pass; existing tests still pass.
+8. Manual verification: a real `/exit` from a `--continue` Pepper session produces either (a) a real `handoff.md` with current content, or (b) a status file showing `failed` with real error info — never a fresh stub marked `ready`.
+
+## Verification step (closes #45 if successful)
+
+After this lands, do a clean experiment:
+
+1. Start a `--continue` session with non-trivial conversation activity.
+2. `/exit`.
+3. Check daemon log / audit feed for an inbound POST to `/internal/handoff-jobs`.
+4. Check `handoff.md` for fresh, real content (or a `failed` status with real error).
+
+If POST hits and handoff produces real content → [#45](https://github.com/jeffrichley/agent_core/issues/45) closes as "investigated, no bug." If no POST hits → [#45](https://github.com/jeffrichley/agent_core/issues/45) stays open and we redesign trigger surface.
+
+## Branch
+
+`fix/issue-44-handoff-worker-tail-fail-loud`
+
+## Risks
+
+- **`_capture_subprocess_stderr` is best-effort.** The bundled `claude_agent_sdk` exception type may not carry stderr in a structured way; we may end up with `repr(exc)` for some failure modes. That's still strictly better than today's "Check stderr output for details" — and the per-job log file at minimum captures what Python sees.
+- **Tail-read could miss context for very chatty short windows.** A burst of 200+ small messages within a minute could push out useful earlier context. Mitigation: the byte cap is the primary bound; the message cap is a safety net for the inverse case (one massive tool_result message).
+- **The `claude_agent_sdk` subprocess may still fail on the tail** if the prompt + tail still exceeds the model's context window. This is correct behavior — fail loudly, status reflects it, agent reads `failed` injector branch.

--- a/packages/core/src/agent_core/endpoints/handoff_jobs.py
+++ b/packages/core/src/agent_core/endpoints/handoff_jobs.py
@@ -417,6 +417,55 @@ Transcript:
 
     # ---- Status + filesystem helpers ----
     @staticmethod
+    def _summarize_stderr(text: str, *, max_chars: int = 500) -> str:
+        """Return a short summary of stderr text capped at ``max_chars``.
+
+        Uses the first and last non-empty lines, joined with " ... " when the
+        full text would exceed the cap. Returns the full text untruncated when
+        it already fits.
+        """
+        if not text:
+            return ""
+        non_empty = [ln.strip() for ln in text.split("\n") if ln.strip()]
+        if not non_empty:
+            return text[:max_chars]
+        if len(text) <= max_chars:
+            return text
+        first = non_empty[0]
+        last = non_empty[-1] if len(non_empty) > 1 else ""
+        if not last or first == last:
+            return first[:max_chars]
+        sep = " ... "
+        # Reserve room for separator and last line; truncate first if needed.
+        budget = max_chars - len(sep) - len(last)
+        if budget <= 0:
+            # last line alone is too long; fall back to truncated first line
+            return first[:max_chars]
+        return f"{first[:budget]}{sep}{last}"
+
+    @staticmethod
+    def _capture_subprocess_stderr(exc: BaseException) -> str:
+        """Best-effort extraction of subprocess stderr from an exception.
+
+        Walks the ``__cause__`` chain looking for messages that mention stderr
+        or subprocess exit. Falls back to ``repr(exc)`` when nothing structured
+        is found.
+        """
+        parts: list[str] = []
+        seen: set[int] = set()
+        current: BaseException | None = exc
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            msg = str(current)
+            if msg:
+                parts.append(msg)
+            current = current.__cause__ or current.__context__
+
+        if parts:
+            return "\n".join(parts)
+        return repr(exc)
+
+    @staticmethod
     def _resolve_under_root(
         path_value: str, root: Path, *, root_label: str = "vault_root"
     ) -> Path:

--- a/packages/core/src/agent_core/endpoints/handoff_jobs.py
+++ b/packages/core/src/agent_core/endpoints/handoff_jobs.py
@@ -71,6 +71,10 @@ def _read_transcript_tail(
         nl_index = tail_bytes.find(b"\n")
         if nl_index >= 0:
             tail_bytes = tail_bytes[nl_index + 1:]
+        # Strict decode is correct after the nl_index+1 skip: bytes start at a
+        # clean line boundary (0x0a is single-byte ASCII, never a UTF-8
+        # continuation byte). Invalid UTF-8 propagates as UnicodeDecodeError →
+        # _write_failed (correct loud-failure behavior, not silent corruption).
         text = tail_bytes.decode("utf-8")
 
     # Normalize line endings to \n (handles Windows CRLF line endings).

--- a/packages/core/src/agent_core/endpoints/handoff_jobs.py
+++ b/packages/core/src/agent_core/endpoints/handoff_jobs.py
@@ -257,7 +257,9 @@ class HandoffJobsEndpoint:
                     max_bytes=self._transcript_tail_max_bytes,
                     max_messages=self._transcript_tail_max_messages,
                 )
-                handoff_content = await self._extract_handoff(req, transcript_text)
+                handoff_content = await self._extract_handoff(
+                    req, transcript_text, job.job_id,
+                )
                 normalized_handoff = handoff_content.rstrip() + "\n"
                 self._atomic_write(handoff_path, normalized_handoff)
                 sha = hashlib.sha256(normalized_handoff.encode("utf-8")).hexdigest()
@@ -300,9 +302,13 @@ class HandoffJobsEndpoint:
             error=error_text,
         )
 
-    async def _extract_handoff(self, req: HandoffJobRequest, transcript_text: str) -> str:
+    async def _extract_handoff(
+        self, req: HandoffJobRequest, transcript_text: str, job_id: str
+    ) -> str:
         try:
-            response_text = await self._call_agent_sdk(req=req, transcript_text=transcript_text)
+            response_text = await self._call_agent_sdk(
+                req=req, transcript_text=transcript_text, job_id=job_id,
+            )
             if response_text.strip():
                 return response_text
             raise RuntimeError("empty handoff extraction")
@@ -316,7 +322,34 @@ class HandoffJobsEndpoint:
                 f"Extraction fallback used: {exc}"
             )
 
-    async def _call_agent_sdk(self, *, req: HandoffJobRequest, transcript_text: str) -> str:
+    async def _call_agent_sdk(
+        self, *, req: HandoffJobRequest, transcript_text: str, job_id: str
+    ) -> str:
+        """Run the SDK summarizer; capture stderr to per-job log on failure."""
+        try:
+            return await self._run_sdk_query(req=req, transcript_text=transcript_text)
+        except Exception as exc:
+            stderr_text = self._capture_subprocess_stderr(exc)
+            job_log_path = self._jobs_log_dir / f"{job_id}.log"
+            try:
+                job_log_path.parent.mkdir(parents=True, exist_ok=True)
+                job_log_path.write_text(stderr_text, encoding="utf-8")
+            except OSError:
+                log.exception(
+                    "failed to write per-job log for handoff job %s at %s",
+                    job_id, job_log_path,
+                )
+            log.error(
+                "handoff job %s SDK call failed; full stderr at %s: %s",
+                job_id, job_log_path, str(exc)[:500],
+            )
+            summary = self._summarize_stderr(stderr_text, max_chars=500)
+            raise RuntimeError(f"summarizer failed: {summary}") from exc
+
+    async def _run_sdk_query(
+        self, *, req: HandoffJobRequest, transcript_text: str
+    ) -> str:
+        """Inner SDK invocation. Tests monkeypatch this; the outer wrapper still runs."""
         from claude_agent_sdk import (
             AssistantMessage,
             ClaudeAgentOptions,

--- a/packages/core/src/agent_core/endpoints/handoff_jobs.py
+++ b/packages/core/src/agent_core/endpoints/handoff_jobs.py
@@ -71,7 +71,7 @@ def _read_transcript_tail(
         nl_index = tail_bytes.find(b"\n")
         if nl_index >= 0:
             tail_bytes = tail_bytes[nl_index + 1:]
-        text = tail_bytes.decode("utf-8", errors="replace")
+        text = tail_bytes.decode("utf-8")
 
     # Normalize line endings to \n (handles Windows CRLF line endings).
     text = text.replace("\r\n", "\n")

--- a/packages/core/src/agent_core/endpoints/handoff_jobs.py
+++ b/packages/core/src/agent_core/endpoints/handoff_jobs.py
@@ -40,6 +40,59 @@ def _default_transcript_root() -> str:
     return str(Path.home() / ".claude" / "projects")
 
 
+def _read_transcript_tail(
+    transcript_path: Path,
+    *,
+    max_bytes: int = 256 * 1024,
+    max_messages: int = 200,
+) -> str:
+    """Return the tail of a jsonl transcript, line-aligned and capped both ways.
+
+    For files at or below ``max_bytes`` returns the full file. For larger
+    files seeks ``max_bytes`` from the end, drops the first (potentially
+    partial) line, and additionally caps to the last ``max_messages`` lines
+    if the byte tail still exceeds that count.
+    """
+    if not transcript_path.exists():
+        raise FileNotFoundError(f"transcript does not exist: {transcript_path}")
+
+    file_size = transcript_path.stat().st_size
+    if file_size == 0:
+        return ""
+
+    if file_size <= max_bytes:
+        text = transcript_path.read_text(encoding="utf-8")
+    else:
+        with transcript_path.open("rb") as fh:
+            fh.seek(file_size - max_bytes)
+            tail_bytes = fh.read()
+        # Drop the partial first line (always — even if the seek happened to
+        # land on a newline, the next byte starts a new line cleanly).
+        nl_index = tail_bytes.find(b"\n")
+        if nl_index >= 0:
+            tail_bytes = tail_bytes[nl_index + 1:]
+        text = tail_bytes.decode("utf-8", errors="replace")
+
+    # Normalize line endings to \n (handles Windows CRLF line endings).
+    text = text.replace("\r\n", "\n")
+
+    # Cap by message count (line count) if needed.
+    lines = text.split("\n")
+    # ``split`` produces a trailing empty string when text ends with newline;
+    # treat empty trailing entry as a sentinel rather than a message.
+    has_trailing_newline = text.endswith("\n")
+    if has_trailing_newline:
+        lines = lines[:-1]
+
+    if len(lines) > max_messages:
+        lines = lines[-max_messages:]
+
+    result = "\n".join(lines)
+    if has_trailing_newline and result:
+        result += "\n"
+    return result
+
+
 class HandoffJobRequest(BaseModel):
     session_id: str = Field(min_length=1)
     event: Literal["SessionEnd", "PreCompact"]

--- a/packages/core/src/agent_core/endpoints/handoff_jobs.py
+++ b/packages/core/src/agent_core/endpoints/handoff_jobs.py
@@ -134,11 +134,21 @@ class HandoffJobsEndpoint:
         mount: str = "/internal/handoff-jobs",
         max_attempts: int = 3,
         retry_backoff_seconds: float = 0.25,
+        transcript_tail_max_bytes: int = 256 * 1024,
+        transcript_tail_max_messages: int = 200,
+        jobs_log_dir: Path | None = None,
     ):
         self.name = name
         self.mount = mount
         self._max_attempts = max(1, max_attempts)
         self._retry_backoff_seconds = max(0.0, retry_backoff_seconds)
+        self._transcript_tail_max_bytes = max(1, transcript_tail_max_bytes)
+        self._transcript_tail_max_messages = max(1, transcript_tail_max_messages)
+        self._jobs_log_dir = (
+            jobs_log_dir
+            if jobs_log_dir is not None
+            else Path("~/.agent-core/handoffs/jobs").expanduser()
+        )
         self._handle: BusHandle | None = None
         self._jobs: asyncio.Queue[_QueuedJob] = asyncio.Queue()
         self._worker_task: asyncio.Task[None] | None = None
@@ -243,7 +253,11 @@ class HandoffJobsEndpoint:
         last_error: Exception | None = None
         for attempt in range(1, self._max_attempts + 1):
             try:
-                transcript_text = self._read_transcript_text(transcript_path)
+                transcript_text = _read_transcript_tail(
+                    transcript_path,
+                    max_bytes=self._transcript_tail_max_bytes,
+                    max_messages=self._transcript_tail_max_messages,
+                )
                 handoff_content = await self._extract_handoff(req, transcript_text)
                 normalized_handoff = handoff_content.rstrip() + "\n"
                 self._atomic_write(handoff_path, normalized_handoff)
@@ -286,12 +300,6 @@ class HandoffJobsEndpoint:
             handoff_status_path=status_path,
             error=error_text,
         )
-
-    @staticmethod
-    def _read_transcript_text(transcript_path: Path) -> str:
-        if not transcript_path.exists():
-            raise FileNotFoundError(f"transcript does not exist: {transcript_path}")
-        return transcript_path.read_text(encoding="utf-8")
 
     async def _extract_handoff(self, req: HandoffJobRequest, transcript_text: str) -> str:
         try:

--- a/packages/core/src/agent_core/endpoints/handoff_jobs.py
+++ b/packages/core/src/agent_core/endpoints/handoff_jobs.py
@@ -305,22 +305,12 @@ class HandoffJobsEndpoint:
     async def _extract_handoff(
         self, req: HandoffJobRequest, transcript_text: str, job_id: str
     ) -> str:
-        try:
-            response_text = await self._call_agent_sdk(
-                req=req, transcript_text=transcript_text, job_id=job_id,
-            )
-            if response_text.strip():
-                return response_text
-            raise RuntimeError("empty handoff extraction")
-        except Exception as exc:
-            generated_at = datetime.now(UTC).isoformat()
-            return (
-                f"# Handoff ({req.agent_name})\n\n"
-                f"- session_id: {req.session_id}\n"
-                f"- event: {req.event}\n"
-                f"- generated_at: {generated_at}\n\n"
-                f"Extraction fallback used: {exc}"
-            )
+        response_text = await self._call_agent_sdk(
+            req=req, transcript_text=transcript_text, job_id=job_id,
+        )
+        if response_text.strip():
+            return response_text
+        raise RuntimeError("empty handoff extraction")
 
     async def _call_agent_sdk(
         self, *, req: HandoffJobRequest, transcript_text: str, job_id: str

--- a/packages/core/src/agent_core/endpoints/handoff_jobs.py
+++ b/packages/core/src/agent_core/endpoints/handoff_jobs.py
@@ -136,7 +136,7 @@ class HandoffJobsEndpoint:
         retry_backoff_seconds: float = 0.25,
         transcript_tail_max_bytes: int = 256 * 1024,
         transcript_tail_max_messages: int = 200,
-        jobs_log_dir: Path | None = None,
+        jobs_log_dir: str | Path | None = None,
     ):
         self.name = name
         self.mount = mount
@@ -144,11 +144,10 @@ class HandoffJobsEndpoint:
         self._retry_backoff_seconds = max(0.0, retry_backoff_seconds)
         self._transcript_tail_max_bytes = max(1, transcript_tail_max_bytes)
         self._transcript_tail_max_messages = max(1, transcript_tail_max_messages)
-        self._jobs_log_dir = (
-            jobs_log_dir
-            if jobs_log_dir is not None
-            else Path("~/.agent-core/handoffs/jobs").expanduser()
-        )
+        if jobs_log_dir is not None:
+            self._jobs_log_dir = Path(jobs_log_dir).expanduser()
+        else:
+            self._jobs_log_dir = Path("~/.agent-core/handoffs/jobs").expanduser()
         self._handle: BusHandle | None = None
         self._jobs: asyncio.Queue[_QueuedJob] = asyncio.Queue()
         self._worker_task: asyncio.Task[None] | None = None

--- a/packages/core/tests/test_handoff_enqueue_integration.py
+++ b/packages/core/tests/test_handoff_enqueue_integration.py
@@ -52,7 +52,7 @@ endpoints:
         await bus.start()
         try:
             endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
-            async def _fake_extract(self, req, transcript_text):
+            async def _fake_extract(self, req, transcript_text, job_id):
                 return "# Handoff\n"
 
             # Must restore after the test — ``setattr`` on the class leaks across the

--- a/packages/core/tests/test_handoff_jobs_endpoint.py
+++ b/packages/core/tests/test_handoff_jobs_endpoint.py
@@ -827,3 +827,47 @@ endpoints:
     finally:
         await http_host.stop()
 
+
+def test_summarize_stderr_returns_full_text_when_short():
+    text = "first line\nlast line"
+    result = HandoffJobsEndpoint._summarize_stderr(text, max_chars=500)
+    assert "first line" in result
+    assert "last line" in result
+
+
+def test_summarize_stderr_truncates_with_ellipsis_when_long():
+    long_middle = "middle\n" * 1000
+    text = f"first line\n{long_middle}last line"
+    result = HandoffJobsEndpoint._summarize_stderr(text, max_chars=80)
+    assert len(result) <= 80
+    assert "first line" in result
+    assert "last line" in result
+    assert "..." in result
+
+
+def test_summarize_stderr_skips_empty_lines():
+    text = "\n\nfirst real line\n\n\nlast real line\n\n"
+    result = HandoffJobsEndpoint._summarize_stderr(text, max_chars=500)
+    assert "first real line" in result
+    assert "last real line" in result
+
+
+def test_summarize_stderr_handles_empty_input():
+    result = HandoffJobsEndpoint._summarize_stderr("", max_chars=500)
+    assert result == ""
+
+
+def test_capture_subprocess_stderr_extracts_from_chained_exception():
+    inner = RuntimeError("subprocess died: file too large")
+    outer = RuntimeError("Command failed with exit code 1")
+    outer.__cause__ = inner
+    result = HandoffJobsEndpoint._capture_subprocess_stderr(outer)
+    assert "file too large" in result or "subprocess died" in result
+
+
+def test_capture_subprocess_stderr_falls_back_to_repr_when_no_chain():
+    exc = ValueError("nothing structured here")
+    result = HandoffJobsEndpoint._capture_subprocess_stderr(exc)
+    assert result
+    assert "nothing structured here" in result
+

--- a/packages/core/tests/test_handoff_jobs_endpoint.py
+++ b/packages/core/tests/test_handoff_jobs_endpoint.py
@@ -56,7 +56,7 @@ endpoints:
         await bus.start()
         try:
             endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
-            async def _fake_extract(self, req, transcript_text):
+            async def _fake_extract(self, req, transcript_text, job_id):
                 return "# Handoff\n"
             monkeypatch.setattr(
                 type(endpoint),
@@ -159,7 +159,7 @@ endpoints:
         await bus.start()
         try:
             endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
-            async def _fake_extract(self, req, transcript_text):
+            async def _fake_extract(self, req, transcript_text, job_id):
                 return extracted
             monkeypatch.setattr(
                 type(endpoint),
@@ -295,7 +295,7 @@ endpoints:
         try:
             endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
 
-            async def _fake_extract(self, req, transcript_text):
+            async def _fake_extract(self, req, transcript_text, job_id):
                 return "# Handoff\n"
 
             monkeypatch.setattr(type(endpoint), "_extract_handoff", _fake_extract)
@@ -404,7 +404,7 @@ endpoints:
         try:
             endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
 
-            async def _fake_extract(self, req, transcript_text):
+            async def _fake_extract(self, req, transcript_text, job_id):
                 return "# Handoff\n"
 
             monkeypatch.setattr(type(endpoint), "_extract_handoff", _fake_extract)
@@ -542,12 +542,12 @@ async def test_extract_handoff_success_uses_model_output(monkeypatch):
     )
     expected = "# Handoff Note\n\n- extracted: yes"
 
-    async def _fake_call(self, *, req, transcript_text):
+    async def _fake_call(self, *, req, transcript_text, job_id):
         return expected
 
     monkeypatch.setattr(HandoffJobsEndpoint, "_call_agent_sdk", _fake_call)
 
-    actual = await endpoint._extract_handoff(req, "transcript text")
+    actual = await endpoint._extract_handoff(req, "transcript text", "test-job-id")
     assert actual == expected
 
 
@@ -570,7 +570,7 @@ async def test_extract_handoff_fallback_on_exception(monkeypatch):
 
     monkeypatch.setattr(HandoffJobsEndpoint, "_call_agent_sdk", _raise)
 
-    fallback = await endpoint._extract_handoff(req, "transcript text")
+    fallback = await endpoint._extract_handoff(req, "transcript text", "test-job-id")
     assert fallback.startswith("# Handoff (pepper)")
     assert "- session_id: session-fallback" in fallback
     assert "- event: PreCompact" in fallback
@@ -611,7 +611,7 @@ endpoints:
 
     attempts = {"count": 0}
 
-    async def always_fail_extract(self, req, transcript_text):
+    async def always_fail_extract(self, req, transcript_text, job_id):
         attempts["count"] += 1
         raise RuntimeError("forced extract failure")
 
@@ -870,4 +870,88 @@ def test_capture_subprocess_stderr_falls_back_to_repr_when_no_chain():
     result = HandoffJobsEndpoint._capture_subprocess_stderr(exc)
     assert result
     assert "nothing structured here" in result
+
+
+@pytest.mark.asyncio
+async def test_handoff_worker_writes_per_job_log_on_sdk_failure(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_root = tmp_path / "claude_projects"
+    transcript_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = transcript_root / "session-fail.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hello"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+    jobs_log_dir = tmp_path / "jobs_logs"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+      jobs_log_dir: {jobs_log_dir}
+      retry_backoff_seconds: 0.0
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+
+            async def _failing_inner(self, *, req, transcript_text):
+                inner = RuntimeError("subprocess stderr: transcript too large")
+                outer = RuntimeError("Command failed with exit code 1")
+                outer.__cause__ = inner
+                raise outer
+
+            monkeypatch.setattr(type(endpoint), "_run_sdk_query", _failing_inner)
+
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-fail",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "transcript_root": str(transcript_root),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
+
+            for _ in range(40):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state in ("ready", "failed"):
+                        break
+                await asyncio.sleep(0.05)
+
+            log_file = jobs_log_dir / f"{job_id}.log"
+            assert log_file.exists(), f"per-job log not written at {log_file}"
+            log_content = log_file.read_text(encoding="utf-8")
+            assert "transcript too large" in log_content or "exit code 1" in log_content
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
 

--- a/packages/core/tests/test_handoff_jobs_endpoint.py
+++ b/packages/core/tests/test_handoff_jobs_endpoint.py
@@ -552,10 +552,10 @@ async def test_extract_handoff_success_uses_model_output(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_extract_handoff_fallback_on_exception(monkeypatch):
+async def test_extract_handoff_propagates_exception_on_sdk_failure(monkeypatch):
     endpoint = HandoffJobsEndpoint(name="handoff-jobs")
     req = HandoffJobRequest(
-        session_id="session-fallback",
+        session_id="session-propagate",
         event="PreCompact",
         agent_name="pepper",
         vault_root="/vault",
@@ -570,11 +570,8 @@ async def test_extract_handoff_fallback_on_exception(monkeypatch):
 
     monkeypatch.setattr(HandoffJobsEndpoint, "_call_agent_sdk", _raise)
 
-    fallback = await endpoint._extract_handoff(req, "transcript text", "test-job-id")
-    assert fallback.startswith("# Handoff (pepper)")
-    assert "- session_id: session-fallback" in fallback
-    assert "- event: PreCompact" in fallback
-    assert "Extraction fallback used: sdk boom" in fallback
+    with pytest.raises(RuntimeError, match="sdk boom"):
+        await endpoint._extract_handoff(req, "transcript text", "test-job-id")
 
 
 @pytest.mark.asyncio
@@ -870,6 +867,246 @@ def test_capture_subprocess_stderr_falls_back_to_repr_when_no_chain():
     result = HandoffJobsEndpoint._capture_subprocess_stderr(exc)
     assert result
     assert "nothing structured here" in result
+
+
+@pytest.mark.asyncio
+async def test_handoff_worker_marks_failed_when_sdk_raises(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_root = tmp_path / "claude_projects"
+    transcript_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = transcript_root / "session-marked.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hi"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+      retry_backoff_seconds: 0.0
+      jobs_log_dir: {tmp_path / "jobs_logs"}
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+
+            async def _always_fail(self, *, req, transcript_text):
+                raise RuntimeError("subprocess stderr: kaboom")
+
+            monkeypatch.setattr(type(endpoint), "_run_sdk_query", _always_fail)
+
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-marked",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "transcript_root": str(transcript_root),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+
+            for _ in range(60):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state in ("ready", "failed"):
+                        break
+                await asyncio.sleep(0.05)
+
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+            assert status["state"] == "failed"
+            assert status.get("error")
+            assert "kaboom" in status["error"] or "summarizer failed" in status["error"]
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
+
+
+@pytest.mark.asyncio
+async def test_handoff_worker_does_not_overwrite_handoff_md_when_failed(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_root = tmp_path / "claude_projects"
+    transcript_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = transcript_root / "session-preserve.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hi"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+
+    pre_existing = "# Last good handoff\n\n- session: prior\n- decision: keep this content\n"
+    handoff_path.write_text(pre_existing, encoding="utf-8")
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+      retry_backoff_seconds: 0.0
+      jobs_log_dir: {tmp_path / "jobs_logs"}
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+
+            async def _always_fail(self, *, req, transcript_text):
+                raise RuntimeError("subprocess stderr: kaboom")
+
+            monkeypatch.setattr(type(endpoint), "_run_sdk_query", _always_fail)
+
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-preserve",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "transcript_root": str(transcript_root),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+
+            for _ in range(60):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state in ("ready", "failed"):
+                        break
+                await asyncio.sleep(0.05)
+
+            assert handoff_path.read_text(encoding="utf-8") == pre_existing
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
+
+
+@pytest.mark.asyncio
+async def test_handoff_worker_truncates_stderr_in_status_error_field(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_root = tmp_path / "claude_projects"
+    transcript_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = transcript_root / "session-trunc.jsonl"
+    transcript_path.write_text('{"message":{"role":"user","content":"hi"}}\n', encoding="utf-8")
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+      retry_backoff_seconds: 0.0
+      jobs_log_dir: {tmp_path / "jobs_logs"}
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+
+            huge_msg = "first line of error\n" + ("noise " * 5000) + "\nlast line of error"
+
+            async def _huge_fail(self, *, req, transcript_text):
+                raise RuntimeError(huge_msg)
+
+            monkeypatch.setattr(type(endpoint), "_run_sdk_query", _huge_fail)
+
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-trunc",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "transcript_root": str(transcript_root),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+
+            for _ in range(60):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state in ("ready", "failed"):
+                        break
+                await asyncio.sleep(0.05)
+
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+            assert status["state"] == "failed"
+            err = status["error"]
+            # Status error must be bounded — allow generous slack for outer wrapping.
+            assert len(err) <= 700
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/test_handoff_jobs_endpoint.py
+++ b/packages/core/tests/test_handoff_jobs_endpoint.py
@@ -674,3 +674,75 @@ endpoints:
     finally:
         await http_host.stop()
 
+
+import json as _json  # alias to avoid shadowing the existing top-level `json`
+
+from agent_core.endpoints.handoff_jobs import _read_transcript_tail
+
+
+def test_read_transcript_tail_returns_whole_file_when_small(tmp_path):
+    f = tmp_path / "small.jsonl"
+    content = '{"a":1}\n{"b":2}\n'
+    f.write_text(content, encoding="utf-8")
+
+    result = _read_transcript_tail(f, max_bytes=1024, max_messages=100)
+    assert result == content
+
+
+def test_read_transcript_tail_caps_by_bytes_aligned_to_newline(tmp_path):
+    f = tmp_path / "big.jsonl"
+    lines = [f'{{"i":{i},"data":"{"x" * 80}"}}' for i in range(100)]
+    content = "\n".join(lines) + "\n"
+    f.write_text(content, encoding="utf-8")
+    assert len(content.encode("utf-8")) > 1024
+
+    result = _read_transcript_tail(f, max_bytes=1024, max_messages=10000)
+
+    assert len(result.encode("utf-8")) <= 1024
+    first_line = result.split("\n", 1)[0]
+    parsed = _json.loads(first_line)
+    assert "i" in parsed
+    assert result.endswith("\n")
+
+
+def test_read_transcript_tail_caps_by_message_count(tmp_path):
+    f = tmp_path / "many.jsonl"
+    lines = [f'{{"i":{i}}}' for i in range(50)]
+    content = "\n".join(lines) + "\n"
+    f.write_text(content, encoding="utf-8")
+
+    result = _read_transcript_tail(f, max_bytes=10**9, max_messages=10)
+    result_lines = [ln for ln in result.split("\n") if ln]
+    assert len(result_lines) == 10
+    assert _json.loads(result_lines[0]) == {"i": 40}
+    assert _json.loads(result_lines[-1]) == {"i": 49}
+
+
+def test_read_transcript_tail_drops_partial_first_line_after_byte_seek(tmp_path):
+    f = tmp_path / "big.jsonl"
+    lines = [f'{{"line":{i},"x":"{"a" * 100}"}}' for i in range(20)]
+    content = "\n".join(lines) + "\n"
+    f.write_text(content, encoding="utf-8")
+
+    result = _read_transcript_tail(f, max_bytes=250, max_messages=10000)
+
+    for line in result.split("\n"):
+        if line:
+            _json.loads(line)  # raises ValueError on partial JSON
+
+
+def test_read_transcript_tail_handles_empty_file(tmp_path):
+    f = tmp_path / "empty.jsonl"
+    f.write_text("", encoding="utf-8")
+    result = _read_transcript_tail(f, max_bytes=1024, max_messages=100)
+    assert result == ""
+
+
+def test_read_transcript_tail_handles_file_with_no_trailing_newline(tmp_path):
+    f = tmp_path / "no_trail.jsonl"
+    content = '{"a":1}\n{"b":2}'
+    f.write_text(content, encoding="utf-8")
+    result = _read_transcript_tail(f, max_bytes=1024, max_messages=100)
+    assert '{"a":1}' in result
+    assert '{"b":2}' in result
+

--- a/packages/core/tests/test_handoff_jobs_endpoint.py
+++ b/packages/core/tests/test_handoff_jobs_endpoint.py
@@ -745,3 +745,85 @@ def test_read_transcript_tail_handles_file_with_no_trailing_newline(tmp_path):
     assert '{"a":1}' in result
     assert '{"b":2}' in result
 
+
+@pytest.mark.asyncio
+async def test_handoff_worker_uses_tail_for_oversized_transcripts(tmp_path, monkeypatch):
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir(parents=True, exist_ok=True)
+    transcript_root = tmp_path / "claude_projects"
+    transcript_root.mkdir(parents=True, exist_ok=True)
+    transcript_path = transcript_root / "session-tail.jsonl"
+
+    # Build a transcript larger than the tail bound so we can see truncation.
+    lines = [f'{{"i":{i},"data":"{"x" * 200}"}}\n' for i in range(2000)]
+    transcript_path.write_text("".join(lines), encoding="utf-8")
+
+    handoff_path = vault_root / "handoff.md"
+    status_path = vault_root / "handoff-status.json"
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        f"""
+bus:
+  storage_path: {tmp_path / "bus.sqlite"}
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.handoff_jobs
+    name: handoff-jobs
+    params:
+      mount: /internal/handoff-jobs
+      transcript_tail_max_bytes: 4096
+      transcript_tail_max_messages: 50
+  - type: builtin.stub
+    name: pepper
+""",
+        encoding="utf-8",
+    )
+
+    bus, http_host = await build_bus_from_config(cfg)
+    assert http_host is not None
+    await http_host.start()
+    received_lengths: list[int] = []
+    try:
+        await bus.start()
+        try:
+            endpoint = bus._endpoints_by_name["handoff-jobs"].endpoint
+
+            async def _capture_extract(self, req, transcript_text, *args, **kwargs):
+                received_lengths.append(len(transcript_text.encode("utf-8")))
+                return "# Handoff\n"
+
+            monkeypatch.setattr(type(endpoint), "_extract_handoff", _capture_extract)
+            url = f"http://127.0.0.1:{http_host.port}/internal/handoff-jobs"
+            payload = {
+                "session_id": "session-tail",
+                "event": "SessionEnd",
+                "agent_name": "pepper",
+                "vault_root": str(vault_root),
+                "handoff_path": str(handoff_path),
+                "handoff_status_path": str(status_path),
+                "transcript_path": str(transcript_path),
+                "transcript_root": str(transcript_root),
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(url, json=payload)
+            assert resp.status_code == 202
+
+            for _ in range(40):
+                if status_path.exists():
+                    state = json.loads(status_path.read_text(encoding="utf-8")).get("state")
+                    if state == "ready":
+                        break
+                await asyncio.sleep(0.05)
+
+            assert received_lengths, "_extract_handoff was not called"
+            assert received_lengths[0] <= 4096
+        finally:
+            await bus.stop()
+    finally:
+        await http_host.stop()
+

--- a/packages/core/tests/test_handoff_jobs_endpoint.py
+++ b/packages/core/tests/test_handoff_jobs_endpoint.py
@@ -1101,8 +1101,8 @@ endpoints:
             status = json.loads(status_path.read_text(encoding="utf-8"))
             assert status["state"] == "failed"
             err = status["error"]
-            # Status error must be bounded — allow generous slack for outer wrapping.
-            assert len(err) <= 700
+            # Bound: len("summarizer failed: ") + max_chars(500) = 519. Allow 1 char of slack.
+            assert len(err) <= 520
         finally:
             await bus.stop()
     finally:

--- a/packages/core/tests/test_handoff_jobs_endpoint.py
+++ b/packages/core/tests/test_handoff_jobs_endpoint.py
@@ -9,7 +9,11 @@ import pytest
 
 from agent_core.bus.envelope import EventPayload
 from agent_core.bus.runner import build_bus_from_config
-from agent_core.endpoints.handoff_jobs import HandoffJobRequest, HandoffJobsEndpoint
+from agent_core.endpoints.handoff_jobs import (
+    HandoffJobRequest,
+    HandoffJobsEndpoint,
+    _read_transcript_tail,
+)
 
 
 @pytest.mark.asyncio
@@ -675,11 +679,6 @@ endpoints:
         await http_host.stop()
 
 
-import json as _json  # alias to avoid shadowing the existing top-level `json`
-
-from agent_core.endpoints.handoff_jobs import _read_transcript_tail
-
-
 def test_read_transcript_tail_returns_whole_file_when_small(tmp_path):
     f = tmp_path / "small.jsonl"
     content = '{"a":1}\n{"b":2}\n'
@@ -700,7 +699,7 @@ def test_read_transcript_tail_caps_by_bytes_aligned_to_newline(tmp_path):
 
     assert len(result.encode("utf-8")) <= 1024
     first_line = result.split("\n", 1)[0]
-    parsed = _json.loads(first_line)
+    parsed = json.loads(first_line)
     assert "i" in parsed
     assert result.endswith("\n")
 
@@ -714,8 +713,8 @@ def test_read_transcript_tail_caps_by_message_count(tmp_path):
     result = _read_transcript_tail(f, max_bytes=10**9, max_messages=10)
     result_lines = [ln for ln in result.split("\n") if ln]
     assert len(result_lines) == 10
-    assert _json.loads(result_lines[0]) == {"i": 40}
-    assert _json.loads(result_lines[-1]) == {"i": 49}
+    assert json.loads(result_lines[0]) == {"i": 40}
+    assert json.loads(result_lines[-1]) == {"i": 49}
 
 
 def test_read_transcript_tail_drops_partial_first_line_after_byte_seek(tmp_path):
@@ -728,7 +727,7 @@ def test_read_transcript_tail_drops_partial_first_line_after_byte_seek(tmp_path)
 
     for line in result.split("\n"):
         if line:
-            _json.loads(line)  # raises ValueError on partial JSON
+            json.loads(line)  # raises ValueError on partial JSON
 
 
 def test_read_transcript_tail_handles_empty_file(tmp_path):


### PR DESCRIPTION
## Summary

Stops the handoff worker from silently writing stub handoffs marked
`state: "ready"` when the bundled Claude SDK fails on oversized
transcripts. Worker now reads only the bounded tail
(`min(256 KB, 200 messages)`); summarization failures propagate to
the existing `_write_failed` path; subprocess stderr is captured to
a per-job log file.

The `HandoffInjector` consumer already handles `state: "failed"`
correctly — labels existing `handoff.md` as last-known-good from an
earlier successful cycle and points the agent at MEMORY.md / dailies.

Closes #44.

## Spec + Plan

- Spec: `docs/superpowers/specs/2026-05-07-issue-44-handoff-worker-tail-fail-loud-design.md`
- Plan: `docs/superpowers/plans/2026-05-07-issue-44-handoff-worker-tail-fail-loud-plan.md`

## Test plan

- [x] New unit tests for `_read_transcript_tail`, `_summarize_stderr`, `_capture_subprocess_stderr`
- [x] New integration tests for tail bound, loud-failure status, no-overwrite, truncated error, per-job log
- [x] Existing `HandoffJobsEndpoint` tests still pass
- [x] Fix e2e test fixture signature (`_fake_extract` gained `job_id` param in Task 4)
- [ ] Manual verification on Pepper's real transcript (Jeff to run after merge)

## After merge

Unblocks #45 (SessionEnd-on-`--continue` investigation). A clean
`/exit` test will tell us whether the originally suspected "Bug 1"
was a real Claude Code behavior gap or a measurement artifact.