### PR TITLE
fix: wake-builder snapshot lag (#33)

### DIFF
--- a/docs/HANDOFF-2026-05-08.md
+++ b/docs/HANDOFF-2026-05-08.md
@@ -1,0 +1,101 @@
+# Handoff — agent_core, 2026-05-08
+
+> Paste this as the opening message to a new Claude Code session, or read it as the first thing in any continuation. It assumes zero prior context.
+
+## Who and where
+
+You are Claude Code helping **Jeff Richley** on the **agent_core** monorepo at `E:\workspaces\ai\agents\agent_core` (Windows 11, PowerShell + Bash via tools, repo on GitHub at `jeffrichley/agent_core`). Branch `main` is clean and pushed. Python 3.12 + `uv`. Ruff line-length 100. Tests via `uv run pytest`.
+
+**Read first** (if context allows): `CLAUDE.md` (project conventions), `docs/superpowers/plans/2026-05-07-open-issues-cleanup-roadmap.md` (the live backlog with triage + mermaid deps), and `C:\Users\jeffr\.claude\projects\E--workspaces-ai-agents-agent-core\memory\MEMORY.md` (Jeff's persistent feedback memory — load whichever entries are relevant before acting).
+
+## What just shipped
+
+Two consecutive multi-PR efforts cleared the first half of the open-issues cleanup:
+
+- **Handoff pipeline reliability** — PR #46 (#44 silent fallback), PR #47 (#42 idempotency key collision). #43 superseded by #42's content-varying key. #45 was a measurement artifact. Validated on Pepper.
+- **Observability foundation** — PR #48 (#39 daemon-wide MCP tool-call audit JSONL), PR #49 (#16 read-only bus tail / audit feed via `builtin.bus_tail_mcp` endpoint type). 47 new tests across 6 task-commits in #16; 597 total passing, ruff clean.
+
+Workflow used for both: brainstorming skill → writing-plans skill → subagent-driven-development skill (fresh subagent per task with two-stage review: spec compliance, then code quality). This pattern works — keep using it.
+
+## What's next
+
+The roadmap was rewritten 2026-05-08 from a phase-based structure (had inconsistent tables, stale issue counts) to a **red/yellow/green/gray triage**. 13 issues are open. The agreed-upon next track is the **RED tier — Pepper reliability cleanup**. Must finish RED before starting GREEN.
+
+RED tier (~4-6 days total, mostly independent):
+
+| # | Title | Cost | Order |
+|---|---|---|---|
+| **#33** | Wake-builder count + urgency_max snapshot lag (BUG) | 1-2d | **start here** — only `bug` label in the tier |
+| **#37** | tools/list_changed not emitted; clients keep stale tool cache | 0.5-1d | high day-to-day pain |
+| **#36** | Discord deny_channels blocklist | 0.5d | tiny; unblocks Discord-perms kludge |
+| **#18** | Enforce expires_at on envelopes | 1-2d | bus-side filter |
+| **#38 (MVP)** | Discord urgency sigil prefix replacement | 1d | standalone; defer full layered design |
+
+Recommended starting point: brainstorm **#33** with Jeff. Surface area is small (re-snapshot at delivery time, or attach wake metadata to envelope groups — that's the design decision he'll want to make). Then writing-plans → subagent-driven-development → PR with `Closes #33`.
+
+Outside RED, in YELLOW:
+- **#50** — EnvelopeFull state-machine fields (~30 min). Today's follow-up, captures a strict-spec gap on #16. Easy quick win when bandwidth allows.
+
+## How Jeff likes to work
+
+These are durable, drawn from saved feedback memory and observed in the recent sessions:
+
+- **Skills before action.** When the user invokes `/something` or a skill applies, use the `Skill` tool to load it before responding. Don't guess skill names — only invoke ones in the available list.
+- **Don't unilaterally punch-list.** Surface findings with severity + cost; the fix-now vs defer call is Jeff's. Don't auto-fix discovered issues mid-stream — log them, propose, let him decide. (Today's #50 is an example — surfaced from final review, logged as an issue, deferred per his call.)
+- **Brainstorming first for non-trivial work.** Use `superpowers:brainstorming` when scope isn't already nailed down. Spec → plan → execute, in that order. Don't skip to implementation.
+- **Subagent-driven for execution.** Use `superpowers:subagent-driven-development` for plans. Fresh subagent per task, two-stage review (spec compliance, then code quality). Trust implementer DONE_WITH_CONCERNS reports — they've twice now caught real plan-test bugs you'd otherwise have missed.
+- **Commit frequently as focused units.** No `Co-Authored-By` trailer in this repo (verify with `git log -3 --format='%B'`). Conventional commits (`feat(scope):`, `fix(scope):`, `docs(scope):`). Stage specific files; never `git add -A`. Don't ask permission for each commit — just make it when there's a coherent chunk done.
+- **Ask before destructive ops.** Force-push, hard reset, amending pushed commits, deleting branches, pushing to main without explicit authorization — pause and check.
+- **Test fakes mirror real strictly.** If you fake a third-party lib, the fake must refuse argument shapes the real lib would refuse. Otherwise green tests ship production bugs.
+- **No dead code in ports.** When porting code, port + rewire — don't carry code targeting soon-to-be-removed infrastructure.
+- **Pepper hands-off until proven.** Don't migrate Pepper to new architecture without explicit greenlight. Validate on a fresh test agent first.
+- **Skills install per-agent, never user-scope.** agent_core skills ship inside packages (`packages/<pkg>/src/<pkg>/skills/`) and install per-agent at init. Never write directly to `~/.claude/skills/`.
+- **Verify color-space conversions empirically.** For cv2/PIL/etc., decode raw bytes to ground-truth; don't trust docs.
+- **Dispatch subagents with context7 for non-trivial library API research.** Tell them to use the context7 MCP server, not training-data guesses.
+
+## Patterns to reuse
+
+These came out of #39 and #16 and will shape future work:
+
+- **Singleton writer + Protocol-based opt-in** (#39's `MCPAuditWriter` + `AuditWriterAwareEndpoint`). Use this when adding a daemon-wide service that endpoints can opt into.
+- **`BusHandle.persistence()` accessor** for read-only consumers of bus state. Don't add another `RunnerServices` field if persistence is already bus-internal — use the lifecycle hook the endpoint already has.
+- **Per-kind summarizer registry with drift-guard test** (`bus_tail/summaries.py`). The test that walks `EnvelopePayload.__args__` and asserts every kind has a registered summarizer is the right shape for any value-free serialization layer.
+- **`PersistenceReader` as wrapper, not extension.** Tail-specific queries live in their own module; the bus's hot-path `Persistence` API stays small.
+- **Schema-summary previews** (value-free shape per envelope kind) for any read-only debugging surface that might leak user content.
+
+## Open follow-ups (not blocking RED)
+
+- **#50** — EnvelopeFull state-machine fields (yellow tier). 30-minute fix when convenient.
+- **No test asserts Pepper/briefs don't see bus_tail tools.** Architectural protection is in place (single call site of `register_bus_tail_tools`), but a regression test would be belt-and-suspenders. Could fold into #50.
+- **Three of four runner tests in `test_bus_tail_runner.py` use the default mount.** Consider varying one to a non-default mount so explicit-yaml-mount → `http_host._mounts` wiring is end-to-end verified.
+
+## Repo guardrails
+
+- Stage specific files only (`git add path1 path2`).
+- Never use `git add -A` or `git add .`.
+- Never `git commit --amend` to a pushed commit without explicit authorization.
+- Never `git push --force` to `main` or any shared branch without explicit authorization.
+- Never use `--no-verify` to skip hooks. If a hook fails, fix the underlying issue.
+- Don't commit files that look like secrets (`.env`, `credentials.json`, `*.pem`) without explicit override.
+- Tests live under `packages/<pkg>/tests/`. Test file structure mirrors source.
+- Files use LF line endings in repo (Windows checkout uses CRLF; ignore the LF→CRLF warnings during commits).
+
+## How to start the next session
+
+If Jeff opens by saying "let's start #33" (or similar), invoke `superpowers:brainstorming` and walk through the design questions — the issue body has the surface area sketched out (re-snapshot at delivery time vs attach metadata to envelope groups). Don't skip ahead to implementation; the design choice matters.
+
+If Jeff asks "what's next?" without a specific issue, point at the RED tier and recommend starting with #33 since it's the only `bug`.
+
+If Jeff asks something tangential (a new feature, a refactor, a pepper question), invoke whichever skill matches before responding.
+
+## Memory + persistent context
+
+Jeff's auto-memory directory is at `C:\Users\jeffr\.claude\projects\E--workspaces-ai-agents-agent-core\memory\`. Skim `MEMORY.md` early in any session and let the relevant entries shape your behavior. Save new memories as situations warrant per the auto-memory rules in your system prompt.
+
+## Recent merge SHAs (for ground-truth)
+
+- `b70e247` — Merge PR #49 (#16 bus tail / audit feed)
+- `4420dcb` — docs(roadmap): rewrite as triage + dependency diagram
+- (earlier) PRs #46, #47, #48 closed in the prior week
+
+End of handoff.

--- a/docs/superpowers/plans/2026-05-08-issue-33-wake-snapshot-lag.md
+++ b/docs/superpowers/plans/2026-05-08-issue-33-wake-snapshot-lag.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** Python 3.12, asyncio, FastMCP, pytest, ruff. Branch: `fix/issue-33-wake-snapshot-lag`.
 
+**Test command:** `uv run pytest packages/core/tests packages/agent-core-channel/tests` (the bare `uv run pytest` hits a pre-existing multi-package conftest plugin-name collision unrelated to this work; this targeted command covers everything in scope and runs 615+ tests).
+
 **Spec:** `docs/superpowers/specs/2026-05-08-issue-33-wake-snapshot-lag-design.md`
 
 ---
@@ -264,7 +266,7 @@ Expected: PASS for all.
 
 - [ ] **Step 6: Run the full suite to catch any indirect breakage**
 
-Run: `uv run pytest`
+Run: `uv run pytest packages/core/tests packages/agent-core-channel/tests`
 Expected: PASS for everything that was passing before. (Some wake/snapshot tests may still be passing because of the temporary `_build_summary` shim — that's expected; Task 2 will tighten them.)
 
 - [ ] **Step 7: Commit**
@@ -480,7 +482,7 @@ Expected: PASS for all.
 
 - [ ] **Step 7: Run the full suite**
 
-Run: `uv run pytest`
+Run: `uv run pytest packages/core/tests packages/agent-core-channel/tests`
 Expected: PASS for everything except possibly `test_bus_snapshot_for_agent.py` (handled in Task 3) and `test_stdio_server.py` / `test_end_to_end_relay.py` if they assert on wake meta (handled in Task 4).
 
 - [ ] **Step 8: Commit**
@@ -539,7 +541,7 @@ Expected: PASS.
 
 - [ ] **Step 3: Run the full suite**
 
-Run: `uv run pytest`
+Run: `uv run pytest packages/core/tests packages/agent-core-channel/tests`
 Expected: PASS for everything except possibly `test_stdio_server.py` / `test_end_to_end_relay.py` (handled in Task 4).
 
 - [ ] **Step 4: Commit**
@@ -739,8 +741,8 @@ Expected: PASS.
 
 - [ ] **Step 7: Run the full suite**
 
-Run: `uv run pytest`
-Expected: PASS — should be 597+ existing tests plus the 3 new tests files (~10 new tests total).
+Run: `uv run pytest packages/core/tests packages/agent-core-channel/tests`
+Expected: PASS — should be 615+ existing tests plus the 3 new tests files (~10 new tests total).
 
 - [ ] **Step 8: Commit**
 
@@ -769,8 +771,8 @@ response."
 
 - [ ] **Step 1: Full test suite**
 
-Run: `uv run pytest`
-Expected: All tests pass. New count should be 597 (pre-existing) + ~10 new (invariant tests parametrized + drift-guard + regression) = ~607 passing.
+Run: `uv run pytest packages/core/tests packages/agent-core-channel/tests`
+Expected: All tests pass. New count should be 615 (pre-existing across core + channel) + ~10 new (invariant tests parametrized + drift-guard + regression) = ~625 passing.
 
 - [ ] **Step 2: Lint**
 
@@ -805,7 +807,7 @@ Approved by consumer (Pepper) for Option B (hybrid). Cutover validated on testbo
 
 ## Test plan
 
-- [ ] `uv run pytest` — all green
+- [ ] `uv run pytest packages/core/tests packages/agent-core-channel/tests` — all green
 - [ ] `uv run ruff check .` — clean
 - [ ] Validate on testbot: send mixed-urgency burst, confirm wake content is fixed string and list_pending meta matches items
 - [ ] Then restart Pepper to pick up new contract

--- a/docs/superpowers/plans/2026-05-08-issue-33-wake-snapshot-lag.md
+++ b/docs/superpowers/plans/2026-05-08-issue-33-wake-snapshot-lag.md
@@ -1,0 +1,830 @@
+# Issue #33 — Wake-builder snapshot lag Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the wake-vs-list_pending snapshot drift by stripping queue-state metadata from wake notifications and moving it to `list_pending`'s response, computed atomically alongside the items it describes.
+
+**Architecture:** Wake notifications become minimal: `meta` carries only `endpoint` and `fired_at`. `list_pending` returns the wrapped shape `{meta: {count, urgency_max, urgency_counts, by_sender, endpoint, fetched_at}, items: [...]}`. `Bus.snapshot_for_agent` follows the same minimal wake contract for uniformity. Race-free by construction — meta and items come from the same atomic read of `self._pending`.
+
+**Tech Stack:** Python 3.12, asyncio, FastMCP, pytest, ruff. Branch: `fix/issue-33-wake-snapshot-lag`.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-issue-33-wake-snapshot-lag-design.md`
+
+---
+
+## Task 1: Wrap `list_pending` response shape
+
+**Files:**
+- Modify: `packages/core/src/agent_core/endpoints/claude_code_mcp.py` — `_call_list_pending` (lines ~389-440), `_build_summary` (lines ~558-608)
+- Test (new): `packages/core/tests/test_list_pending_meta_invariants.py`
+- Test (modify): `packages/core/tests/test_claude_code_mcp.py`
+- Test (modify): `packages/core/tests/test_claude_code_mcp_urgency_ordering.py`
+- Test (modify): `packages/core/tests/test_claude_code_mcp_batching.py`
+
+### Steps
+
+- [ ] **Step 1: Create the failing invariant test**
+
+Create `packages/core/tests/test_list_pending_meta_invariants.py`:
+
+```python
+"""Property tests: list_pending's meta and items must agree by construction.
+
+The bug behind issue #33 was that wake-meta could disagree with list_pending.
+The fix moves meta into list_pending's response, computed from the same
+atomic read of self._pending. These tests assert that contract holds for
+varied inbox states.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agent_core.bus.core import Bus
+from agent_core.bus.envelopes import Envelope
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+
+
+def _envelope(idx: int, urgency: str = "green", from_: str = "alice", kind: str = "TextMessage") -> Envelope:
+    return Envelope(
+        from_=from_,
+        to="agent",
+        kind=kind,
+        urgency=urgency,  # type: ignore[arg-type]
+        payload={"text": f"msg{idx}"},
+    )
+
+
+@pytest.mark.parametrize(
+    "envelopes, batch_window",
+    [
+        ([], 0),
+        ([_envelope(0, "green")], 0),
+        ([_envelope(0, "red"), _envelope(1, "yellow"), _envelope(2, "green")], 0),
+        ([_envelope(0, "red"), _envelope(1, "red"), _envelope(2, "green")], 0),
+        ([_envelope(i, "green", from_="alice") for i in range(3)], 30),
+        (
+            [
+                _envelope(0, "yellow", from_="alice"),
+                _envelope(1, "yellow", from_="alice"),
+                _envelope(2, "green", from_="bob"),
+            ],
+            30,
+        ),
+    ],
+)
+def test_list_pending_meta_matches_items(envelopes: list[Envelope], batch_window: int) -> None:
+    """meta.count, urgency_max, urgency_counts, by_sender all reconstruct from items."""
+
+    async def _run() -> dict:
+        bus = Bus()
+        endpoint = ClaudeCodeMCPEndpoint(name="agent")
+        bus.register_endpoint(endpoint)
+        for env in envelopes:
+            endpoint.queue_for_pickup(env)
+        return await endpoint._call_list_pending(batch_window_seconds=batch_window)
+
+    result = asyncio.run(_run())
+
+    assert set(result.keys()) == {"meta", "items"}
+    meta = result["meta"]
+    items = result["items"]
+
+    assert meta["count"] == len(envelopes)
+    assert meta["endpoint"] == "agent"
+    assert "fetched_at" in meta
+
+    # urgency_max
+    if not envelopes:
+        assert meta["urgency_max"] == "green"
+    else:
+        order = {"red": 0, "yellow": 1, "green": 2}
+        expected_max = min((e.urgency for e in envelopes), key=lambda u: order[u])
+        assert meta["urgency_max"] == expected_max
+
+    # urgency_counts
+    counts = {"red": 0, "yellow": 0, "green": 0}
+    for e in envelopes:
+        counts[e.urgency] += 1
+    assert meta["urgency_counts"] == counts
+
+    # by_sender
+    by_sender_index = {entry["from"]: entry for entry in meta["by_sender"]}
+    sender_counts: dict[str, int] = {}
+    for e in envelopes:
+        sender_counts[e.from_] = sender_counts.get(e.from_, 0) + 1
+    for sender, expected_count in sender_counts.items():
+        assert by_sender_index[sender]["count"] == expected_count
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run: `uv run pytest packages/core/tests/test_list_pending_meta_invariants.py -v`
+Expected: FAIL (current `_call_list_pending` returns a flat list, not `{meta, items}`).
+
+- [ ] **Step 3: Refactor `_build_summary` and update `_call_list_pending`**
+
+In `packages/core/src/agent_core/endpoints/claude_code_mcp.py`, replace the existing `_build_summary` method (lines ~558-608) and `_call_list_pending` method (lines ~389-440) with:
+
+```python
+def _compute_meta(self) -> dict:
+    """Compute aggregate metadata from the current pending queue.
+
+    Reads self._pending atomically (no awaits). Used by _call_list_pending
+    so meta and items come from the same read — eliminates the wake-vs-
+    list_pending drift that caused issue #33.
+    """
+    pending = list(self._pending)
+    count = len(pending)
+    # urgency counts
+    urg_counts = Counter(e.urgency for e in pending)
+    urg_full: dict[Literal["red", "yellow", "green"], int] = {}
+    for tier in self._URGENCY_ORDER:
+        urgency_key = cast(Literal["red", "yellow", "green"], tier)
+        urg_full[urgency_key] = int(urg_counts.get(urgency_key, 0))
+    # urgency_max — highest tier present (default "green" when count == 0)
+    urgency_max = "green"
+    for tier in self._URGENCY_ORDER:
+        urgency_key = cast(Literal["red", "yellow", "green"], tier)
+        if urg_full[urgency_key] > 0:
+            urgency_max = tier
+            break
+    # by_sender
+    sender_index: dict[str, dict] = {}
+    for env in pending:
+        entry = sender_index.setdefault(env.from_, {"from": env.from_, "count": 0, "kinds": []})
+        entry["count"] += 1
+        if env.kind not in entry["kinds"]:
+            entry["kinds"].append(env.kind)
+    by_sender = list(sender_index.values())
+    return {
+        "count": count,
+        "urgency_max": urgency_max,
+        "urgency_counts": urg_full,
+        "by_sender": by_sender,
+        "endpoint": self.name,
+        "fetched_at": datetime.now(UTC).isoformat(),
+    }
+
+def _build_wake_summary(self) -> dict:
+    """Minimal wake notification — pure 'go look' signal.
+
+    Carries no queue-state metadata. The agent calls list_pending for
+    authoritative count/urgency_max/by_sender, computed atomically with
+    the items list. See issue #33.
+    """
+    return {
+        "content": f"INBOX: pending ({self.name})",
+        "meta": {
+            "endpoint": self.name,
+            "fired_at": datetime.now(UTC).isoformat(),
+        },
+    }
+```
+
+Then update `_call_list_pending` to return the wrapped shape. Replace its body (lines ~389-440) with:
+
+```python
+async def _call_list_pending(self, batch_window_seconds: int = 0) -> dict:
+    """Mailbox view sorted by urgency, optionally batched by sender.
+
+    Returns {"meta": {...}, "items": [...]}. meta carries count, urgency_max,
+    urgency_counts, by_sender, endpoint, fetched_at. items is the flat list
+    of envelope dicts (when batch_window_seconds == 0) or batched/single
+    entries (when > 0). meta and items are computed from the same atomic
+    read of self._pending — see issue #33.
+    """
+    meta = self._compute_meta()
+    sorted_pending = sorted(
+        self._pending,
+        key=lambda e: (self._URGENCY_RANK[e.urgency], e.created_at),
+    )
+    if batch_window_seconds <= 0:
+        items: list[dict] = [self._envelope_to_dict(env) for env in sorted_pending]
+        return {"meta": meta, "items": items}
+
+    window = timedelta(seconds=batch_window_seconds)
+    groups: list[dict] = []
+    i = 0
+    while i < len(sorted_pending):
+        head = sorted_pending[i]
+        j = i + 1
+        run = [head]
+        while j < len(sorted_pending):
+            cand = sorted_pending[j]
+            # ... keep existing batching logic ...
+```
+
+**Note for the implementer:** keep the rest of `_call_list_pending`'s batching logic intact (lines ~405-440 in the current file). Only change is: prepend the `meta = self._compute_meta()` call at the top and wrap the returned list as `{"meta": meta, "items": <list>}` in both branches (flat and batched).
+
+The existing `_build_summary(urgency_floor=...)` method's body gets replaced with a thin shim — Task 2 will remove the shim entirely. The wake-firing path in `_fire_after_debounce` still references `_build_summary` until Task 2; for this task, leave that reference intact and have `_build_summary` delegate to the new `_build_wake_summary`:
+
+```python
+def _build_summary(
+    self, urgency_floor: Literal["red", "yellow", "green"] | None = None
+) -> dict:
+    """Temporary shim — Task 2 will remove this in favor of _build_wake_summary().
+
+    For now, return the minimal wake shape so callers (debounced wake path,
+    snapshot()) get the new contract immediately. urgency_floor is ignored
+    (the new wake carries no urgency).
+    """
+    return self._build_wake_summary()
+```
+
+- [ ] **Step 4: Update existing list_pending tests**
+
+In `packages/core/tests/test_claude_code_mcp.py`, find every test asserting on `list_pending`'s return as a flat list. Update assertions to access `result["items"]` instead of indexing `result` directly. Where tests assert on length, change `len(result)` to `len(result["items"])` or `result["meta"]["count"]`.
+
+In `packages/core/tests/test_claude_code_mcp_urgency_ordering.py`, the urgency-ordering assertions inspect the order of returned envelopes. Change to inspect `result["items"]`.
+
+In `packages/core/tests/test_claude_code_mcp_batching.py`, batching tests assert on `{"type": "single"|"batch", ...}` entries. Change to inspect `result["items"]`.
+
+The implementer should grep each file for `list_pending` calls and adjust. Pattern:
+
+```python
+# Before:
+result = await endpoint._call_list_pending()
+assert len(result) == 3
+assert result[0]["urgency"] == "red"
+
+# After:
+result = await endpoint._call_list_pending()
+assert result["meta"]["count"] == 3
+assert len(result["items"]) == 3
+assert result["items"][0]["urgency"] == "red"
+```
+
+- [ ] **Step 5: Run the targeted test suite**
+
+Run: `uv run pytest packages/core/tests/test_list_pending_meta_invariants.py packages/core/tests/test_claude_code_mcp.py packages/core/tests/test_claude_code_mcp_urgency_ordering.py packages/core/tests/test_claude_code_mcp_batching.py -v`
+Expected: PASS for all.
+
+- [ ] **Step 6: Run the full suite to catch any indirect breakage**
+
+Run: `uv run pytest`
+Expected: PASS for everything that was passing before. (Some wake/snapshot tests may still be passing because of the temporary `_build_summary` shim — that's expected; Task 2 will tighten them.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git checkout -b fix/issue-33-wake-snapshot-lag
+git add packages/core/src/agent_core/endpoints/claude_code_mcp.py \
+        packages/core/tests/test_list_pending_meta_invariants.py \
+        packages/core/tests/test_claude_code_mcp.py \
+        packages/core/tests/test_claude_code_mcp_urgency_ordering.py \
+        packages/core/tests/test_claude_code_mcp_batching.py
+git commit -m "fix(claude_code_mcp): wrap list_pending response with atomic meta (#33)
+
+Returns {meta, items} where meta carries count, urgency_max,
+urgency_counts, by_sender, endpoint, fetched_at — computed from the
+same atomic read of self._pending as items. Eliminates the source
+of the wake-vs-list_pending drift Pepper has been catching.
+
+_build_summary is temporarily shimmed to delegate to a new
+_build_wake_summary helper; Task 2 removes the shim and tightens
+the wake notification path."
+```
+
+---
+
+## Task 2: Minimize wake notification + drop `urgency_floor` plumbing
+
+**Files:**
+- Modify: `packages/core/src/agent_core/endpoints/claude_code_mcp.py` — `_fire_after_debounce` (lines ~675-700), `_notify_mail_arrived` (lines ~646-674), debounce-state fields (line ~190ish), remove `_build_summary` shim
+- Test (new): `packages/core/tests/test_wake_meta_drift_guard.py`
+- Test (modify): `packages/core/tests/test_notify_mail_arrived.py`
+- Test (modify): `packages/core/tests/test_bus_daemon_push_integration.py`
+
+### Steps
+
+- [ ] **Step 1: Write the failing drift-guard test**
+
+Create `packages/core/tests/test_wake_meta_drift_guard.py`:
+
+```python
+"""Drift-guard: wake notifications carry only endpoint + fired_at in meta.
+
+If anyone re-introduces count, urgency_max, by_sender, or urgency_counts
+to the wake notification's meta, this test fires. The fix for issue #33
+relies on the wake being purely a 'go look' signal — re-adding queue-state
+fields would re-introduce the original race.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from agent_core.bus.core import Bus
+from agent_core.bus.envelopes import Envelope
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+
+ALLOWED_WAKE_META_KEYS = frozenset({"endpoint", "fired_at"})
+
+
+def test_wake_summary_meta_keys_are_minimal() -> None:
+    """The wake-only summary builder emits exactly the allowed keys."""
+    endpoint = ClaudeCodeMCPEndpoint(name="agent")
+    summary = endpoint._build_wake_summary()
+    assert set(summary["meta"].keys()) == ALLOWED_WAKE_META_KEYS
+
+
+def test_wake_content_is_fixed_string() -> None:
+    """Wake content is the fixed non-lying string — not a stale snapshot."""
+    endpoint = ClaudeCodeMCPEndpoint(name="agent")
+    # Even if pending is non-empty, content does not reference counts.
+    endpoint.queue_for_pickup(
+        Envelope(from_="x", to="agent", kind="TextMessage", urgency="green", payload={})
+    )
+    endpoint.queue_for_pickup(
+        Envelope(from_="y", to="agent", kind="TextMessage", urgency="red", payload={})
+    )
+    summary = endpoint._build_wake_summary()
+    assert summary["content"] == "INBOX: pending (agent)"
+
+
+def test_published_wake_has_no_queue_state_meta() -> None:
+    """Verify the actual debounce-fire path emits the minimal shape."""
+
+    async def _run() -> dict:
+        published: list[dict] = []
+
+        class CaptureBroker:
+            async def publish(self, agent: str, event: dict) -> None:
+                published.append(event)
+
+        bus = Bus()
+        endpoint = ClaudeCodeMCPEndpoint(name="agent")
+        endpoint._notify_broker = CaptureBroker()
+        bus.register_endpoint(endpoint)
+        env = Envelope(from_="x", to="agent", kind="TextMessage", urgency="green", payload={})
+        endpoint.queue_for_pickup(env)
+        await endpoint._notify_mail_arrived(urgency="green")
+        # Wait long enough for the debounce to fire (green = 1.0s).
+        await asyncio.sleep(1.2)
+        return published[-1] if published else {}
+
+    event = asyncio.run(_run())
+    assert event, "expected at least one published wake event"
+    assert set(event["meta"].keys()) == ALLOWED_WAKE_META_KEYS
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run: `uv run pytest packages/core/tests/test_wake_meta_drift_guard.py -v`
+Expected: PASS for the first two unit tests (they call `_build_wake_summary` directly, which exists from Task 1). The third test (`test_published_wake_has_no_queue_state_meta`) may PASS already due to Task 1's shim — that's fine; this task tightens the implementation behind it.
+
+- [ ] **Step 3: Drop `urgency_floor` plumbing and the `_build_summary` shim**
+
+In `packages/core/src/agent_core/endpoints/claude_code_mcp.py`:
+
+(a) Remove the `_debounce_urgency_floor` field initialization in `__init__` (search for `self._debounce_urgency_floor` and delete the assignment).
+
+(b) Update `_notify_mail_arrived` to remove all `_debounce_urgency_floor` reads/writes. The new version:
+
+```python
+async def _notify_mail_arrived(self, urgency: str = "green") -> None:
+    """Schedule a debounced push announcing inbox activity.
+
+    Called by deliver() on each arrival. Red arrivals wake promptly,
+    yellow waits briefly, green waits long enough to collect bursts.
+    A more urgent arrival shortens a pending timer; less urgent
+    arrivals never delay an already-pending urgent push.
+
+    The wake notification itself carries no queue-state — see issue #33.
+    The urgency parameter only affects debounce timing, not wake content.
+    """
+    delay = self._notify_debounce_seconds_by_urgency.get(urgency, 1.0)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + delay
+
+    if self._debounce_task is not None and not self._debounce_task.done():
+        if self._debounce_deadline is not None and deadline >= self._debounce_deadline:
+            return
+        self._debounce_task.cancel()
+    self._debounce_deadline = deadline
+    self._debounce_task = asyncio.create_task(self._fire_after_debounce(delay))
+```
+
+(c) Update `_fire_after_debounce` to call `_build_wake_summary()` instead of `_build_summary(urgency_floor=...)`:
+
+```python
+async def _fire_after_debounce(self, delay: float) -> None:
+    task = asyncio.current_task()
+    try:
+        await asyncio.sleep(delay)
+    except asyncio.CancelledError:
+        return
+    if task is self._debounce_task:
+        self._debounce_deadline = None
+    summary = self._build_wake_summary()
+
+    # Always publish to the broker so /notify/<agent> subscribers
+    # (the channel relay) wake the agent regardless of whether the
+    # daemon's HTTP MCP session is currently captured.
+    if self._notify_broker is not None:
+        try:
+            await self._notify_broker.publish(self.name, summary)
+        except Exception:
+            log.warning("endpoint '%s': broker publish failed", self.name, exc_info=True)
+
+    # ... keep the existing in-session push logic below this line ...
+```
+
+**Note for the implementer:** keep everything below the broker-publish block in `_fire_after_debounce` intact (the in-session push to `self._sessions`).
+
+(d) Delete the temporary `_build_summary` shim added in Task 1. The `snapshot()` method (used by `Bus.snapshot_for_agent`) currently calls `self._build_summary()`; update it to call `self._build_wake_summary()` instead. Task 3 expands on snapshot semantics — for now this one-line change keeps tests green.
+
+```python
+def snapshot(self) -> dict:
+    """Public wrapper used by Bus.snapshot_for_agent.
+
+    Emits the same minimal wake shape as a regular debounced wake (see
+    issue #33) — one contract for everything wake-shaped.
+    """
+    return self._build_wake_summary()
+```
+
+- [ ] **Step 4: Update `test_notify_mail_arrived.py`**
+
+In `packages/core/tests/test_notify_mail_arrived.py`, find every assertion that inspects `count`, `urgency_max`, `urgency_counts`, or `by_sender` in the wake notification's meta. Update them either to:
+- assert those keys are NOT present (when checking the wake), OR
+- delete the assertion entirely (when the test was simply verifying the value).
+
+Pattern:
+
+```python
+# Before:
+assert summary["meta"]["count"] == 3
+assert summary["meta"]["urgency_max"] == "red"
+
+# After:
+assert "count" not in summary["meta"]
+assert "urgency_max" not in summary["meta"]
+# Or simply:
+assert set(summary["meta"].keys()) == {"endpoint", "fired_at"}
+```
+
+Tests verifying wake-fire timing, debounce coalescing, cancel behavior, and broker publish should keep working with no changes.
+
+- [ ] **Step 5: Update `test_bus_daemon_push_integration.py`**
+
+Same pattern: drop assertions on count/urgency_max/by_sender in the pushed wake notifications. Keep assertions on push timing, session targeting, and event delivery.
+
+- [ ] **Step 6: Run the targeted test suite**
+
+Run: `uv run pytest packages/core/tests/test_wake_meta_drift_guard.py packages/core/tests/test_notify_mail_arrived.py packages/core/tests/test_bus_daemon_push_integration.py -v`
+Expected: PASS for all.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `uv run pytest`
+Expected: PASS for everything except possibly `test_bus_snapshot_for_agent.py` (handled in Task 3) and `test_stdio_server.py` / `test_end_to_end_relay.py` if they assert on wake meta (handled in Task 4).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/agent_core/endpoints/claude_code_mcp.py \
+        packages/core/tests/test_wake_meta_drift_guard.py \
+        packages/core/tests/test_notify_mail_arrived.py \
+        packages/core/tests/test_bus_daemon_push_integration.py
+git commit -m "fix(claude_code_mcp): minimize wake notification meta (#33)
+
+Wake notifications now carry only endpoint + fired_at. count,
+urgency_max, urgency_counts, by_sender are gone — they were the
+race-prone fields. Agents read authoritative state via list_pending
+(see Task 1, which already wrapped its return shape).
+
+Drops _debounce_urgency_floor plumbing — the only consumer was the
+wake's urgency_max field, which no longer exists. Adds a drift-guard
+test asserting wake meta keys remain minimal."
+```
+
+---
+
+## Task 3: `Bus.snapshot_for_agent` follows the minimal wake shape
+
+**Files:**
+- Modify: `packages/core/src/agent_core/endpoints/claude_code_mcp.py` — `snapshot()` (already updated in Task 2 step 3d, this task adds tests + verifies)
+- Test (modify): `packages/core/tests/test_bus_snapshot_for_agent.py`
+
+### Steps
+
+- [ ] **Step 1: Update test_bus_snapshot_for_agent.py**
+
+In `packages/core/tests/test_bus_snapshot_for_agent.py`, find every assertion on the snapshot's `meta` fields. Update them to assert the new minimal shape:
+
+```python
+# Before:
+snapshot = bus.snapshot_for_agent("agent")
+assert snapshot["meta"]["count"] == 2
+assert snapshot["meta"]["urgency_max"] == "yellow"
+
+# After:
+snapshot = bus.snapshot_for_agent("agent")
+assert set(snapshot["meta"].keys()) == {"endpoint", "fired_at"}
+assert snapshot["meta"]["endpoint"] == "agent"
+```
+
+Tests verifying that the snapshot fires, that it targets the right agent, and that it triggers a wake should keep working unchanged. Only the meta-shape assertions move.
+
+If a test was specifically verifying that `urgency_max` flowed through correctly from envelopes, replace it with a test that calls `list_pending` after the snapshot and asserts on `meta.urgency_max` there — the contract has moved, not gone.
+
+- [ ] **Step 2: Run the snapshot tests**
+
+Run: `uv run pytest packages/core/tests/test_bus_snapshot_for_agent.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `uv run pytest`
+Expected: PASS for everything except possibly `test_stdio_server.py` / `test_end_to_end_relay.py` (handled in Task 4).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/tests/test_bus_snapshot_for_agent.py
+git commit -m "fix(snapshot_for_agent): align with minimal wake contract (#33)
+
+Bus.snapshot_for_agent emits the same minimal {endpoint, fired_at}
+meta as a regular debounced wake. One wake contract everywhere —
+agents have a single parser path. Future synthetic wake sources
+inherit it.
+
+Source change for snapshot() landed alongside the debounce-path
+update in the previous commit; this commit covers the test
+assertions."
+```
+
+---
+
+## Task 4: Regression test for the original bug shape
+
+**Files:**
+- Test (modify): `packages/core/tests/test_notify_mail_arrived.py` — add the deterministic-sequence regression test
+
+### Steps
+
+- [ ] **Step 1: Add the regression test**
+
+Append to `packages/core/tests/test_notify_mail_arrived.py`:
+
+```python
+import asyncio
+
+import pytest
+
+from agent_core.bus.core import Bus
+from agent_core.bus.envelopes import Envelope
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+
+
+@pytest.mark.asyncio
+async def test_wake_and_list_pending_disagreement_eliminated() -> None:
+    """Issue #33 regression: agent drains envelopes between wake-fire and consumption.
+
+    Reproduces the failure shape Pepper saw: count=3 reported, only 1 actually
+    pending. Under the new contract, the wake carries no count/urgency_max,
+    and list_pending's meta agrees with its own items by construction.
+    """
+    published: list[dict] = []
+
+    class CaptureBroker:
+        async def publish(self, agent: str, event: dict) -> None:
+            published.append(event)
+
+    bus = Bus()
+    endpoint = ClaudeCodeMCPEndpoint(name="agent")
+    endpoint._notify_broker = CaptureBroker()
+    bus.register_endpoint(endpoint)
+
+    # Queue 3 envelopes; debounce window starts on first arrival.
+    e0 = Envelope(from_="alice", to="agent", kind="TextMessage", urgency="red", payload={"text": "0"})
+    e1 = Envelope(from_="alice", to="agent", kind="TextMessage", urgency="red", payload={"text": "1"})
+    e2 = Envelope(from_="alice", to="agent", kind="TextMessage", urgency="green", payload={"text": "2"})
+    endpoint.queue_for_pickup(e0)
+    endpoint.queue_for_pickup(e1)
+    endpoint.queue_for_pickup(e2)
+    await endpoint._notify_mail_arrived(urgency="red")  # red = 0.05s debounce
+
+    # Simulate the agent draining the two red envelopes mid-debounce
+    # (this is what Pepper does between wakes — finishes processing the
+    # prior batch). Drain happens BEFORE the debounce fires.
+    endpoint._pending = [e for e in endpoint._pending if e.id not in {e0.id, e1.id}]
+
+    # Let the debounce fire.
+    await asyncio.sleep(0.2)
+
+    # Wake notification: must be the minimal shape, with no stale count.
+    assert published, "expected wake to fire"
+    wake = published[-1]
+    assert set(wake["meta"].keys()) == {"endpoint", "fired_at"}
+    assert wake["content"] == "INBOX: pending (agent)"
+
+    # list_pending: meta agrees with the actual remaining envelope.
+    result = await endpoint._call_list_pending()
+    assert result["meta"]["count"] == 1
+    assert result["meta"]["urgency_max"] == "green"
+    assert len(result["items"]) == 1
+    assert result["items"][0]["id"] == e2.id
+```
+
+- [ ] **Step 2: Run the regression test**
+
+Run: `uv run pytest packages/core/tests/test_notify_mail_arrived.py::test_wake_and_list_pending_disagreement_eliminated -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/tests/test_notify_mail_arrived.py
+git commit -m "test(claude_code_mcp): regression test for wake/list_pending drift (#33)
+
+Reproduces the shape Pepper caught — agent drains envelopes between
+wake-fire and consumption. Under the new contract:
+- wake carries no count/urgency_max, so it cannot lie
+- list_pending's meta is computed from the same atomic read as items,
+  so meta.count always matches len(items)
+
+This test would have failed under the pre-fix code path (it fixates
+on the disagreement between the wake's snapshot and list_pending's
+later read). Under the fix it passes by construction."
+```
+
+---
+
+## Task 5: Update contract documentation strings
+
+**Files:**
+- Modify: `packages/core/src/agent_core/endpoints/claude_code_mcp.py` — `instructions=` kwarg in `__init__` (lines ~171-185)
+- Modify: `packages/agent-core-channel/src/agent_core_channel/stdio_server.py` — `_RELAY_INSTRUCTIONS` (lines ~33-44)
+- Modify (if relevant): `packages/agent-core-channel/README.md`
+- Modify (if relevant): `docs/cutover/notification-surfaces.md`
+- Test (modify): `packages/agent-core-channel/tests/test_stdio_server.py` (assertion-shape updates if any)
+- Test (modify): `packages/agent-core-channel/tests/test_end_to_end_relay.py` (assertion-shape updates if any)
+
+### Steps
+
+- [ ] **Step 1: Rewrite the FastMCP `instructions=` kwarg in `claude_code_mcp.py`**
+
+Replace lines ~171-185 (the `instructions=` block in `__init__`) with:
+
+```python
+instructions=(
+    f"You are agent '{name}'. The bus pushes you notifications with method "
+    '"notifications/claude/channel" when envelopes arrive in your mailbox. '
+    'Each notification\'s params contain "content" (a fixed string of the form '
+    '"INBOX: pending (<endpoint>)") and "meta" (endpoint, fired_at). The '
+    "wake is purely a 'go look' signal — it carries no queue-state. "
+    "On receipt: call list_pending() to read the actual envelopes (set "
+    "batch_window_seconds=30 to fold human-paced bursts from the same "
+    'sender). list_pending returns {"meta": {count, urgency_max, '
+    "urgency_counts, by_sender, endpoint, fetched_at}, \"items\": [...]}; "
+    "meta is the authoritative aggregate, computed atomically with items. "
+    "Process each item, then call handle(envelope_id) on each to ack and "
+    "remove from the queue. Send replies via the send tool. "
+    "Routine delivery Acknowledgments for your own recent outbounds may "
+    "be auto-cleared without a wake; you are still notified for failures, "
+    "urgent acks, other envelope kinds, and missing-ack timeouts."
+),
+```
+
+- [ ] **Step 2: Rewrite `_RELAY_INSTRUCTIONS` in `stdio_server.py`**
+
+Replace lines ~33-44 with:
+
+```python
+_RELAY_INSTRUCTIONS = (
+    "Inbox wake notifications for an agent-core agent. "
+    'Messages arrive as JSON-RPC notifications with method "notifications/claude/channel". '
+    'The params object has "content" (a fixed "INBOX: pending (<endpoint>)" string) '
+    'and "meta" (endpoint, fired_at). The wake is a pure "go look" signal — it '
+    "carries no queue-state. "
+    "When such a notification arrives, treat it as a wake signal: "
+    "call mcp__agent-core__list_pending to fetch the authoritative "
+    '{"meta": {count, urgency_max, urgency_counts, by_sender, endpoint, '
+    'fetched_at}, "items": [...]} response. Higher urgency tiers '
+    "(red > yellow > green) should be addressed first — read meta.urgency_max "
+    "and the per-item urgency. Respond via mcp__agent-core__send when "
+    "appropriate. Do not wait for user input - the notification IS the prompt."
+)
+```
+
+- [ ] **Step 3: Check `packages/agent-core-channel/README.md`**
+
+Run: `grep -n "urgency_max\|by_sender\|count.*pending" packages/agent-core-channel/README.md` (use the Grep tool, not bash grep).
+Expected: if matches found, update the prose to reflect the new contract. If no matches, skip.
+
+- [ ] **Step 4: Check `docs/cutover/notification-surfaces.md`**
+
+Run: `grep -n "urgency_max\|by_sender\|wake meta" docs/cutover/notification-surfaces.md` (use the Grep tool).
+Expected: if matches found describing the wake's meta fields, update the prose. The current sweep showed no specific field references, but check the prose around line 26+ for any "summary contains count..." phrasing that still implies the old shape and update it.
+
+- [ ] **Step 5: Update relay tests**
+
+In `packages/agent-core-channel/tests/test_stdio_server.py`, find any assertions on:
+- `_RELAY_INSTRUCTIONS` content (likely a substring check) — update to match new wording.
+- Wake notification meta-field shape — drop `count`/`urgency_max`/`by_sender`.
+
+In `packages/agent-core-channel/tests/test_end_to_end_relay.py`, find any assertions on:
+- `list_pending` return shape — update to inspect `result["items"]` and `result["meta"]`.
+- Wake notification meta — same as above.
+
+- [ ] **Step 6: Run the relay tests**
+
+Run: `uv run pytest packages/agent-core-channel/tests/test_stdio_server.py packages/agent-core-channel/tests/test_end_to_end_relay.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `uv run pytest`
+Expected: PASS — should be 597+ existing tests plus the 3 new tests files (~10 new tests total).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/agent_core/endpoints/claude_code_mcp.py \
+        packages/agent-core-channel/src/agent_core_channel/stdio_server.py \
+        packages/agent-core-channel/tests/test_stdio_server.py \
+        packages/agent-core-channel/tests/test_end_to_end_relay.py
+# Also add README/notification-surfaces.md if they were updated.
+git commit -m "docs(claude_code_mcp,channel): sync wake-contract instructions (#33)
+
+Both the FastMCP server's instructions= kwarg and the channel relay's
+_RELAY_INSTRUCTIONS now describe the new wake shape: minimal meta
+(endpoint + fired_at), pure 'go look' signal, list_pending carries
+authoritative aggregate metadata in its wrapped {meta, items}
+response."
+```
+
+---
+
+## Task 6: Final verification + PR
+
+**Files:** none modified.
+
+### Steps
+
+- [ ] **Step 1: Full test suite**
+
+Run: `uv run pytest`
+Expected: All tests pass. New count should be 597 (pre-existing) + ~10 new (invariant tests parametrized + drift-guard + regression) = ~607 passing.
+
+- [ ] **Step 2: Lint**
+
+Run: `uv run ruff check .`
+Expected: clean.
+
+- [ ] **Step 3: Type-check (if configured)**
+
+Run: `uv run mypy packages/core/src packages/agent-core-channel/src` (skip if mypy isn't configured for the project).
+Expected: clean.
+
+- [ ] **Step 4: Verify branch state**
+
+Run: `git log --oneline main..HEAD`
+Expected: 5 commits on `fix/issue-33-wake-snapshot-lag` (one per Task 1-5).
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin fix/issue-33-wake-snapshot-lag
+gh pr create --title "fix: wake-builder snapshot lag (#33)" --body "$(cat <<'EOF'
+## Summary
+
+Fixes #33. Wake notifications and `list_pending` no longer drift.
+
+- Wake notification meta minimized to `{endpoint, fired_at}`.
+- `list_pending` returns `{meta, items}` where meta carries `count`, `urgency_max`, `urgency_counts`, `by_sender`, computed atomically from the same `self._pending` read as items.
+- `Bus.snapshot_for_agent` follows the same minimal wake contract.
+- Drops `_debounce_urgency_floor` plumbing (its only consumer was the now-removed wake `urgency_max`).
+
+Approved by consumer (Pepper) for Option B (hybrid). Cutover validated on testbot first per the durable hands-off rule.
+
+## Test plan
+
+- [ ] `uv run pytest` — all green
+- [ ] `uv run ruff check .` — clean
+- [ ] Validate on testbot: send mixed-urgency burst, confirm wake content is fixed string and list_pending meta matches items
+- [ ] Then restart Pepper to pick up new contract
+
+## Spec
+
+`docs/superpowers/specs/2026-05-08-issue-33-wake-snapshot-lag-design.md`
+EOF
+)"
+```
+
+Expected: PR opens cleanly. Return the PR URL.
+
+---
+
+## Self-review checklist (run by orchestrator after plan-write)
+
+- [x] Spec coverage: Task 1 covers list_pending wrap; Task 2 covers wake minimization; Task 3 covers snapshot_for_agent; Task 4 covers regression test; Task 5 covers contract documentation; Task 6 covers verification.
+- [x] Placeholder scan: no TBD/TODO/"add appropriate"/etc.
+- [x] Type consistency: `_build_wake_summary`, `_compute_meta`, `_call_list_pending` signatures used uniformly across tasks.
+- [x] Conventional commits: `fix(scope):`, `test(scope):`, `docs(scope):` per repo style. No `Co-Authored-By` trailer (matches repo convention verified via `git log -3`).
+- [x] Branch + PR convention: `fix/issue-33-wake-snapshot-lag` per the roadmap doc; `Closes #33` will auto-close via the PR title `(#33)`.

--- a/docs/superpowers/specs/2026-05-08-issue-33-wake-snapshot-lag-design.md
+++ b/docs/superpowers/specs/2026-05-08-issue-33-wake-snapshot-lag-design.md
@@ -1,0 +1,169 @@
+# Issue #33 — Wake-builder snapshot lag (Design)
+
+> **Status:** Approved 2026-05-08. Ready for implementation plan.
+>
+> **Issue:** [#33](https://github.com/jeffrichley/agent_core/issues/33) — Wake-builder count + urgency_max snapshot lags actual queue state.
+>
+> **Roadmap:** RED tier of `docs/superpowers/plans/2026-05-07-open-issues-cleanup-roadmap.md`.
+
+## Problem
+
+Wake-channel notifications occasionally report `count` and `urgency_max` values that disagree with what `list_pending` returns moments later. Pepper has caught this multiple times per session: wake says `count=3`, `list_pending` returns 1; wake reports `urgency_max="yellow"` when every envelope in the queue is green. Envelope content is always correct — only the wake-builder's metadata snapshot is off.
+
+Functionally harmless (the agent treats `list_pending` as authoritative), but corrosive: the agent suspects failures that don't exist, wastes turns investigating phantom backlogs, and learns to distrust the wake's urgency signal — defeating its purpose as a triage primitive.
+
+### Root cause
+
+The race is **not** inside the snapshot. `_build_summary()` (`packages/core/src/agent_core/endpoints/claude_code_mcp.py:558`) reads `self._pending` atomically at debounce-fire time. The seam is between the snapshot moment and the agent's next consumption moment, during which the agent is still draining a previous batch:
+
+- `t=1.2`: debounce fires → snapshot reads `_pending=[e2,e3,e4]`, count=3.
+- `t=1.2..1.3`: agent finishes processing e2, e3 from its prior `list_pending` batch, ack'd via `handle()`.
+- `t=1.3`: agent receives the wake, calls `list_pending` → sees [e4], count=1.
+
+This explains the "count=3, only 1 pending" sighting exactly.
+
+The issue body's suggested fix shape (a) — recompute inside `list_pending`'s transaction — does not close this race. The wake is delivered *before* the agent's next `list_pending`; by then the queue has changed.
+
+The fix shape that closes the race is **moving the metadata to the consumption point**: the wake notification carries no queue-state metadata; `list_pending` returns metadata alongside the envelopes it returns, computed atomically from the same `self._pending` read. Consumer (Pepper) confirmed this is the contract they want: zero added round-trip, urgency_max still available at the natural triage point.
+
+## Out of scope
+
+- No backward-compat shim. Pepper is the only consumer; clean cutover at daemon restart, validated on testbot first per the durable hands-off rule.
+- No changes to envelope ordering, ack semantics, debounce timing, or persistence.
+- No changes to `Bus.snapshot_for_agent`'s firing path — only its emitted shape.
+- No changes to per-envelope urgency on individual envelopes.
+
+## Design
+
+### Wake notification — minimal contract
+
+`notifications/claude/channel` `params` becomes:
+
+```python
+{
+    "content": f"INBOX: pending ({endpoint})",
+    "meta": {
+        "endpoint": str,
+        "fired_at": str,  # ISO-8601 UTC
+    },
+}
+```
+
+No `count`, `urgency_max`, `urgency_counts`, `by_sender`. The wake is a pure "go look" signal. `content` is a fixed, non-lying string referencing only the endpoint identity.
+
+### `list_pending` — wrapped return shape
+
+`list_pending(batch_window_seconds: int = 0)` returns:
+
+```python
+{
+    "meta": {
+        "count": int,
+        "urgency_max": "red" | "yellow" | "green",  # "green" when count == 0
+        "urgency_counts": {"red": int, "yellow": int, "green": int},
+        "by_sender": [{"from": str, "count": int, "kinds": [str, ...]}, ...],
+        "endpoint": str,
+        "fetched_at": str,  # ISO-8601 UTC; semantically distinct from wake's fired_at
+    },
+    "items": [
+        # When batch_window_seconds == 0: bare envelope dicts (today's behavior).
+        # When > 0: {"type": "single", "envelope": {...}} or {"type": "batch", ...}.
+    ],
+}
+```
+
+`meta` and `items` are computed in the same synchronous block of `_call_list_pending` — no `await` between the read of `self._pending` and the construction of either field. Race-free by event-loop semantics: identical to the atomicity guarantee `_build_summary` had today.
+
+`meta.count` counts envelopes (when batch entries are present, sums their inner envelopes — i.e., `meta.count == len(self._pending)` regardless of batching).
+
+`meta.urgency_max` is `"green"` when `count == 0` (preserves current default; avoids forcing a None-check on the consumer).
+
+### `Bus.snapshot_for_agent` — same minimal wake contract
+
+The relay-connect synthetic wake follows the new wake shape: `{content, meta: {endpoint, fired_at}}`. One contract for everything wake-shaped — the relay-connect "freshness advantage" collapses the moment the agent reads the next envelope, so it's not worth a second contract. Forward-compatible: future wake sources (synthetic wakes from webhooks, inter-agent pushes) inherit the contract.
+
+### `_build_summary` split
+
+The current `_build_summary(urgency_floor: ...) -> dict` becomes two builders:
+
+- `_build_wake_summary(self) -> dict` — emits the minimal wake shape. No parameters. No `urgency_floor`.
+- `_build_list_pending_response(self, batch_window_seconds: int = 0) -> dict` — emits the wrapped `{meta, items}` shape. Called from `_call_list_pending`.
+
+The `_debounce_urgency_floor` field and the `urgency_floor` argument plumbing through `_fire_after_debounce` are removed. Their only purpose was biasing the wake's `urgency_max` — which no longer exists on the wake.
+
+The `snapshot()` public method (used by `Bus.snapshot_for_agent`) becomes a thin wrapper around `_build_wake_summary()`.
+
+### Instructions / contract documentation
+
+Two strings document the wake contract to the agent and need synchronization with the new shape:
+
+- `claude_code_mcp.py` `__init__`'s `instructions=` kwarg passed to `FastMCP` (lines ~169-185).
+- `agent_core_channel/stdio_server.py`'s wake-contract description string (lines ~36-42).
+
+Both rewrite to reflect: "wake meta carries `endpoint` and `fired_at` only; call `list_pending` for authoritative queue state, including `meta.count` and `meta.urgency_max`."
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| Empty inbox at wake time | Wake fires anyway with the fixed content. Agent calls `list_pending` → `meta.count=0`, no items. No-op. |
+| Two `list_pending` calls in quick succession | Each returns its own atomically-consistent `{meta, items}`. No state mutation. Safe. |
+| `urgency_max` when `count == 0` | Returns `"green"`. Consistent with today's default; no None-check needed on consumer. |
+| Daemon restart mid-cutover | Pre-restart: old contract. Post-restart: new contract. Consumer (testbot, then Pepper) must be parser-ready before the daemon flips. Same dance as #44 / #42. |
+| Race during the debounce window | Eliminated by construction — wake carries no race-prone fields; `list_pending` reads atomically. |
+
+## Testing
+
+### Regression test (new)
+
+In `test_notify_mail_arrived.py`: deterministic sequence reproducing the original bug shape.
+
+1. Queue 3 envelopes via `queue_for_pickup`. Trigger a debounce.
+2. Before the debounce fires, drain 2 via `handle()`.
+3. Let the debounce fire.
+4. Assert the wake notification's `meta` contains exactly `{"endpoint", "fired_at"}` — no `count`, no `urgency_max`. Assert `content` equals the fixed string.
+5. Call `list_pending`. Assert `meta.count == 1`, `meta.urgency_max` matches the remaining envelope's urgency, `len(items) == 1`.
+
+This is the test that would have failed under the current implementation and passes under the new one.
+
+### Invariant test (new)
+
+In `test_claude_code_mcp.py` (or a new `test_list_pending_meta_invariants.py`): parametrize over varied states (0/1/N envelopes, mixed urgencies, with and without `batch_window_seconds`). For each, call `list_pending` and assert:
+
+- `meta.count == sum(envelopes per item)` (handles batching).
+- `meta.urgency_max` equals the highest urgency across all envelopes in items (or `"green"` if empty).
+- `meta.urgency_counts` per-tier sums match per-tier counts in items.
+- `meta.by_sender` reconstructs from items.
+
+Catches future drift if anyone ever computes meta separately from items.
+
+### Drift-guard test (new)
+
+A test asserting wake-meta keys are exactly `{"endpoint", "fired_at"}`. Same shape as the per-kind summarizer drift-guard from PR #49 (`packages/core/tests/test_bus_tail_summaries.py`). Cheap insurance against re-introducing `count` / `urgency_max` to the wake.
+
+### Existing-test updates (mechanical)
+
+- `test_notify_mail_arrived.py` — drop wake-meta assertions on `count` / `urgency_max` / `by_sender`. Keep wake-fire timing / cancel / coalesce assertions.
+- `test_bus_snapshot_for_agent.py` — assert the new minimal snapshot shape.
+- `test_bus_daemon_push_integration.py` — push-path assertions follow the new wake shape.
+- `test_claude_code_mcp.py` + `test_claude_code_mcp_urgency_ordering.py` + `test_claude_code_mcp_batching.py` — wrap `list_pending` return assertions in the new shape; move urgency-ordering assertions to inspect `meta.urgency_max` and `items` order.
+- `test_stdio_server.py` + `test_end_to_end_relay.py` — wake-shape assertions drop `count` / `urgency_max`.
+
+## Components touched
+
+**Source:**
+- `packages/core/src/agent_core/endpoints/claude_code_mcp.py` — `_build_summary` split, `_call_list_pending` return shape, `snapshot()` wrapper, `_fire_after_debounce` simplification, `instructions` string.
+- `packages/agent-core-channel/src/agent_core_channel/stdio_server.py` — wake-contract description string.
+- `packages/agent-core-channel/README.md` — only if it references the old wake meta fields.
+
+**Tests:** as enumerated above.
+
+**Docs:**
+- `docs/cutover/notification-surfaces.md` — sync to new wake contract if it documents meta fields.
+
+## References
+
+- Practice-run runbook: `docs/cutover/testbot-practice-run-2026-05-05.md` — Phase 6 "Bus-meta observation" + round-2 verification notes.
+- Recent precedents for the cutover validation pattern: PR #46 (#44), PR #47 (#42), PR #48 (#39), PR #49 (#16).
+- `_build_summary` current implementation: `packages/core/src/agent_core/endpoints/claude_code_mcp.py:558`.
+- `_call_list_pending` current implementation: `packages/core/src/agent_core/endpoints/claude_code_mcp.py:389`.

--- a/packages/agent-core-channel/src/agent_core_channel/stdio_server.py
+++ b/packages/agent-core-channel/src/agent_core_channel/stdio_server.py
@@ -33,14 +33,16 @@ log = logging.getLogger(__name__)
 _RELAY_INSTRUCTIONS = (
     "Inbox wake notifications for an agent-core agent. "
     'Messages arrive as JSON-RPC notifications with method "notifications/claude/channel". '
-    'The params object has "content" (a brief inbox summary string, '
-    'e.g. "INBOX: 3 pending - 2 from discord (TextMessage), 1 from email") '
-    'and "meta" (count, by_sender, urgency_counts, urgency_max, endpoint, fired_at). '
+    'The params object has "content" (a fixed "INBOX: pending (<endpoint>)" string) '
+    'and "meta" (endpoint, fired_at). The wake is a pure "go look" signal — it '
+    "carries no queue-state. "
     "When such a notification arrives, treat it as a wake signal: "
-    "call mcp__agent-core__list_pending to fetch the actual envelopes, "
-    "process each, and respond via mcp__agent-core__send when appropriate. "
-    "Higher urgency tiers (red > yellow > green) should be addressed first. "
-    "Do not wait for user input - the notification IS the prompt."
+    "call mcp__agent-core__list_pending to fetch the authoritative "
+    '{"meta": {count, urgency_max, urgency_counts, by_sender, endpoint, '
+    'fetched_at}, "items": [...]} response. Higher urgency tiers '
+    "(red > yellow > green) should be addressed first — read meta.urgency_max "
+    "and the per-item urgency. Respond via mcp__agent-core__send when "
+    "appropriate. Do not wait for user input - the notification IS the prompt."
 )
 
 

--- a/packages/agent-core-channel/tests/test_end_to_end_relay.py
+++ b/packages/agent-core-channel/tests/test_end_to_end_relay.py
@@ -113,10 +113,12 @@ async def test_bus_arrival_reaches_relay_stdio_stream(tmp_path: Path) -> None:
                 root = received.message.root
                 assert root.method == "notifications/claude/channel"
                 assert root.params is not None
+                # Wake is a pure "go look" signal: meta carries only the
+                # minimal {endpoint, fired_at}. Agents read authoritative
+                # queue-state via list_pending. meta values are stringified
+                # per Claude Code's channel spec (Record<string, string>).
                 meta = root.params["meta"]
-                # meta values are stringified per Claude Code's channel spec
-                # (Record<string, string>).
-                assert int(meta["count"]) >= 1
+                assert set(meta.keys()) == {"endpoint", "fired_at"}
                 assert meta["endpoint"] == "agent"
             finally:
                 relay_task.cancel()

--- a/packages/core/src/agent_core/bus/http_host.py
+++ b/packages/core/src/agent_core/bus/http_host.py
@@ -273,7 +273,7 @@ class HTTPHost:
             async def event_stream() -> AsyncIterator[bytes]:
                 try:
                     initial = snapshot(agent)
-                    if initial is not None and initial.get("meta", {}).get("count", 0) > 0:
+                    if initial is not None:
                         yield f"data: {json.dumps(initial)}\n\n".encode()
                     while True:
                         event = await queue.get()

--- a/packages/core/src/agent_core/endpoints/claude_code_mcp.py
+++ b/packages/core/src/agent_core/endpoints/claude_code_mcp.py
@@ -386,21 +386,74 @@ class ClaudeCodeMCPEndpoint:
             self._recent_outbound_ids.pop(rid, None)
             self._cancel_missing_ack(rid)
 
-    async def _call_list_pending(self, batch_window_seconds: int = 0) -> list[dict]:
+    def _compute_meta(self) -> dict:
+        """Compute aggregate metadata from the current pending queue.
+
+        Reads self._pending atomically (no awaits). Used by _call_list_pending
+        so meta and items come from the same read — eliminates the wake-vs-
+        list_pending drift that caused issue #33.
+        """
+        pending = list(self._pending)
+        count = len(pending)
+        urg_counts = Counter(e.urgency for e in pending)
+        urg_full: dict[Literal["red", "yellow", "green"], int] = {}
+        for tier in self._URGENCY_ORDER:
+            urgency_key = cast(Literal["red", "yellow", "green"], tier)
+            urg_full[urgency_key] = int(urg_counts.get(urgency_key, 0))
+        urgency_max = "green"
+        for tier in self._URGENCY_ORDER:
+            urgency_key = cast(Literal["red", "yellow", "green"], tier)
+            if urg_full[urgency_key] > 0:
+                urgency_max = tier
+                break
+        sender_index: dict[str, dict] = {}
+        for env in pending:
+            entry = sender_index.setdefault(env.from_, {"from": env.from_, "count": 0, "kinds": []})
+            entry["count"] += 1
+            if env.kind not in entry["kinds"]:
+                entry["kinds"].append(env.kind)
+        by_sender = list(sender_index.values())
+        return {
+            "count": count,
+            "urgency_max": urgency_max,
+            "urgency_counts": urg_full,
+            "by_sender": by_sender,
+            "endpoint": self.name,
+            "fetched_at": datetime.now(UTC).isoformat(),
+        }
+
+    def _build_wake_summary(self) -> dict:
+        """Minimal wake notification — pure 'go look' signal.
+
+        Carries no queue-state metadata. The agent calls list_pending for
+        authoritative count/urgency_max/by_sender, computed atomically with
+        the items list. See issue #33.
+        """
+        return {
+            "content": f"INBOX: pending ({self.name})",
+            "meta": {
+                "endpoint": self.name,
+                "fired_at": datetime.now(UTC).isoformat(),
+            },
+        }
+
+    async def _call_list_pending(self, batch_window_seconds: int = 0) -> dict:
         """Mailbox view sorted by urgency, optionally batched by sender.
 
-        When batch_window_seconds == 0: returns a flat list of envelope dicts
-        (today's behavior). When > 0: consecutive envelopes (within urgency
-        tier and same `from_`) whose created_at fall within the window collapse
-        into one {"type": "batch", ...} entry; standalone entries are wrapped
-        as {"type": "single", "envelope": {...}}.
+        Returns {"meta": {...}, "items": [...]}. meta carries count, urgency_max,
+        urgency_counts, by_sender, endpoint, fetched_at. items is the flat list
+        of envelope dicts (when batch_window_seconds == 0) or batched/single
+        entries (when > 0). meta and items are computed from the same atomic
+        read of self._pending — see issue #33.
         """
+        meta = self._compute_meta()
         sorted_pending = sorted(
             self._pending,
             key=lambda e: (self._URGENCY_RANK[e.urgency], e.created_at),
         )
         if batch_window_seconds <= 0:
-            return [self._envelope_to_dict(env) for env in sorted_pending]
+            items: list[dict] = [self._envelope_to_dict(env) for env in sorted_pending]
+            return {"meta": meta, "items": items}
 
         window = timedelta(seconds=batch_window_seconds)
         groups: list[dict] = []
@@ -438,7 +491,7 @@ class ClaudeCodeMCPEndpoint:
                     }
                 )
             i = j
-        return groups
+        return {"meta": meta, "items": groups}
 
     @staticmethod
     def _envelope_to_dict(env: Envelope) -> dict:
@@ -558,54 +611,13 @@ class ClaudeCodeMCPEndpoint:
     def _build_summary(
         self, urgency_floor: Literal["red", "yellow", "green"] | None = None
     ) -> dict:
-        """Snapshot the current mailbox into a notification summary."""
-        pending = list(self._pending)
-        count = len(pending)
-        # urgency counts
-        urg_counts = Counter(e.urgency for e in pending)
-        urg_full: dict[Literal["red", "yellow", "green"], int] = {}
-        for tier in self._URGENCY_ORDER:
-            urgency_key = cast(Literal["red", "yellow", "green"], tier)
-            urg_full[urgency_key] = int(urg_counts.get(urgency_key, 0))
-        # urgency_max — highest tier present
-        urgency_max = "green"
-        for tier in self._URGENCY_ORDER:
-            urgency_key = cast(Literal["red", "yellow", "green"], tier)
-            if urg_full[urgency_key] > 0:
-                urgency_max = tier
-                break
-        if urgency_floor in self._URGENCY_RANK:
-            floor_rank = self._URGENCY_RANK[urgency_floor]
-            current_rank = self._URGENCY_RANK[urgency_max]
-            if floor_rank < current_rank:
-                urgency_max = urgency_floor
-        # by_sender
-        sender_index: dict[str, dict] = {}
-        for env in pending:
-            entry = sender_index.setdefault(env.from_, {"from": env.from_, "count": 0, "kinds": []})
-            entry["count"] += 1
-            if env.kind not in entry["kinds"]:
-                entry["kinds"].append(env.kind)
-        by_sender = list(sender_index.values())
-        # Headline content — terse, useful for triage.
-        if count == 0:
-            content = "INBOX: 0 pending"
-        else:
-            sender_summary = ", ".join(
-                f"{e['count']} from {e['from']} ({'/'.join(e['kinds'])})" for e in by_sender
-            )
-            content = f"INBOX: {count} pending — {sender_summary}"
-        return {
-            "content": content,
-            "meta": {
-                "count": count,
-                "urgency_max": urgency_max,
-                "urgency_counts": urg_full,
-                "by_sender": by_sender,
-                "endpoint": self.name,
-                "fired_at": datetime.now(UTC).isoformat(),
-            },
-        }
+        """Temporary shim — Task 2 will remove this in favor of _build_wake_summary().
+
+        For now, return the minimal wake shape so callers (debounced wake path,
+        snapshot()) get the new contract immediately. urgency_floor is ignored
+        (the new wake carries no urgency).
+        """
+        return self._build_wake_summary()
 
     def snapshot(self) -> dict:
         """Public wrapper around _build_summary; used by Bus.snapshot_for_agent.
@@ -706,10 +718,9 @@ class ClaudeCodeMCPEndpoint:
         for session in sessions:
             try:
                 log.info(
-                    "endpoint '%s': pushing notifications/claude/channel to session %d (count=%d)",
+                    "endpoint '%s': pushing notifications/claude/channel to session %d",
                     self.name,
                     id(session),
-                    summary["meta"]["count"],
                 )
                 await session.send_message(message)
                 log.info("endpoint '%s': push to session %d returned", self.name, id(session))
@@ -779,15 +790,20 @@ class ClaudeCodeMCPEndpoint:
             return None
 
         @self._mcp.tool()
-        async def list_pending(batch_window_seconds: int = 0) -> list[dict]:
+        async def list_pending(batch_window_seconds: int = 0) -> dict:
             """Return a snapshot of envelopes in this agent's pickup queue,
             sorted by urgency (red → yellow → green) with FIFO within tier.
 
+            Returns {"meta": {...}, "items": [...]}. meta carries count,
+            urgency_max, urgency_counts, by_sender, endpoint, fetched_at —
+            computed atomically with items, so the aggregate cannot drift
+            from the actual queue contents (see issue #33).
+
             When batch_window_seconds > 0, consecutive same-sender same-urgency
             same-kind envelopes whose arrival times fall within the window are
-            collapsed into a single {"type": "batch", ...} entry. Each
-            underlying envelope retains its own id and ack semantics — call
-            handle(envelope_id) per envelope.
+            collapsed into a single {"type": "batch", ...} entry inside items.
+            Each underlying envelope retains its own id and ack semantics —
+            call handle(envelope_id) per envelope.
             """
             return await self._call_list_pending(batch_window_seconds=batch_window_seconds)
 

--- a/packages/core/src/agent_core/endpoints/claude_code_mcp.py
+++ b/packages/core/src/agent_core/endpoints/claude_code_mcp.py
@@ -171,14 +171,16 @@ class ClaudeCodeMCPEndpoint:
             instructions=(
                 f"You are agent '{name}'. The bus pushes you notifications with method "
                 '"notifications/claude/channel" when envelopes arrive in your mailbox. '
-                'Each notification\'s params contain "content" (a brief summary) and '
-                '"meta" (count, urgency_max, urgency_counts, by_sender, endpoint, '
-                "fired_at). On receipt: call list_pending() to read the actual "
-                "envelopes (set batch_window_seconds=30 to fold human-paced bursts "
-                "from the same sender), process them, then call handle(envelope_id) "
-                "on each to ack and remove from the queue. Send replies via the "
-                "send tool. Treat the notification's content as a hint, not the "
-                "message itself — list_pending is authoritative. "
+                'Each notification\'s params contain "content" (a fixed string of the form '
+                '"INBOX: pending (<endpoint>)") and "meta" (endpoint, fired_at). The '
+                "wake is purely a 'go look' signal — it carries no queue-state. "
+                "On receipt: call list_pending() to read the actual envelopes (set "
+                "batch_window_seconds=30 to fold human-paced bursts from the same "
+                'sender). list_pending returns {"meta": {count, urgency_max, '
+                "urgency_counts, by_sender, endpoint, fetched_at}, \"items\": [...]}; "
+                "meta is the authoritative aggregate, computed atomically with items. "
+                "Process each item, then call handle(envelope_id) on each to ack and "
+                "remove from the queue. Send replies via the send tool. "
                 "Routine delivery Acknowledgments for your own recent outbounds may "
                 "be auto-cleared without a wake; you are still notified for failures, "
                 "urgent acks, other envelope kinds, and missing-ack timeouts."

--- a/packages/core/src/agent_core/endpoints/claude_code_mcp.py
+++ b/packages/core/src/agent_core/endpoints/claude_code_mcp.py
@@ -194,7 +194,6 @@ class ClaudeCodeMCPEndpoint:
         }
         self._debounce_task: asyncio.Task | None = None
         self._debounce_deadline: float | None = None
-        self._debounce_urgency_floor: Literal["red", "yellow", "green"] | None = None
         self._notify_broker = notify_broker
         self._recent_outbound_ids: dict[str, float] = {}
         self._missing_ack_tasks: dict[str, asyncio.Task[None]] = {}
@@ -584,7 +583,6 @@ class ClaudeCodeMCPEndpoint:
                 pass
         self._debounce_task = None
         self._debounce_deadline = None
-        self._debounce_urgency_floor = None
         log.info("ClaudeCodeMCPEndpoint(name=%s) stopped", self.name)
 
     # --- MCPHostable Protocol ---
@@ -608,24 +606,13 @@ class ClaudeCodeMCPEndpoint:
 
     # --- Internal ---
 
-    def _build_summary(
-        self, urgency_floor: Literal["red", "yellow", "green"] | None = None
-    ) -> dict:
-        """Temporary shim — Task 2 will remove this in favor of _build_wake_summary().
+    def snapshot(self) -> dict:
+        """Public wrapper used by Bus.snapshot_for_agent.
 
-        For now, return the minimal wake shape so callers (debounced wake path,
-        snapshot()) get the new contract immediately. urgency_floor is ignored
-        (the new wake carries no urgency).
+        Emits the same minimal wake shape as a regular debounced wake (see
+        issue #33) — one contract for everything wake-shaped.
         """
         return self._build_wake_summary()
-
-    def snapshot(self) -> dict:
-        """Public wrapper around _build_summary; used by Bus.snapshot_for_agent.
-
-        Returns the same dict shape as the push pipeline produces, so a
-        snapshot emitted on relay connect looks identical to a real push.
-        """
-        return self._build_summary()
 
     def _make_channel_notification(self, summary: dict) -> SessionMessage:
         """Wrap the summary into a JSON-RPC notification SessionMessage."""
@@ -656,26 +643,19 @@ class ClaudeCodeMCPEndpoint:
         return out
 
     async def _notify_mail_arrived(self, urgency: str = "green") -> None:
-        """Schedule a debounced push summarizing the current mailbox.
+        """Schedule a debounced push announcing inbox activity.
 
-        Called by `deliver()` on each arrival. Red arrivals wake promptly,
-        yellow waits briefly, and green waits long enough to collect
-        human-paced bursts. A more urgent arrival shortens a pending timer;
-        less urgent arrivals never delay an already pending urgent push.
+        Called by deliver() on each arrival. Red arrivals wake promptly,
+        yellow waits briefly, green waits long enough to collect bursts.
+        A more urgent arrival shortens a pending timer; less urgent
+        arrivals never delay an already-pending urgent push.
+
+        The wake notification itself carries no queue-state — see issue #33.
+        The urgency parameter only affects debounce timing, not wake content.
         """
         delay = self._notify_debounce_seconds_by_urgency.get(urgency, 1.0)
         loop = asyncio.get_running_loop()
         deadline = loop.time() + delay
-        incoming_urgency = cast(
-            Literal["red", "yellow", "green"],
-            urgency if urgency in self._URGENCY_RANK else "green",
-        )
-        if self._debounce_urgency_floor is None:
-            self._debounce_urgency_floor = incoming_urgency
-        elif (
-            self._URGENCY_RANK[incoming_urgency] < self._URGENCY_RANK[self._debounce_urgency_floor]
-        ):
-            self._debounce_urgency_floor = incoming_urgency
 
         if self._debounce_task is not None and not self._debounce_task.done():
             if self._debounce_deadline is not None and deadline >= self._debounce_deadline:
@@ -692,11 +672,7 @@ class ClaudeCodeMCPEndpoint:
             return
         if task is self._debounce_task:
             self._debounce_deadline = None
-            urgency_floor = self._debounce_urgency_floor
-            self._debounce_urgency_floor = None
-        else:
-            urgency_floor = None
-        summary = self._build_summary(urgency_floor=urgency_floor)
+        summary = self._build_wake_summary()
 
         # Always publish to the broker so /notify/<agent> subscribers
         # (the channel relay) wake the agent regardless of whether the

--- a/packages/core/tests/test_bus_daemon_integration.py
+++ b/packages/core/tests/test_bus_daemon_integration.py
@@ -85,11 +85,11 @@ endpoints:
                 # would be notified. Either way, list_pending should surface it.
                 # Allow a short window for async dispatch to settle.
                 for _ in range(40):
-                    pending = (await client.call_tool("list_pending", {})).data
+                    pending = (await client.call_tool("list_pending", {})).data["items"]
                     if pending:
                         break
                     await asyncio.sleep(0.05)
-                pending = (await client.call_tool("list_pending", {})).data
+                pending = (await client.call_tool("list_pending", {})).data["items"]
                 texts = [p["payload"]["text"] for p in pending]
                 assert "hello-agent" in texts
 
@@ -97,7 +97,7 @@ endpoints:
                 env_id = next(p["id"] for p in pending if p["payload"]["text"] == "hello-agent")
                 await client.call_tool("handle", {"envelope_id": env_id})
 
-                pending2 = (await client.call_tool("list_pending", {})).data
+                pending2 = (await client.call_tool("list_pending", {})).data["items"]
                 assert all(p["id"] != env_id for p in pending2)
         finally:
             await bus.stop()

--- a/packages/core/tests/test_bus_daemon_push_integration.py
+++ b/packages/core/tests/test_bus_daemon_push_integration.py
@@ -155,12 +155,11 @@ endpoints:
                     )
 
                     params = matched.params or {}
-                    assert int(params.get("meta", {}).get("count", "0")) >= 1
                     assert params["meta"]["endpoint"] == "agent"
-                    # Sanity-check the summary shape Task 6 ships.
-                    assert "urgency_max" in params["meta"]
-                    assert "urgency_counts" in params["meta"]
-                    assert "by_sender" in params["meta"]
+                    # Wake meta is minimal (issue #33): endpoint + fired_at.
+                    # Authoritative count/urgency_max/by_sender are read from
+                    # list_pending after waking.
+                    assert set(params["meta"].keys()) == {"endpoint", "fired_at"}
                     assert all(isinstance(v, str) for v in params["meta"].values())
         finally:
             await bus.stop()

--- a/packages/core/tests/test_bus_snapshot_for_agent.py
+++ b/packages/core/tests/test_bus_snapshot_for_agent.py
@@ -27,26 +27,26 @@ def _env(eid: str, frm: str = "stub", urgency: str = "green") -> Envelope:
 
 
 @pytest.mark.asyncio
-async def test_snapshot_for_agent_returns_summary_when_pending(tmp_path: Path):
+async def test_snapshot_for_agent_fires_when_pending(tmp_path: Path):
     bus = Bus(BusConfig(storage_path=tmp_path / "bus.sqlite"))
     ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
     bus.register(EndpointSpec(endpoint=ep))
     ep._pending = [_env("a"), _env("b", urgency="red")]
     summary = bus.snapshot_for_agent("agent")
     assert summary is not None
-    assert summary["meta"]["count"] == 2
-    assert summary["meta"]["urgency_max"] == "red"
+    assert set(summary["meta"].keys()) == {"endpoint", "fired_at"}
     assert summary["meta"]["endpoint"] == "agent"
 
 
 @pytest.mark.asyncio
-async def test_snapshot_for_agent_returns_zero_count_when_empty(tmp_path: Path):
+async def test_snapshot_for_agent_fires_when_empty(tmp_path: Path):
     bus = Bus(BusConfig(storage_path=tmp_path / "bus.sqlite"))
     ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
     bus.register(EndpointSpec(endpoint=ep))
     summary = bus.snapshot_for_agent("agent")
     assert summary is not None
-    assert summary["meta"]["count"] == 0
+    assert set(summary["meta"].keys()) == {"endpoint", "fired_at"}
+    assert summary["meta"]["endpoint"] == "agent"
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/test_claude_code_mcp.py
+++ b/packages/core/tests/test_claude_code_mcp.py
@@ -220,10 +220,12 @@ async def test_list_pending_returns_queued_envelopes():
 
         async with Client(ep._mcp) as client:
             res = await client.call_tool("list_pending", {})
-        assert len(res.data) == 1
-        assert res.data[0]["id"] == "env-1"
-        assert res.data[0]["from"] == "stub"
-        assert res.data[0]["kind"] == "TextMessage"
+        items = res.data["items"]
+        assert res.data["meta"]["count"] == 1
+        assert len(items) == 1
+        assert items[0]["id"] == "env-1"
+        assert items[0]["from"] == "stub"
+        assert items[0]["kind"] == "TextMessage"
     finally:
         await ep.stop()
 
@@ -269,7 +271,8 @@ async def test_handle_tool_acks_and_removes_from_pending():
         # And the pending entry is gone.
         async with Client(ep._mcp) as client:
             res = await client.call_tool("list_pending", {})
-        assert res.data == []
+        assert res.data["items"] == []
+        assert res.data["meta"]["count"] == 0
     finally:
         await ep.stop()
 
@@ -290,7 +293,7 @@ async def test_deliver_without_session_raises_endpoint_unavailable_and_queues():
         # internally so a freshly-attached client can pick it up.
         async with Client(ep._mcp) as client:
             res = await client.call_tool("list_pending", {})
-        ids = {item["id"] for item in res.data}
+        ids = {item["id"] for item in res.data["items"]}
         assert "env-q" in ids
     finally:
         await ep.stop()
@@ -358,7 +361,7 @@ async def test_session_registry_tracks_connected_sessions_after_mcp_message():
             await ep.deliver(env)
             # Envelope should be in pending (no EU raised).
             res = await client.call_tool("list_pending", {})
-            ids = {item["id"] for item in res.data}
+            ids = {item["id"] for item in res.data["items"]}
             assert "env-active" in ids
     finally:
         await ep.stop()

--- a/packages/core/tests/test_claude_code_mcp_batching.py
+++ b/packages/core/tests/test_claude_code_mcp_batching.py
@@ -31,10 +31,12 @@ async def test_list_pending_batch_window_zero_returns_flat_list():
         _env("b", "alice", age_seconds=8),
         _env("c", "alice", age_seconds=6),
     ]
-    rows = await ep._call_list_pending(batch_window_seconds=0)
+    result = await ep._call_list_pending(batch_window_seconds=0)
+    rows = result["items"]
     # Default 0: no batching — flat list of envelope dicts.
     assert all(row.get("type") in (None, "single") or "envelope" not in row for row in rows)
     assert len(rows) == 3
+    assert result["meta"]["count"] == 3
 
 
 @pytest.mark.asyncio
@@ -45,7 +47,8 @@ async def test_list_pending_batches_three_same_sender_within_window():
         _env("b", "alice", age_seconds=10),
         _env("c", "alice", age_seconds=5),
     ]
-    rows = await ep._call_list_pending(batch_window_seconds=30)
+    result = await ep._call_list_pending(batch_window_seconds=30)
+    rows = result["items"]
     assert len(rows) == 1
     group = rows[0]
     assert group["type"] == "batch"
@@ -63,7 +66,8 @@ async def test_list_pending_does_not_batch_different_senders():
         _env("b", "bob", age_seconds=8),
         _env("c", "alice", age_seconds=6),
     ]
-    rows = await ep._call_list_pending(batch_window_seconds=30)
+    result = await ep._call_list_pending(batch_window_seconds=30)
+    rows = result["items"]
     assert len(rows) == 3
     assert all(r["type"] == "single" for r in rows)
     assert [r["envelope"]["id"] for r in rows] == ["a", "b", "c"]
@@ -78,7 +82,8 @@ async def test_list_pending_batches_only_within_window():
         _env("b", "alice", age_seconds=110),
         _env("c", "alice", age_seconds=5),
     ]
-    rows = await ep._call_list_pending(batch_window_seconds=30)
+    result = await ep._call_list_pending(batch_window_seconds=30)
+    rows = result["items"]
     assert len(rows) == 2
     assert rows[0]["type"] == "batch"
     assert [e["id"] for e in rows[0]["envelopes"]] == ["a", "b"]
@@ -94,7 +99,8 @@ async def test_list_pending_batches_respect_urgency_grouping():
         _env("r1", "alice", age_seconds=10, urgency="red"),
         _env("g1", "alice", age_seconds=5, urgency="green"),
     ]
-    rows = await ep._call_list_pending(batch_window_seconds=30)
+    result = await ep._call_list_pending(batch_window_seconds=30)
+    rows = result["items"]
     # Red comes first (tier sort), green second; they're not in the same group
     # because urgency differs.
     assert len(rows) == 2

--- a/packages/core/tests/test_claude_code_mcp_urgency_ordering.py
+++ b/packages/core/tests/test_claude_code_mcp_urgency_ordering.py
@@ -40,8 +40,8 @@ async def test_list_pending_red_first_then_yellow_then_green():
         _env("r1", "red", age_seconds=6),
         _env("g2", "green", age_seconds=4),
     ]
-    rows = await ep._call_list_pending()
-    assert _ids(rows) == ["r1", "y1", "g1", "g2"]
+    result = await ep._call_list_pending()
+    assert _ids(result["items"]) == ["r1", "y1", "g1", "g2"]
 
 
 @pytest.mark.asyncio
@@ -52,8 +52,8 @@ async def test_list_pending_fifo_within_same_tier():
         _env("r2", "red", age_seconds=20),
         _env("r3", "red", age_seconds=10),  # newest
     ]
-    rows = await ep._call_list_pending()
-    assert _ids(rows) == ["r1", "r2", "r3"]
+    result = await ep._call_list_pending()
+    assert _ids(result["items"]) == ["r1", "r2", "r3"]
 
 
 @pytest.mark.asyncio
@@ -64,12 +64,13 @@ async def test_list_pending_tier_wins_over_arrival_time():
         _env("g_old", "green", age_seconds=100),
         _env("r_new", "red", age_seconds=1),
     ]
-    rows = await ep._call_list_pending()
-    assert _ids(rows) == ["r_new", "g_old"]
+    result = await ep._call_list_pending()
+    assert _ids(result["items"]) == ["r_new", "g_old"]
 
 
 @pytest.mark.asyncio
 async def test_list_pending_empty_returns_empty():
     ep = _make_endpoint()
-    rows = await ep._call_list_pending()
-    assert rows == []
+    result = await ep._call_list_pending()
+    assert result["items"] == []
+    assert result["meta"]["count"] == 0

--- a/packages/core/tests/test_list_pending_meta_invariants.py
+++ b/packages/core/tests/test_list_pending_meta_invariants.py
@@ -1,0 +1,97 @@
+"""Property tests: list_pending's meta and items must agree by construction.
+
+The bug behind issue #33 was that wake-meta could disagree with list_pending.
+The fix moves meta into list_pending's response, computed from the same
+atomic read of self._pending. These tests assert that contract holds for
+varied inbox states.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from agent_core.bus.envelope import Envelope, TextMessagePayload
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+
+
+def _envelope(
+    idx: int,
+    urgency: str = "green",
+    from_: str = "alice",
+    kind: str = "TextMessage",
+) -> Envelope:
+    return Envelope(
+        id=f"env-{idx}-{uuid.uuid4().hex[:8]}",
+        correlation_id=f"c-{idx}",
+        from_=from_,
+        to="agent",
+        kind=kind,  # type: ignore[arg-type]
+        payload=TextMessagePayload(text=f"msg{idx}"),
+        urgency=urgency,  # type: ignore[arg-type]
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.parametrize(
+    "envelopes, batch_window",
+    [
+        ([], 0),
+        ([_envelope(0, "green")], 0),
+        ([_envelope(0, "red"), _envelope(1, "yellow"), _envelope(2, "green")], 0),
+        ([_envelope(0, "red"), _envelope(1, "red"), _envelope(2, "green")], 0),
+        ([_envelope(i, "green", from_="alice") for i in range(3)], 30),
+        (
+            [
+                _envelope(0, "yellow", from_="alice"),
+                _envelope(1, "yellow", from_="alice"),
+                _envelope(2, "green", from_="bob"),
+            ],
+            30,
+        ),
+    ],
+)
+def test_list_pending_meta_matches_items(
+    envelopes: list[Envelope], batch_window: int
+) -> None:
+    """meta.count, urgency_max, urgency_counts, by_sender all reconstruct from items."""
+
+    async def _run() -> dict:
+        endpoint = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+        for env in envelopes:
+            endpoint.queue_for_pickup(env)
+        return await endpoint._call_list_pending(batch_window_seconds=batch_window)
+
+    result = asyncio.run(_run())
+
+    assert set(result.keys()) == {"meta", "items"}
+    meta = result["meta"]
+
+    assert meta["count"] == len(envelopes)
+    assert meta["endpoint"] == "agent"
+    assert "fetched_at" in meta
+
+    # urgency_max
+    if not envelopes:
+        assert meta["urgency_max"] == "green"
+    else:
+        order = {"red": 0, "yellow": 1, "green": 2}
+        expected_max = min((e.urgency for e in envelopes), key=lambda u: order[u])
+        assert meta["urgency_max"] == expected_max
+
+    # urgency_counts
+    counts = {"red": 0, "yellow": 0, "green": 0}
+    for e in envelopes:
+        counts[e.urgency] += 1
+    assert meta["urgency_counts"] == counts
+
+    # by_sender
+    by_sender_index = {entry["from"]: entry for entry in meta["by_sender"]}
+    sender_counts: dict[str, int] = {}
+    for e in envelopes:
+        sender_counts[e.from_] = sender_counts.get(e.from_, 0) + 1
+    for sender, expected_count in sender_counts.items():
+        assert by_sender_index[sender]["count"] == expected_count

--- a/packages/core/tests/test_list_pending_meta_invariants.py
+++ b/packages/core/tests/test_list_pending_meta_invariants.py
@@ -8,7 +8,6 @@ varied inbox states.
 
 from __future__ import annotations
 
-import asyncio
 import uuid
 from datetime import UTC, datetime
 
@@ -54,18 +53,14 @@ def _envelope(
         ),
     ],
 )
-def test_list_pending_meta_matches_items(
+async def test_list_pending_meta_matches_items(
     envelopes: list[Envelope], batch_window: int
 ) -> None:
     """meta.count, urgency_max, urgency_counts, by_sender all reconstruct from items."""
-
-    async def _run() -> dict:
-        endpoint = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
-        for env in envelopes:
-            endpoint.queue_for_pickup(env)
-        return await endpoint._call_list_pending(batch_window_seconds=batch_window)
-
-    result = asyncio.run(_run())
+    endpoint = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    for env in envelopes:
+        endpoint.queue_for_pickup(env)
+    result = await endpoint._call_list_pending(batch_window_seconds=batch_window)
 
     assert set(result.keys()) == {"meta", "items"}
     meta = result["meta"]

--- a/packages/core/tests/test_notify_broker_publish_hook.py
+++ b/packages/core/tests/test_notify_broker_publish_hook.py
@@ -43,8 +43,10 @@ async def test_endpoint_publishes_to_broker_when_session_active():
     await asyncio.sleep(0.1)  # let debounce fire
 
     event = q.get_nowait()
-    assert event["meta"]["count"] == 1
+    # Wake meta is minimal (issue #33). The agent reads count from
+    # list_pending after waking.
     assert event["meta"]["endpoint"] == "agent-a"
+    assert set(event["meta"].keys()) == {"endpoint", "fired_at"}
 
 
 @pytest.mark.asyncio
@@ -66,7 +68,10 @@ async def test_endpoint_publishes_to_broker_even_when_no_session():
         await ep.deliver(_env("e1", urgency="red"))
 
     event = await asyncio.wait_for(q.get(), timeout=1.0)
-    assert event["meta"]["count"] == 1
+    # Wake meta is minimal (issue #33) — the broker fan-out carries the
+    # same minimal shape as the HTTP-push wake.
+    assert set(event["meta"].keys()) == {"endpoint", "fired_at"}
+    assert event["meta"]["endpoint"] == "agent-a"
 
 
 @pytest.mark.asyncio
@@ -93,7 +98,9 @@ async def test_deliver_publishes_to_broker_when_no_session_attached():
 
     # Wait for the red debounce window to fire (default ~50ms; bound generously).
     summary = await asyncio.wait_for(queue.get(), timeout=1.0)
-    assert summary["meta"]["count"] == 1
+    # Wake meta is minimal (issue #33). The relay's downstream consumer reads
+    # authoritative state via list_pending after the wake.
+    assert set(summary["meta"].keys()) == {"endpoint", "fired_at"}
     assert summary["meta"]["endpoint"] == "agent"
 
 

--- a/packages/core/tests/test_notify_mail_arrived.py
+++ b/packages/core/tests/test_notify_mail_arrived.py
@@ -393,9 +393,10 @@ async def test_list_pending_surfaces_event_payload_type_and_data():
     ]
 
     listing = await ep._call_list_pending()
-    assert len(listing) == 2
+    assert listing["meta"]["count"] == 2
+    assert len(listing["items"]) == 2
 
-    by_type = {entry["payload"]["type"]: entry for entry in listing}
+    by_type = {entry["payload"]["type"]: entry for entry in listing["items"]}
     assert {"HandoffReady", "HandoffFailed"} <= by_type.keys()
 
     ready = by_type["HandoffReady"]

--- a/packages/core/tests/test_notify_mail_arrived.py
+++ b/packages/core/tests/test_notify_mail_arrived.py
@@ -435,6 +435,66 @@ async def test_list_pending_surfaces_event_payload_type_and_data():
 
 
 @pytest.mark.asyncio
+async def test_wake_and_list_pending_disagreement_eliminated():
+    """Regression test for issue #33: wake/list_pending drift eliminated.
+
+    Reproduces the exact failure shape Pepper caught — pre-fix, the wake
+    notification carried a stale snapshot (e.g. ``count=3``) that could
+    disagree with what ``list_pending`` returned later (e.g. only 1 item
+    actually pending) once the agent had drained envelopes between the
+    wake firing and being consumed.
+
+    Under the post-fix contract this test passes by construction:
+    - the wake meta is minimal (``endpoint`` + ``fired_at`` only) and the
+      content is the fixed ``"INBOX: pending (<endpoint>)"`` string, so
+      the wake cannot lie about queue state, and
+    - ``list_pending``'s ``meta`` is computed from the same atomic read
+      of ``self._pending`` that produces ``items``, so ``meta.count``
+      always agrees with ``len(items)``.
+    """
+    published: list[dict] = []
+
+    class CaptureBroker:
+        async def publish(self, agent: str, event: dict) -> None:
+            published.append(event)
+
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    ep._notify_broker = CaptureBroker()  # type: ignore[assignment]
+
+    # Queue 3 envelopes: red, red, green.
+    e0 = _env("e0", urgency="red")
+    e1 = _env("e1", urgency="red")
+    e2 = _env("e2", urgency="green")
+    ep.queue_for_pickup(e0)
+    ep.queue_for_pickup(e1)
+    ep.queue_for_pickup(e2)
+
+    # Trigger debounce on red (0.05s in defaults).
+    await ep._notify_mail_arrived(urgency="red")
+
+    # Mid-debounce, simulate the agent draining the two red envelopes
+    # between wake-fire and consumption — this is exactly what Pepper
+    # does between wakes when finishing the prior batch.
+    ep._pending = [env for env in ep._pending if env.id not in {e0.id, e1.id}]
+
+    # Let the debounce fire.
+    await asyncio.sleep(0.2)
+
+    # The wake fired and carries no queue-state meta.
+    assert published, "expected wake to fire after debounce"
+    event = published[-1]
+    assert set(event["meta"].keys()) == {"endpoint", "fired_at"}
+    assert event["content"] == "INBOX: pending (agent)"
+
+    # list_pending's meta and items are computed atomically — they agree.
+    listing = await ep._call_list_pending()
+    assert listing["meta"]["count"] == 1
+    assert listing["meta"]["urgency_max"] == "green"
+    assert len(listing["items"]) == 1
+    assert listing["items"][0]["id"] == e2.id
+
+
+@pytest.mark.asyncio
 async def test_mixed_event_and_text_envelopes_surface_together():
     """Discord traffic and bus Events coexist on the same perception surface.
     The agent sees one notification covering both, with grouped sender counts."""

--- a/packages/core/tests/test_notify_mail_arrived.py
+++ b/packages/core/tests/test_notify_mail_arrived.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from datetime import UTC, datetime
 from typing import Any
 
@@ -90,11 +89,11 @@ async def test_notify_pushes_summary_when_session_active():
     assert len(session.sent) == 1
     assert _extract_method(session.sent[0]) == "notifications/claude/channel"
     params = _extract_params(session.sent[0])
-    assert "INBOX: 1 pending" in params["content"]
-    assert params["meta"]["count"] == "1"
+    # Wake content is the fixed "go look" string — no count baked in (issue #33).
+    assert params["content"] == "INBOX: pending (a)"
     assert params["meta"]["endpoint"] == "a"
-    assert params["meta"]["urgency_max"] == "green"
-    assert json.loads(params["meta"]["urgency_counts"]) == {"red": 0, "yellow": 0, "green": 1}
+    # Wake meta is minimal: endpoint + fired_at only.
+    assert set(params["meta"].keys()) == {"endpoint", "fired_at"}
 
 
 @pytest.mark.asyncio
@@ -128,8 +127,9 @@ async def test_notify_channel_meta_values_are_strings_on_http_push_path():
     await asyncio.sleep(0.1)
 
     meta = _extract_params(session.sent[0])["meta"]
-    assert meta["count"] == "1"
-    assert meta["urgency_counts"] == '{"red": 1, "yellow": 0, "green": 0}'
+    # Channel meta is Record<string, string> — even the minimal wake fields
+    # must be coerced to strings.
+    assert meta["endpoint"] == "a"
     assert all(isinstance(v, str) for v in meta.values())
 
 
@@ -147,13 +147,17 @@ async def test_notify_debounces_burst_into_one_push():
     await ep._notify_mail_arrived("green")
     await asyncio.sleep(0.1)  # let debounce fire
 
+    # Three arrivals coalesce into a single wake push. Count is no longer in
+    # wake meta (issue #33) — coalescing is observable as len(session.sent)==1.
     assert len(session.sent) == 1
-    params = _extract_params(session.sent[0])
-    assert params["meta"]["count"] == "3"
 
 
 @pytest.mark.asyncio
-async def test_notify_summary_reports_max_urgency():
+async def test_notify_wake_fires_for_mixed_urgencies():
+    """Wake fires regardless of urgency mix — content/meta are wake-only (issue #33).
+
+    Authoritative urgency_max is now in list_pending's meta, not the wake.
+    """
     ep = ClaudeCodeMCPEndpoint(name="a", mount="/mcp/a")
     _speed_up_debounce(ep)
     session = _RecordingSession()
@@ -167,12 +171,15 @@ async def test_notify_summary_reports_max_urgency():
     await asyncio.sleep(0.1)
 
     params = _extract_params(session.sent[0])
-    assert params["meta"]["urgency_max"] == "red"
-    assert json.loads(params["meta"]["urgency_counts"]) == {"red": 1, "yellow": 1, "green": 1}
+    assert set(params["meta"].keys()) == {"endpoint", "fired_at"}
 
 
 @pytest.mark.asyncio
-async def test_notify_summary_uses_yellow_floor_for_empty_inbox_timeout_wake():
+async def test_notify_fires_on_empty_inbox_timeout_wake():
+    """Missing-ack timeout fires a wake even with empty inbox.
+
+    Wake content is the fixed string regardless of pending count (issue #33).
+    """
     ep = ClaudeCodeMCPEndpoint(name="a", mount="/mcp/a")
     _speed_up_debounce(ep)
     session = _RecordingSession()
@@ -183,30 +190,40 @@ async def test_notify_summary_uses_yellow_floor_for_empty_inbox_timeout_wake():
     await ep._notify_mail_arrived("yellow")
     await asyncio.sleep(0.1)
 
+    assert len(session.sent) == 1
     params = _extract_params(session.sent[0])
-    assert params["meta"]["count"] == "0"
-    assert params["meta"]["urgency_max"] == "yellow"
-    assert json.loads(params["meta"]["urgency_counts"]) == {"red": 0, "yellow": 0, "green": 0}
+    assert params["content"] == "INBOX: pending (a)"
+    assert set(params["meta"].keys()) == {"endpoint", "fired_at"}
 
 
 @pytest.mark.asyncio
-async def test_notify_summary_keeps_red_when_yellow_floor_and_red_pending():
+async def test_notify_yellow_wake_with_red_pending_still_fires_minimal_wake():
+    """Even if wake floor is yellow, the wake meta stays minimal.
+
+    Pre-#33 the wake carried urgency_max; now it carries only endpoint +
+    fired_at and the agent reads urgency_max from list_pending.
+    """
     ep = ClaudeCodeMCPEndpoint(name="a", mount="/mcp/a")
     _speed_up_debounce(ep)
     session = _RecordingSession()
     ep._register_session(session)
     ep._pending = [_env("r1", urgency="red")]
 
-    # Even if wake floor is yellow, red pending should remain red.
     await ep._notify_mail_arrived("yellow")
     await asyncio.sleep(0.1)
 
+    assert len(session.sent) == 1
     params = _extract_params(session.sent[0])
-    assert params["meta"]["urgency_max"] == "red"
+    assert set(params["meta"].keys()) == {"endpoint", "fired_at"}
 
 
 @pytest.mark.asyncio
-async def test_notify_summary_groups_by_sender():
+async def test_notify_wake_does_not_carry_by_sender():
+    """Sender breakdown moved to list_pending's meta (issue #33).
+
+    The wake itself must not embed by_sender — that was the race-prone
+    field. Agents read it from list_pending after waking.
+    """
     ep = ClaudeCodeMCPEndpoint(name="a", mount="/mcp/a")
     _speed_up_debounce(ep)
     session = _RecordingSession()
@@ -220,8 +237,7 @@ async def test_notify_summary_groups_by_sender():
     await asyncio.sleep(0.1)
 
     params = _extract_params(session.sent[0])
-    by_sender = {entry["from"]: entry["count"] for entry in json.loads(params["meta"]["by_sender"])}
-    assert by_sender == {"alice": 2, "bob": 1}
+    assert "by_sender" not in params["meta"]
 
 
 @pytest.mark.asyncio
@@ -262,8 +278,11 @@ async def test_red_arrival_shortens_pending_green_debounce():
     await ep._notify_mail_arrived("red")
     await asyncio.sleep(0.02)
 
+    # The red arrival shortens the debounce; observable as the wake firing
+    # within ~20ms of the red call. Wake meta is minimal (issue #33) — the
+    # agent reads urgency_max from list_pending after waking.
     assert len(session.sent) == 1
-    assert _extract_params(session.sent[0])["meta"]["urgency_max"] == "red"
+    assert set(_extract_params(session.sent[0])["meta"].keys()) == {"endpoint", "fired_at"}
 
 
 @pytest.mark.asyncio
@@ -279,8 +298,10 @@ async def test_green_arrival_does_not_delay_pending_red_debounce():
     await ep._notify_mail_arrived("green")
     await asyncio.sleep(0.02)
 
+    # Red's short debounce wins; only one wake fires within ~25ms total.
+    # Wake meta is minimal — the agent reads urgency_max from list_pending.
     assert len(session.sent) == 1
-    assert _extract_params(session.sent[0])["meta"]["urgency_max"] == "red"
+    assert set(_extract_params(session.sent[0])["meta"].keys()) == {"endpoint", "fired_at"}
 
 
 @pytest.mark.asyncio
@@ -364,10 +385,10 @@ async def test_deliver_kind_agnostic_pushes_for_handoff_ready_event_envelope():
     assert len(session.sent) == 1
     assert _extract_method(session.sent[0]) == "notifications/claude/channel"
     params = _extract_params(session.sent[0])
-    # The summary is generic — the agent then calls list_pending to see specifics.
-    assert "INBOX: 1 pending" in params["content"]
-    assert params["meta"]["count"] == "1"
-    assert params["meta"]["urgency_max"] == "green"
+    # The wake is generic (issue #33) — fixed string, minimal meta.
+    # The agent calls list_pending to see specifics (count, urgency_max, etc.).
+    assert params["content"] == "INBOX: pending (a)"
+    assert set(params["meta"].keys()) == {"endpoint", "fired_at"}
 
 
 @pytest.mark.asyncio
@@ -436,7 +457,7 @@ async def test_mixed_event_and_text_envelopes_surface_together():
 
     assert len(session.sent) == 1
     params = _extract_params(session.sent[0])
-    assert params["meta"]["count"] == "2"
-    assert params["meta"]["urgency_max"] == "yellow"
-    by_sender = {entry["from"]: entry["count"] for entry in json.loads(params["meta"]["by_sender"])}
-    assert by_sender == {"discord": 1, "handoff-jobs": 1}
+    # Wake meta is minimal (issue #33). The agent reads count, urgency_max,
+    # and by_sender from list_pending's meta after waking — it sees both the
+    # Discord TextMessage and the handoff-jobs Event there.
+    assert set(params["meta"].keys()) == {"endpoint", "fired_at"}

--- a/packages/core/tests/test_notify_route.py
+++ b/packages/core/tests/test_notify_route.py
@@ -41,12 +41,19 @@ async def test_notify_route_streams_published_events():
 
 
 @pytest.mark.asyncio
-async def test_notify_route_emits_initial_snapshot_when_pending_exists():
+async def test_notify_route_emits_initial_snapshot_on_connect():
+    """Under the new minimal wake contract (issue #33), the route always emits
+    the initial snapshot when one is provided. The snapshot is a pure "go look"
+    signal — its meta carries only ``endpoint`` and ``fired_at``, never a count.
+    """
     broker = NotificationBroker()
 
     def fake_snapshot(name: str) -> dict | None:
         if name == "agent-a":
-            return {"content": "INBOX: 1 pending", "meta": {"count": 1, "endpoint": "agent-a"}}
+            return {
+                "content": "INBOX: pending (agent-a)",
+                "meta": {"endpoint": "agent-a", "fired_at": "2026-05-08T00:00:00+00:00"},
+            }
         return None
 
     host = HTTPHost(bind_port=0, notify_broker=broker, notify_snapshot=fake_snapshot)
@@ -61,42 +68,53 @@ async def test_notify_route_emits_initial_snapshot_when_pending_exists():
                         events.append(json.loads(line[len("data: ") :]))
                         break  # initial snapshot received
         assert len(events) == 1
-        assert events[0]["meta"]["count"] == 1
+        # New-contract drift-guard: meta carries exactly endpoint + fired_at,
+        # nothing else. No count, no queue-state metadata.
+        assert events[0]["meta"]["endpoint"] == "agent-a"
+        assert set(events[0]["meta"].keys()) == {"endpoint", "fired_at"}
     finally:
         await host.stop()
 
 
 @pytest.mark.asyncio
-async def test_notify_route_skips_initial_snapshot_when_count_zero():
+async def test_notify_route_emits_initial_snapshot_even_when_inbox_is_empty():
+    """Inverse of the old count-zero suppression test.
+
+    Under the new contract the wake snapshot has no count field — its sole
+    purpose on relay-connect is to nudge the agent to call ``list_pending``.
+    Whether the inbox actually has mail is the agent's problem, not the
+    route's. So when ``snapshot()`` returns a snapshot, the route MUST emit
+    it on connect, even if the underlying queue would be empty.
+    """
     broker = NotificationBroker()
 
+    # Snapshot shape no longer carries count; the route can't know (and must
+    # not care) whether the inbox is empty. _build_wake_summary returns a
+    # snapshot regardless — see Bus.snapshot_for_agent.
     def fake_snapshot(_name: str) -> dict | None:
-        return {"content": "INBOX: 0 pending", "meta": {"count": 0, "endpoint": "agent-a"}}
+        return {
+            "content": "INBOX: pending (agent-a)",
+            "meta": {"endpoint": "agent-a", "fired_at": "2026-05-08T00:00:00+00:00"},
+        }
 
     host = HTTPHost(bind_port=0, notify_broker=broker, notify_snapshot=fake_snapshot)
     await host.start()
     try:
         url = f"http://127.0.0.1:{host.port}/notify/agent-a"
-        async with httpx.AsyncClient(timeout=2.0) as client:
+        events = []
+        async with httpx.AsyncClient(timeout=5.0) as client:
             async with client.stream("GET", url) as resp:
-                # No initial snapshot. Drive a real publish to confirm the
-                # stream is live but the snapshot was suppressed.
-                async def push_after_delay():
-                    await asyncio.sleep(0.2)
-                    await broker.publish("agent-a", {"meta": {"count": 1}})
-
-                pump = asyncio.create_task(push_after_delay())
-                events = []
-                try:
-                    async for line in resp.aiter_lines():
-                        if line.startswith("data: "):
-                            events.append(json.loads(line[len("data: ") :]))
-                            break
-                finally:
-                    pump.cancel()
-        # The first event we received was the post-connect publish, not the
-        # zero-count snapshot.
-        assert events == [{"meta": {"count": 1}}]
+                async for line in resp.aiter_lines():
+                    if line.startswith("data: "):
+                        events.append(json.loads(line[len("data: ") :]))
+                        break  # initial snapshot received
+        # The first frame on connect is the snapshot — emitted regardless of
+        # whether the inbox actually has pending mail.
+        assert len(events) == 1
+        assert events[0]["meta"]["endpoint"] == "agent-a"
+        assert set(events[0]["meta"].keys()) == {"endpoint", "fired_at"}
+        # No count field anywhere in the new contract.
+        assert "count" not in events[0]["meta"]
     finally:
         await host.stop()
 

--- a/packages/core/tests/test_wake_meta_drift_guard.py
+++ b/packages/core/tests/test_wake_meta_drift_guard.py
@@ -1,0 +1,70 @@
+"""Drift-guard: wake notifications carry only endpoint + fired_at in meta.
+
+If anyone re-introduces count, urgency_max, by_sender, or urgency_counts
+to the wake notification's meta, this test fires. The fix for issue #33
+relies on the wake being purely a 'go look' signal — re-adding queue-state
+fields would re-introduce the original race.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from agent_core.bus.envelope import Envelope, TextMessagePayload
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+
+ALLOWED_WAKE_META_KEYS = frozenset({"endpoint", "fired_at"})
+
+
+def _envelope(idx: int, urgency: str = "green", from_: str = "alice") -> Envelope:
+    return Envelope(
+        id=f"env-{idx}-{uuid.uuid4().hex[:8]}",
+        correlation_id=f"c-{idx}",
+        from_=from_,
+        to="agent",
+        kind="TextMessage",
+        payload=TextMessagePayload(text=f"msg{idx}"),
+        urgency=urgency,  # type: ignore[arg-type]
+        created_at=datetime.now(UTC),
+    )
+
+
+def test_wake_summary_meta_keys_are_minimal() -> None:
+    """The wake-only summary builder emits exactly the allowed keys."""
+    endpoint = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    summary = endpoint._build_wake_summary()
+    assert set(summary["meta"].keys()) == ALLOWED_WAKE_META_KEYS
+
+
+def test_wake_content_is_fixed_string() -> None:
+    """Wake content is the fixed non-lying string — not a stale snapshot."""
+    endpoint = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    # Even if pending is non-empty, content does not reference counts.
+    endpoint.queue_for_pickup(_envelope(0, urgency="green", from_="x"))
+    endpoint.queue_for_pickup(_envelope(1, urgency="red", from_="y"))
+    summary = endpoint._build_wake_summary()
+    assert summary["content"] == "INBOX: pending (agent)"
+
+
+@pytest.mark.asyncio
+async def test_published_wake_has_no_queue_state_meta() -> None:
+    """Verify the actual debounce-fire path emits the minimal shape."""
+    published: list[dict] = []
+
+    class CaptureBroker:
+        async def publish(self, agent: str, event: dict) -> None:
+            published.append(event)
+
+    endpoint = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    endpoint._notify_broker = CaptureBroker()  # type: ignore[assignment]
+    endpoint.queue_for_pickup(_envelope(0, urgency="green"))
+    await endpoint._notify_mail_arrived(urgency="green")
+    # Wait long enough for the debounce to fire (green = 1.0s in defaults).
+    await asyncio.sleep(1.2)
+    assert published, "expected at least one published wake event"
+    event = published[-1]
+    assert set(event["meta"].keys()) == ALLOWED_WAKE_META_KEYS


### PR DESCRIPTION
## Summary

Closes #33. Wake notifications and `list_pending` no longer drift.

- **Wake notification meta minimized** to `{endpoint, fired_at}`. Wake content is the fixed string `"INBOX: pending (<endpoint>)"`. The wake is now a pure "go look" signal — no queue-state on board.
- **`list_pending` returns `{meta, items}`** where `meta` carries `count`, `urgency_max`, `urgency_counts`, `by_sender` — computed atomically from the same `self._pending` read as `items`. Race-free by construction.
- **`Bus.snapshot_for_agent`** follows the same minimal wake contract for uniformity. One wake shape, one parser path.
- **`/notify/<agent>` SSE route** always emits the initial snapshot on relay-connect (was gated on the now-removed `meta.count`). Caught by final whole-branch review.
- **Drops `_debounce_urgency_floor`** plumbing — its only consumer was the wake's `urgency_max` field, which no longer exists.

Approved by consumer (Pepper) for option B (hybrid): wake = "go look", `list_pending` = authoritative aggregate. Cutover validates on testbot first per the durable hands-off rule.

## Test plan

- [x] `uv run pytest packages/core/tests packages/agent-core-channel/tests` — 625 passed, 0 failed (up from 615 pre-branch baseline; +10 net)
- [x] `uv run ruff check` on changed files — clean (19 pre-existing errors in `memory-compiler/` are unrelated and out of scope)
- [x] `uv run mypy` on changed source — clean
- [ ] Validate on testbot: send mixed-urgency burst, confirm wake content is the fixed string and `list_pending` meta matches its own items
- [ ] Then restart Pepper to pick up the new contract

## New tests

- **Invariant** (`test_list_pending_meta_invariants.py`) — parametrized property test asserting `meta.count == sum(envelopes)`, `urgency_max` correctness, `urgency_counts` sums, and `by_sender` reconstruction across varied inbox states. Catches future drift if anyone ever computes meta separately from items.
- **Drift-guard** (`test_wake_meta_drift_guard.py`) — asserts wake meta keys are exactly `{endpoint, fired_at}` and content is the fixed string, including a published-via-broker integration check. Same shape as PR #49's per-kind summarizer drift-guard.
- **Regression** (in `test_notify_mail_arrived.py`) — `test_wake_and_list_pending_disagreement_eliminated` reproduces the exact failure shape Pepper caught: queue 3 envelopes, drain 2 mid-debounce, fire wake, assert wake has no count/urgency_max and that `list_pending` reports `count=1`. Would have failed under the pre-fix code path.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-08-issue-33-wake-snapshot-lag-design.md`
- Plan: `docs/superpowers/plans/2026-05-08-issue-33-wake-snapshot-lag.md`