### PR TITLE
feat+fix: per-round-trip call reduction (#54 + #67)

### DIFF
--- a/packages/core/changelog.d/54.fixed.md
+++ b/packages/core/changelog.d/54.fixed.md
@@ -1,0 +1,8 @@
+Routine green Acknowledgments now auto-clear by **shape**, not by registry
+lookup. The earlier gate required `_recent_outbound_ids[in_reply_to]` to be
+present, which left a startup gap: any ack arriving for a send issued
+before the daemon's most recent restart fell through to the pickup queue
+and woke the agent. The auto-clear path now relies on
+kind/urgency/note + the `in_reply_to == payload.of` integrity guard, so it
+survives daemon restarts. Yellow/red acks and notes prefixed `error:`
+still wake.

--- a/packages/core/changelog.d/67.added.md
+++ b/packages/core/changelog.d/67.added.md
@@ -1,0 +1,15 @@
+Two new MCP tools on `ClaudeCodeMCPEndpoint` cut the per-round-trip floor
+to 2 calls (was 3 after #54, was 5 before #54). Both are additive —
+existing `list_pending`, `handle`, and `send` remain available unchanged.
+
+- `consume(batch_window_seconds=30, auto_ack=True, max_items=None)` —
+  same return shape as `list_pending`; with `auto_ack=True` (default)
+  every envelope id in the returned items is ack'd before the call
+  returns.
+- `reply(in_reply_to, payload, urgency='green', metadata=None)` —
+  publishes a `TextMessage` outbound and acks the inbound atomically.
+  Routing (`to`, `correlation_id`) inherits from the inbound; metadata
+  is shallow-merged with the override winning per top-level key.
+  Urgency defaults to `'green'`; pass `'auto'` to inherit from the
+  inbound. Looks up the inbound in the pickup queue first, then in a
+  new recent-inbounds cache so it works after `consume(auto_ack=True)`.

--- a/packages/core/src/agent_core/endpoints/claude_code_mcp.py
+++ b/packages/core/src/agent_core/endpoints/claude_code_mcp.py
@@ -181,9 +181,12 @@ class ClaudeCodeMCPEndpoint:
                 "meta is the authoritative aggregate, computed atomically with items. "
                 "Process each item, then call handle(envelope_id) on each to ack and "
                 "remove from the queue. Send replies via the send tool. "
-                "Routine delivery Acknowledgments for your own recent outbounds may "
-                "be auto-cleared without a wake; you are still notified for failures, "
-                "urgent acks, other envelope kinds, and missing-ack timeouts."
+                "Routine green Acknowledgments matching your outbounds (kind="
+                "Acknowledgment, urgency=green, note not prefixed 'error:', "
+                "in_reply_to set) are auto-cleared by the bus and never reach "
+                "your queue or wake you. You see only failures (yellow/red acks, "
+                "or notes prefixed 'error:'), other envelope kinds, and missing-ack "
+                "timeouts. Auto-clear is shape-based, so it survives daemon restarts."
             ),
         )
         self._handle: BusHandle | None = None
@@ -312,7 +315,18 @@ class ClaudeCodeMCPEndpoint:
             self._recent_outbound_ids.pop(oldest_key)
             self._cancel_missing_ack(oldest_key)
 
-    def _is_routine_green_ack(self, envelope: Envelope, *, now: float) -> bool:
+    def _is_routine_green_ack(self, envelope: Envelope) -> bool:
+        """Decide whether to auto-clear an Acknowledgment by *shape*.
+
+        Issue #54: the gate is shape-only — kind/urgency/note + the
+        in_reply_to/payload.of integrity check. The earlier registry
+        lookup leaked routine acks into the queue any time the daemon
+        restarted between the send and the ack (registry empty until
+        sends warmed it back up). Auto-clear now survives restarts.
+
+        The ``_recent_outbound_ids`` registry stays — it still drives the
+        missing-ack-timeout path. But it no longer gates auto-clear.
+        """
         if self.wake_on_all_acknowledgments:
             return False
         if envelope.kind != "Acknowledgment":
@@ -326,11 +340,6 @@ class ClaudeCodeMCPEndpoint:
             return False
         irt = envelope.in_reply_to
         if irt is None or envelope.payload.of != irt:
-            return False
-        registered_at = self._recent_outbound_ids.get(irt)
-        if registered_at is None:
-            return False
-        if now - registered_at > self._outbound_registry_ttl_seconds:
             return False
         return True
 
@@ -544,7 +553,7 @@ class ClaudeCodeMCPEndpoint:
         """
         now = asyncio.get_running_loop().time()
         self._evict_stale_outbounds(now)
-        if self._is_routine_green_ack(envelope, now=now):
+        if self._is_routine_green_ack(envelope):
             if self._handle is None:
                 raise RuntimeError(f"endpoint '{self.name}' is not started")
             irt = envelope.in_reply_to

--- a/packages/core/src/agent_core/endpoints/claude_code_mcp.py
+++ b/packages/core/src/agent_core/endpoints/claude_code_mcp.py
@@ -181,6 +181,14 @@ class ClaudeCodeMCPEndpoint:
                 "meta is the authoritative aggregate, computed atomically with items. "
                 "Process each item, then call handle(envelope_id) on each to ack and "
                 "remove from the queue. Send replies via the send tool. "
+                "Two combined tools shave the round-trip floor to 2 calls: "
+                "consume(batch_window_seconds=30, auto_ack=True) reads + acks "
+                "in one call (same shape as list_pending); reply(in_reply_to, "
+                "payload) publishes a TextMessage and acks the inbound in one "
+                "call, inheriting routing/correlation_id from the inbound and "
+                "shallow-merging any metadata override on top. The classic "
+                "list_pending / handle / send tools remain available for "
+                "power-use (manual triage, non-text replies, partial acks). "
                 "Routine green Acknowledgments matching your outbounds (kind="
                 "Acknowledgment, urgency=green, note not prefixed 'error:', "
                 "in_reply_to set) are auto-cleared by the bus and never reach "
@@ -202,6 +210,11 @@ class ClaudeCodeMCPEndpoint:
         self._notify_broker = notify_broker
         self._recent_outbound_ids: dict[str, float] = {}
         self._missing_ack_tasks: dict[str, asyncio.Task[None]] = {}
+        # Issue #67: cache routing of recently-delivered inbounds so reply()
+        # can derive `to`/`metadata`/`urgency`/`correlation_id` even after
+        # the inbound has been acked (e.g., by consume(auto_ack=True)).
+        # TTL'd alongside the outbound registry — same operational concern.
+        self._recent_inbounds: dict[str, dict[str, Any]] = {}
         self._mcp.add_middleware(SessionRegistry(self))
         self._register_tools()
         # T14: plugin-provided tool mounters can register additional MCP
@@ -314,6 +327,30 @@ class ClaudeCodeMCPEndpoint:
             oldest_key = min(self._recent_outbound_ids.items(), key=lambda kv: kv[1])[0]
             self._recent_outbound_ids.pop(oldest_key)
             self._cancel_missing_ack(oldest_key)
+
+    def _evict_stale_inbounds(self, now: float) -> None:
+        ttl = self._outbound_registry_ttl_seconds
+        stale = [
+            k for k, info in self._recent_inbounds.items() if now - info["registered_at"] > ttl
+        ]
+        for k in stale:
+            self._recent_inbounds.pop(k, None)
+        while len(self._recent_inbounds) > self._max_tracked_outbounds:
+            oldest_key = min(
+                self._recent_inbounds.items(), key=lambda kv: kv[1]["registered_at"]
+            )[0]
+            self._recent_inbounds.pop(oldest_key)
+
+    def _record_recent_inbound(self, envelope: Envelope, *, now: float) -> None:
+        self._recent_inbounds[envelope.id] = {
+            "from": envelope.from_,
+            "to": envelope.to,
+            "kind": envelope.kind,
+            "metadata": envelope.metadata,
+            "urgency": envelope.urgency,
+            "correlation_id": envelope.correlation_id,
+            "registered_at": now,
+        }
 
     def _is_routine_green_ack(self, envelope: Envelope) -> bool:
         """Decide whether to auto-clear an Acknowledgment by *shape*.
@@ -553,6 +590,7 @@ class ClaudeCodeMCPEndpoint:
         """
         now = asyncio.get_running_loop().time()
         self._evict_stale_outbounds(now)
+        self._evict_stale_inbounds(now)
         if self._is_routine_green_ack(envelope):
             if self._handle is None:
                 raise RuntimeError(f"endpoint '{self.name}' is not started")
@@ -570,6 +608,9 @@ class ClaudeCodeMCPEndpoint:
             self._cancel_missing_ack(irt)
             return
         self.queue_for_pickup(envelope)
+        # queue_for_pickup also captures routing into _recent_inbounds for
+        # reply() lookups after the inbound is acked (issue #67). Auto-cleared
+        # acks above never reach this point.
         await self._notify_mail_arrived(envelope.urgency)
         if not self._sessions:
             raise EndpointUnavailable(f"no MCP session connected for {self.name}")
@@ -583,6 +624,7 @@ class ClaudeCodeMCPEndpoint:
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
         self._recent_outbound_ids.clear()
+        self._recent_inbounds.clear()
 
         self._handle = None
         self._sessions.clear()
@@ -610,10 +652,23 @@ class ClaudeCodeMCPEndpoint:
         Idempotent on envelope id: the bus retries deliver() on
         EndpointUnavailable, and we'd otherwise grow stale duplicates.
 
-        Used by deliver() when no session is connected, and by tests."""
+        Used by deliver() when no session is connected, and by tests.
+        Also captures the envelope's routing into the recent-inbounds cache
+        (issue #67) so reply() can look it up after the inbound is acked.
+        """
         if any(e.id == envelope.id for e in self._pending):
             return
         self._pending.append(envelope)
+        try:
+            now = asyncio.get_running_loop().time()
+        except RuntimeError:
+            # Sync caller without a running loop — fall back to a monotonic
+            # clock. The cache TTL comparison stays correct because all
+            # registrations + evictions go through the same code paths.
+            import time as _time
+
+            now = _time.monotonic()
+        self._record_recent_inbound(envelope, now=now)
 
     # --- Internal ---
 
@@ -829,6 +884,133 @@ class ClaudeCodeMCPEndpoint:
                 self._release_outbound_registry_for_ack_envelope(env_before)
             self._pending = [e for e in self._pending if e.id != envelope_id]
             return {"status": "nacked", "id": envelope_id, "requeue": requeue}
+
+        @self._mcp.tool()
+        async def consume(
+            batch_window_seconds: int = 30,
+            auto_ack: bool = True,
+            max_items: int | None = None,
+        ) -> dict:
+            """Read pending envelopes and ack them in one call (issue #67).
+
+            Same return shape as ``list_pending``: ``{"meta": {...}, "items": [...]}``.
+            ``meta`` always reflects the current full queue (the ``max_items``
+            cap trims ``items`` only — meta is presentational-of-total, not
+            of-the-trimmed-slice).
+
+            When ``auto_ack=True`` (default), every envelope referenced in the
+            returned ``items`` is ack'd via the bus before this call returns;
+            the items are also dropped from the pickup queue. When False,
+            ``consume`` is a pure read — ack with ``handle()`` later. Set
+            False if you might bail before processing and need redelivery.
+
+            Composes with ``reply()``: a typical Discord round-trip is
+            ``consume()`` → ``reply(in_reply_to=item_id, payload=...)`` (2
+            calls).
+            """
+            if self._handle is None:
+                raise RuntimeError(f"endpoint '{self.name}' is not started")
+            result = await self._call_list_pending(batch_window_seconds=batch_window_seconds)
+            items = result["items"]
+            if max_items is not None and max_items >= 0:
+                items = items[:max_items]
+                result = {"meta": result["meta"], "items": items}
+
+            if auto_ack:
+                ids: list[str] = []
+                for item in items:
+                    if "envelope" in item:  # batched single
+                        ids.append(item["envelope"]["id"])
+                    elif "envelopes" in item:  # batched run
+                        ids.extend(e["id"] for e in item["envelopes"])
+                    elif "id" in item:  # flat envelope dict
+                        ids.append(item["id"])
+                for env_id in ids:
+                    env_before = next((e for e in self._pending if e.id == env_id), None)
+                    await self._handle.ack(env_id)
+                    if env_before is not None:
+                        self._release_outbound_registry_for_ack_envelope(env_before)
+                    self._pending = [e for e in self._pending if e.id != env_id]
+            return result
+
+        @self._mcp.tool()
+        async def reply(
+            in_reply_to: str,
+            payload: dict[str, Any],
+            urgency: str = "green",
+            metadata: dict[str, Any] | None = None,
+        ) -> dict:
+            """Publish an outbound and ack the inbound it answers in one call.
+
+            Routing inherits from the inbound envelope (``to`` ← inbound.from_,
+            ``correlation_id`` ← inbound.correlation_id, ``metadata`` ← inbound
+            metadata, then top-level keys overridden by the ``metadata``
+            argument). The metadata merge is **shallow** — supplying
+            ``{"discord": {"channel_id": "X"}}`` replaces the entire
+            ``discord`` dict, dropping sibling keys like ``guild_id`` from the
+            inbound. Override fully or not at all when touching transport
+            metadata.
+
+            ``urgency`` defaults to ``"green"`` (matching ``send()``); a
+            reply is its own message and inherits no urgency by default.
+            Pass ``"auto"`` to inherit the inbound's urgency (escalating
+            error chains, etc.) or an explicit ``"red"|"yellow"|"green"``
+            override.
+
+            ``in_reply_to`` is looked up in the pickup queue first, then in
+            the recent-inbounds cache (so it works after
+            ``consume(auto_ack=True)``). Raises if the id isn't known.
+
+            The reply's ``kind`` is ``TextMessage`` — for non-text replies,
+            use ``send()`` + ``handle()`` instead.
+
+            Returns ``{"published_envelope_id": ..., "acked_envelope_id": ...}``.
+            """
+            if self._handle is None:
+                raise RuntimeError(f"endpoint '{self.name}' is not started")
+
+            inbound_pending = next((e for e in self._pending if e.id == in_reply_to), None)
+            if inbound_pending is not None:
+                from_ = inbound_pending.from_
+                inbound_metadata = inbound_pending.metadata
+                inbound_urgency = inbound_pending.urgency
+                inbound_correlation = inbound_pending.correlation_id
+            else:
+                cached = self._recent_inbounds.get(in_reply_to)
+                if cached is None:
+                    raise ValueError(
+                        f"reply: no inbound found for in_reply_to={in_reply_to!r}"
+                    )
+                from_ = cached["from"]
+                inbound_metadata = cached["metadata"]
+                inbound_urgency = cached["urgency"]
+                inbound_correlation = cached["correlation_id"]
+
+            out_urgency: str = inbound_urgency if urgency == "auto" else urgency
+            out_metadata = {**inbound_metadata, **(metadata or {})}
+
+            env = Envelope(
+                id=uuid.uuid4().hex,
+                correlation_id=inbound_correlation,
+                in_reply_to=in_reply_to,
+                to=from_,
+                kind="TextMessage",
+                payload=payload,  # type: ignore[arg-type]  # discriminated by kind
+                metadata=out_metadata,
+                urgency=out_urgency,  # type: ignore[arg-type]  # validated by Pydantic
+                created_at=datetime.now(UTC),
+            )
+            await self._handle.publish(env)
+            if not self.wake_on_all_acknowledgments:
+                self._register_outbound_sent(env.id, env.metadata)
+
+            await self._handle.ack(in_reply_to)
+            if inbound_pending is not None:
+                self._release_outbound_registry_for_ack_envelope(inbound_pending)
+            self._pending = [e for e in self._pending if e.id != in_reply_to]
+            self._recent_inbounds.pop(in_reply_to, None)
+
+            return {"published_envelope_id": env.id, "acked_envelope_id": in_reply_to}
 
         @self._mcp.tool()
         async def show_my_day(

--- a/packages/core/src/agent_core/endpoints/claude_code_mcp.py
+++ b/packages/core/src/agent_core/endpoints/claude_code_mcp.py
@@ -342,11 +342,14 @@ class ClaudeCodeMCPEndpoint:
             self._recent_inbounds.pop(oldest_key)
 
     def _record_recent_inbound(self, envelope: Envelope, *, now: float) -> None:
+        # Copy ``metadata`` so post-cache mutations of the original envelope's
+        # metadata dict don't bleed into reply() lookups. The cache's whole
+        # point is making routing safe to use after the inbound is gone.
         self._recent_inbounds[envelope.id] = {
             "from": envelope.from_,
             "to": envelope.to,
             "kind": envelope.kind,
-            "metadata": envelope.metadata,
+            "metadata": dict(envelope.metadata),
             "urgency": envelope.urgency,
             "correlation_id": envelope.correlation_id,
             "registered_at": now,
@@ -653,8 +656,11 @@ class ClaudeCodeMCPEndpoint:
         EndpointUnavailable, and we'd otherwise grow stale duplicates.
 
         Used by deliver() when no session is connected, and by tests.
-        Also captures the envelope's routing into the recent-inbounds cache
-        (issue #67) so reply() can look it up after the inbound is acked.
+        When called from inside a running event loop, also captures the
+        envelope's routing into the recent-inbounds cache (issue #67) so
+        reply() can find it after the inbound is acked. Sync test paths
+        without a loop skip the cache record to avoid mixing clock
+        sources with the eviction path (which always runs under a loop).
         """
         if any(e.id == envelope.id for e in self._pending):
             return
@@ -662,12 +668,7 @@ class ClaudeCodeMCPEndpoint:
         try:
             now = asyncio.get_running_loop().time()
         except RuntimeError:
-            # Sync caller without a running loop — fall back to a monotonic
-            # clock. The cache TTL comparison stays correct because all
-            # registrations + evictions go through the same code paths.
-            import time as _time
-
-            now = _time.monotonic()
+            return
         self._record_recent_inbound(envelope, now=now)
 
     # --- Internal ---
@@ -925,12 +926,19 @@ class ClaudeCodeMCPEndpoint:
                         ids.extend(e["id"] for e in item["envelopes"])
                     elif "id" in item:  # flat envelope dict
                         ids.append(item["id"])
+                # Ack everything FIRST; only mutate _pending after the bus has
+                # accepted every ack. If a mid-walk ack raises, _pending is
+                # untouched and the caller can retry the whole consume safely
+                # (bus acks are idempotent). Without this ordering, a partial
+                # failure would drop items from _pending whose ids never made
+                # it back to the caller — a silent data-loss path.
                 for env_id in ids:
-                    env_before = next((e for e in self._pending if e.id == env_id), None)
                     await self._handle.ack(env_id)
-                    if env_before is not None:
-                        self._release_outbound_registry_for_ack_envelope(env_before)
-                    self._pending = [e for e in self._pending if e.id != env_id]
+                drop = set(ids)
+                envs_dropped = [e for e in self._pending if e.id in drop]
+                self._pending = [e for e in self._pending if e.id not in drop]
+                for env in envs_dropped:
+                    self._release_outbound_registry_for_ack_envelope(env)
             return result
 
         @self._mcp.tool()

--- a/packages/core/tests/test_claude_code_mcp_auto_ack.py
+++ b/packages/core/tests/test_claude_code_mcp_auto_ack.py
@@ -130,7 +130,12 @@ async def test_auto_ack_without_session_does_not_raise_endpoint_unavailable() ->
 
 @pytest.mark.looptime
 @pytest.mark.asyncio
-async def test_green_ack_without_registered_outbound_still_pushes() -> None:
+async def test_green_ack_without_registered_outbound_is_auto_cleared() -> None:
+    """Issue #54: auto-clear is shape-based. A green Acknowledgment with a
+    valid in_reply_to/payload.of pair clears even when the outbound was
+    never registered (e.g., the agent restarted after sending). Without
+    this, every restart would leak ~12 routine acks/min into the queue
+    until the registry warmed back up."""
     ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
     _speed_up_debounce(ep)
     stub = _StubHandle()
@@ -139,6 +144,58 @@ async def test_green_ack_without_registered_outbound_still_pushes() -> None:
     ep._register_session(session)
 
     await ep.deliver(_green_ack("ack-2", "unknown-outbound"))
+    await _flush_debounce()
+    assert session.sent == []
+    assert "ack-2" in stub.acked
+    assert all(e.id != "ack-2" for e in ep._pending)
+
+
+@pytest.mark.looptime
+@pytest.mark.asyncio
+async def test_green_ack_after_simulated_restart_is_auto_cleared() -> None:
+    """Cross-restart simulation for issue #54: agent sends, daemon restarts
+    (registry empty), adapter ack arrives — must still auto-clear by shape."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    _speed_up_debounce(ep)
+    stub = _StubHandle()
+    await ep.start(stub)  # type: ignore[arg-type]
+    session = _RecordingSession()
+    ep._register_session(session)
+
+    assert ep._recent_outbound_ids == {}
+    await ep.deliver(
+        _green_ack("ack-restart", "outbound-from-before-restart", note='{"status": "sent"}')
+    )
+    await _flush_debounce()
+    assert session.sent == []
+    assert "ack-restart" in stub.acked
+
+
+@pytest.mark.looptime
+@pytest.mark.asyncio
+async def test_green_ack_with_no_in_reply_to_still_pushes() -> None:
+    """The integrity guard (in_reply_to set + payload.of == in_reply_to) keeps
+    malformed acks visible. A green Acknowledgment with no in_reply_to is
+    not auto-cleared."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    _speed_up_debounce(ep)
+    stub = _StubHandle()
+    await ep.start(stub)  # type: ignore[arg-type]
+    session = _RecordingSession()
+    ep._register_session(session)
+
+    env = Envelope(
+        id="ack-noref",
+        correlation_id="c-noref",
+        in_reply_to=None,
+        from_="discord",
+        to="agent",
+        kind="Acknowledgment",
+        payload=AcknowledgmentPayload(of="some-outbound", note='{"status": "sent"}'),
+        urgency="green",
+        created_at=datetime.now(UTC),
+    )
+    await ep.deliver(env)
     await _flush_debounce()
     assert len(session.sent) == 1
 

--- a/packages/core/tests/test_claude_code_mcp_consume_reply.py
+++ b/packages/core/tests/test_claude_code_mcp_consume_reply.py
@@ -120,6 +120,28 @@ async def test_consume_auto_ack_false_does_not_ack() -> None:
 
 
 @pytest.mark.asyncio
+async def test_consume_max_items_zero_acks_nothing() -> None:
+    """max_items=0 returns no items and acks none — useful for callers that
+    want to peek at meta without committing to processing."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        ep.queue_for_pickup(_inbound_text("a", from_="src-a"))
+        ep.queue_for_pickup(_inbound_text("b", from_="src-b"))
+
+        async with Client(ep._mcp) as client:
+            cons = await client.call_tool("consume", {"max_items": 0})
+
+        assert cons.data["items"] == []  # type: ignore[index]
+        assert cons.data["meta"]["count"] == 2  # type: ignore[index]
+        assert handle.acked == []
+        assert {e.id for e in ep._pending} == {"a", "b"}
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
 async def test_consume_max_items_trims_items_meta_unchanged() -> None:
     ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
     handle = _RecordingHandle()
@@ -333,6 +355,67 @@ async def test_reply_after_consume_uses_recent_inbounds_cache() -> None:
         assert res.data["acked_envelope_id"] == "in-1"  # type: ignore[index]
         assert handle.published[0].to == "discord-pepper"
         assert handle.published[0].metadata == {"discord": {"channel_id": "C1"}}
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_reply_after_inbound_evicted_from_cache_raises() -> None:
+    """If the inbound has aged out of _recent_inbounds and is no longer in
+    _pending, reply() must surface a clear error rather than silently
+    fabricating routing."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        ep.queue_for_pickup(_inbound_text("in-evict"))
+
+        async with Client(ep._mcp) as client:
+            await client.call_tool("consume", {})  # auto_ack=True drains _pending
+            assert "in-evict" in ep._recent_inbounds
+            ep._recent_inbounds.clear()  # simulate TTL eviction
+
+            with pytest.raises(ToolError, match="no inbound found"):
+                await client.call_tool(
+                    "reply",
+                    {
+                        "in_reply_to": "in-evict",
+                        "payload": {"kind": "TextMessage", "text": "too late"},
+                    },
+                )
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_consume_partial_ack_failure_leaves_pending_intact() -> None:
+    """Important issue from review: if a mid-walk ack raises, _pending must
+    not be partially mutated — caller can retry the whole consume safely
+    and the bus's idempotent acks make the retry correct."""
+
+    class _MidwalkFailingHandle(_RecordingHandle):
+        def __init__(self, fail_on: str) -> None:
+            super().__init__()
+            self._fail_on = fail_on
+
+        async def ack(self, envelope_id: str) -> None:
+            if envelope_id == self._fail_on:
+                raise RuntimeError("simulated bus ack failure")
+            await super().ack(envelope_id)
+
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _MidwalkFailingHandle(fail_on="b")
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        for env_id in ("a", "b", "c"):
+            ep.queue_for_pickup(_inbound_text(env_id, from_=f"src-{env_id}"))
+
+        async with Client(ep._mcp) as client:
+            with pytest.raises(ToolError, match="simulated bus ack failure"):
+                await client.call_tool("consume", {})
+
+        # _pending must be untouched so the caller's retry sees the same items
+        assert {e.id for e in ep._pending} == {"a", "b", "c"}
     finally:
         await ep.stop()
 

--- a/packages/core/tests/test_claude_code_mcp_consume_reply.py
+++ b/packages/core/tests/test_claude_code_mcp_consume_reply.py
@@ -1,0 +1,440 @@
+"""Issue #67: consume + reply tools to drop the per-round-trip floor to 2.
+
+``consume`` combines ``list_pending`` + ``handle``; ``reply`` combines ``send``
++ ``handle(inbound)``. Both are additive — the existing tools stay registered.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from agent_core.bus.envelope import AcknowledgmentPayload, Envelope, TextMessagePayload
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+
+
+class _RecordingHandle:
+    def __init__(self) -> None:
+        self.published: list[Envelope] = []
+        self.acked: list[str] = []
+        self.nacked: list[tuple[str, bool]] = []
+
+    async def publish(self, envelope: Envelope, to: str | list[str] | None = None) -> None:
+        self.published.append(envelope)
+
+    async def ack(self, envelope_id: str) -> None:
+        self.acked.append(envelope_id)
+
+    async def nack(self, envelope_id: str, requeue: bool = True) -> None:
+        self.nacked.append((envelope_id, requeue))
+
+    def endpoints(self) -> list:
+        return []
+
+
+def _inbound_text(
+    env_id: str,
+    *,
+    from_: str = "discord",
+    text: str = "hi",
+    metadata: dict[str, Any] | None = None,
+    urgency: str = "green",
+) -> Envelope:
+    return Envelope(
+        id=env_id,
+        correlation_id=f"corr-{env_id}",
+        in_reply_to=None,
+        from_=from_,
+        to="agent",
+        kind="TextMessage",
+        payload=TextMessagePayload(text=text),
+        metadata=metadata or {},
+        urgency=urgency,  # type: ignore[arg-type]
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_consume_returns_same_shape_as_list_pending() -> None:
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        ep.queue_for_pickup(_inbound_text("a"))
+        ep.queue_for_pickup(_inbound_text("b"))
+
+        async with Client(ep._mcp) as client:
+            # Use matching batch_window so the shapes line up directly.
+            cons = await client.call_tool(
+                "consume", {"auto_ack": False, "batch_window_seconds": 0}
+            )
+            lp = await client.call_tool("list_pending", {})
+
+        assert cons.data["meta"]["count"] == 2  # type: ignore[index]
+        assert {i["id"] for i in cons.data["items"]} == {"a", "b"}  # type: ignore[index]
+        assert cons.data["meta"]["count"] == lp.data["meta"]["count"]  # type: ignore[index]
+        assert {i["id"] for i in cons.data["items"]} == {  # type: ignore[index]
+            i["id"] for i in lp.data["items"]  # type: ignore[index]
+        }
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_consume_auto_ack_true_acks_and_clears() -> None:
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        ep.queue_for_pickup(_inbound_text("a"))
+        ep.queue_for_pickup(_inbound_text("b"))
+
+        async with Client(ep._mcp) as client:
+            await client.call_tool("consume", {})  # auto_ack=True default
+
+        assert sorted(handle.acked) == ["a", "b"]
+        assert ep._pending == []
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_consume_auto_ack_false_does_not_ack() -> None:
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        ep.queue_for_pickup(_inbound_text("a"))
+
+        async with Client(ep._mcp) as client:
+            await client.call_tool("consume", {"auto_ack": False})
+
+        assert handle.acked == []
+        assert [e.id for e in ep._pending] == ["a"]
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_consume_max_items_trims_items_meta_unchanged() -> None:
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        # Use distinct senders so the items don't collapse into one batch
+        # under the default 30s batch_window.
+        ep.queue_for_pickup(_inbound_text("a", from_="src-a"))
+        ep.queue_for_pickup(_inbound_text("b", from_="src-b"))
+        ep.queue_for_pickup(_inbound_text("c", from_="src-c"))
+
+        async with Client(ep._mcp) as client:
+            cons = await client.call_tool("consume", {"auto_ack": False, "max_items": 2})
+
+        assert len(cons.data["items"]) == 2  # type: ignore[index]
+        # meta still reports total queue state (3) — trimming is presentational
+        assert cons.data["meta"]["count"] == 3  # type: ignore[index]
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_consume_auto_ack_walks_batched_items() -> None:
+    """With batch_window_seconds > 0, items can collapse into batch entries.
+    auto_ack must reach into batch envelopes and ack each underlying id."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        # Two envelopes from same sender, same kind, same urgency, near in time
+        # → should batch under list_pending(batch_window_seconds=30) shape.
+        now = datetime.now(UTC)
+        e1 = _inbound_text("a").model_copy(update={"created_at": now})
+        e2 = _inbound_text("b").model_copy(update={"created_at": now})
+        ep.queue_for_pickup(e1)
+        ep.queue_for_pickup(e2)
+
+        async with Client(ep._mcp) as client:
+            await client.call_tool("consume", {"batch_window_seconds": 30})
+
+        assert sorted(handle.acked) == ["a", "b"]
+        assert ep._pending == []
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_reply_publishes_and_acks_atomically() -> None:
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        inbound = _inbound_text(
+            "in-1",
+            from_="discord-pepper",
+            metadata={"discord": {"channel_id": "C1", "guild_id": "G1"}},
+        )
+        ep.queue_for_pickup(inbound)
+
+        async with Client(ep._mcp) as client:
+            res = await client.call_tool(
+                "reply",
+                {
+                    "in_reply_to": "in-1",
+                    "payload": {"kind": "TextMessage", "text": "got it"},
+                },
+            )
+
+        assert res.data["acked_envelope_id"] == "in-1"  # type: ignore[index]
+        published_id = res.data["published_envelope_id"]  # type: ignore[index]
+        assert "in-1" in handle.acked
+        assert len(handle.published) == 1
+        out = handle.published[0]
+        assert out.id == published_id
+        assert out.in_reply_to == "in-1"
+        assert out.to == "discord-pepper"
+        assert out.kind == "TextMessage"
+        assert out.metadata == {"discord": {"channel_id": "C1", "guild_id": "G1"}}
+        # urgency default is green (does NOT inherit inbound urgency)
+        assert out.urgency == "green"
+        assert out.correlation_id == inbound.correlation_id
+        assert ep._pending == []
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_reply_default_urgency_is_green_not_inherited() -> None:
+    """Pepper pushback: a reply to a red message should not auto-promote to red.
+    urgency default is 'green' (matches send()); 'auto' is opt-in inherit."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        ep.queue_for_pickup(_inbound_text("in-r", urgency="red"))
+
+        async with Client(ep._mcp) as client:
+            await client.call_tool(
+                "reply",
+                {"in_reply_to": "in-r", "payload": {"kind": "TextMessage", "text": "ack"}},
+            )
+
+        assert handle.published[0].urgency == "green"
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_reply_urgency_auto_inherits_inbound() -> None:
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        ep.queue_for_pickup(_inbound_text("in-r", urgency="red"))
+
+        async with Client(ep._mcp) as client:
+            await client.call_tool(
+                "reply",
+                {
+                    "in_reply_to": "in-r",
+                    "payload": {"kind": "TextMessage", "text": "escalating"},
+                    "urgency": "auto",
+                },
+            )
+
+        assert handle.published[0].urgency == "red"
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_reply_explicit_urgency_overrides() -> None:
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        ep.queue_for_pickup(_inbound_text("in-y", urgency="green"))
+
+        async with Client(ep._mcp) as client:
+            await client.call_tool(
+                "reply",
+                {
+                    "in_reply_to": "in-y",
+                    "payload": {"kind": "TextMessage", "text": "warn"},
+                    "urgency": "yellow",
+                },
+            )
+
+        assert handle.published[0].urgency == "yellow"
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_reply_metadata_override_wins_per_key() -> None:
+    """Shallow merge: top-level keys in the override replace inbound's.
+    Documented limitation — see the tool's instructions for details."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        inbound_meta = {"discord": {"channel_id": "X"}, "trace_id": "T1"}
+        ep.queue_for_pickup(_inbound_text("in-m", metadata=inbound_meta))
+
+        async with Client(ep._mcp) as client:
+            await client.call_tool(
+                "reply",
+                {
+                    "in_reply_to": "in-m",
+                    "payload": {"kind": "TextMessage", "text": "ok"},
+                    "metadata": {"trace_id": "T2"},  # override only trace_id
+                },
+            )
+
+        out_meta = handle.published[0].metadata
+        assert out_meta["trace_id"] == "T2"
+        assert out_meta["discord"] == {"channel_id": "X"}  # untouched
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_reply_after_consume_uses_recent_inbounds_cache() -> None:
+    """The most important compose-case: consume(auto_ack=True) + reply.
+    consume removes the inbound from _pending; reply must still find its
+    routing via the _recent_inbounds cache."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        ep.queue_for_pickup(
+            _inbound_text(
+                "in-1",
+                from_="discord-pepper",
+                metadata={"discord": {"channel_id": "C1"}},
+            )
+        )
+
+        async with Client(ep._mcp) as client:
+            await client.call_tool("consume", {})  # auto_ack=True
+            assert ep._pending == []
+            # inbound is no longer in _pending; reply must use the cache
+            res = await client.call_tool(
+                "reply",
+                {
+                    "in_reply_to": "in-1",
+                    "payload": {"kind": "TextMessage", "text": "after consume"},
+                },
+            )
+
+        assert res.data["acked_envelope_id"] == "in-1"  # type: ignore[index]
+        assert handle.published[0].to == "discord-pepper"
+        assert handle.published[0].metadata == {"discord": {"channel_id": "C1"}}
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_reply_unknown_in_reply_to_raises() -> None:
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        async with Client(ep._mcp) as client:
+            with pytest.raises(ToolError, match="no inbound found"):
+                await client.call_tool(
+                    "reply",
+                    {
+                        "in_reply_to": "ghost",
+                        "payload": {"kind": "TextMessage", "text": "nope"},
+                    },
+                )
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_reply_registers_outbound_for_missing_ack_timer() -> None:
+    """reply() should populate _recent_outbound_ids the same way send() does,
+    so the missing-ack-timer path stays wired up."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        ep.queue_for_pickup(_inbound_text("in-1"))
+
+        async with Client(ep._mcp) as client:
+            res = await client.call_tool(
+                "reply",
+                {
+                    "in_reply_to": "in-1",
+                    "payload": {"kind": "TextMessage", "text": "hi"},
+                },
+            )
+
+        published_id = res.data["published_envelope_id"]  # type: ignore[index]
+        assert published_id in ep._recent_outbound_ids
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_existing_tools_remain_registered() -> None:
+    """Additive: list_pending, handle, send must still be callable."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        async with Client(ep._mcp) as client:
+            tools = await client.list_tools()
+            names = {t.name for t in tools}
+        assert {"list_pending", "handle", "send", "consume", "reply"} <= names
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_deliver_populates_recent_inbounds() -> None:
+    """deliver() of a non-auto-cleared envelope captures routing into the
+    cache so subsequent reply() can find it after the inbound is acked."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        # No session connected, so deliver raises EndpointUnavailable after
+        # queueing — but the cache should still be populated.
+        from agent_core.bus.protocol import EndpointUnavailable
+
+        env = _inbound_text("in-cache", from_="discord")
+        with pytest.raises(EndpointUnavailable):
+            await ep.deliver(env)
+        assert "in-cache" in ep._recent_inbounds
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_auto_cleared_ack_does_not_populate_recent_inbounds() -> None:
+    """Auto-cleared routine green acks must not pollute the inbound cache."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    handle = _RecordingHandle()
+    await ep.start(handle)  # type: ignore[arg-type]
+    try:
+        ack = Envelope(
+            id="ack-x",
+            correlation_id="c-ack-x",
+            in_reply_to="out-1",
+            from_="discord",
+            to="agent",
+            kind="Acknowledgment",
+            payload=AcknowledgmentPayload(of="out-1", note='{"status": "sent"}'),
+            urgency="green",
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(ack)
+        assert "ack-x" not in ep._recent_inbounds
+    finally:
+        await ep.stop()


### PR DESCRIPTION
## Summary

Two issues, one branch, executed in dependency order. Closes #54 and #67.

**Bottom-line metric** (the reason this work exists):

| Stage | agent-core calls per Discord round-trip |
|---|---|
| Pre-#54 | 5 (list_pending + handle + send + list_pending-on-routine-ack-wake + handle-routine-ack) |
| Post-#54 | 3 (list_pending + handle + send) |
| Post-#67 | 2 (consume + reply) |

A 60% reduction in calls/round-trip — each call is a model turn against ~500K context. That's the headline for the verification report.

## #54 — auto-clear routine green acks by shape, not by registry

The auto-clear path required `_recent_outbound_ids[in_reply_to]` to be present, which created a startup gap: any ack arriving for a send issued before the daemon's most recent restart fell through to the pickup queue and woke the agent. Pepper observed this on 2026-05-08 as ~12 routine acks landing in her queue across 12 minutes.

**Change:** drop the registry lookup from `_is_routine_green_ack`. The integrity guard (`in_reply_to` set + `payload.of == in_reply_to`) and the green/non-error filter both stay. The registry itself is still populated by `send()` and consumed by the missing-ack timer — that path is unchanged.

**Behavior note for future maintainers:** post-fix, an ack arriving after a daemon restart for a send issued *before* the restart will auto-clear by shape. That's the correct behavior — these are still routine acks of real prior sends — but worth being explicit so it's not later mistaken for a regression.

**Acceptance criteria** (all met):
- ✅ Routine success acks auto-handle at the bus level. Agent's `list_pending` does not return them.
- ✅ Error acks (note prefixed `error:` or non-green urgency) still surface and wake.
- ✅ Cross-restart simulation: ack arrives with empty registry → still auto-cleared.

## #67 — add `consume` + `reply` tools

Two new MCP tools, **additive** — existing `list_pending` / `handle` / `send` stay registered for power-use (manual triage, non-text replies, partial acks).

**`consume(batch_window_seconds=30, auto_ack=True, max_items=None)`**
- Same return shape as `list_pending` (preserves the #33 `{meta, items}` contract).
- `auto_ack=True` acks every envelope id reachable from the returned items before the call returns.
- `max_items` trims the items list; meta still reflects total queue state.

**`reply(in_reply_to, payload, urgency='green', metadata=None)`**
- Publishes a `TextMessage` envelope and acks the inbound atomically.
- Routing inherits from the inbound: `to ← inbound.from_`, `correlation_id ← inbound.correlation_id`.
- Metadata is **shallow-merged** with override-wins per top-level key. Pepper flagged this as a minor risk: supplying `{"discord": {"channel_id": "X"}}` replaces the entire `discord` dict, dropping siblings like `guild_id`. Documented in the tool's instructions text and the docstring; deepening the merge is deferred to a real bite, not preemptive complexity.
- **Urgency defaults to `'green'`** (matching `send()`), per Pepper's pushback. A reply is its own message; inheriting urgency could cascade red across an exchange. Pass `urgency='auto'` to opt into inherit-from-inbound semantics.
- Looks up the inbound in the pickup queue first, then in a new `_recent_inbounds` cache so it works after `consume(auto_ack=True)` has already removed the inbound from `_pending`.

**Acceptance criteria** (all met):
- ✅ Both new tools registered alongside existing tools (`test_existing_tools_remain_registered`).
- ✅ `consume` matches `list_pending` shape; `auto_ack=true` acks; `auto_ack=false` doesn't.
- ✅ `reply` produces equivalent outbound + acks atomically; routing inherits.
- ✅ Cache fallback: `reply` works after `consume(auto_ack=True)` removed the inbound.
- ✅ MCP `instructions=` text names both new tools and their composability with the existing surface.

## Test plan

- [x] `uv run pytest packages/core/tests packages/agent-core-discord/tests packages/agent-core-channel/tests` — **808 passed, 3 skipped** (baseline + ~17 net new).
- [x] `uv run ruff check packages/core/src packages/core/tests/test_claude_code_mcp_auto_ack.py packages/core/tests/test_claude_code_mcp_consume_reply.py` — clean.
- [x] `uv run mypy packages/core/src/agent_core/endpoints/claude_code_mcp.py` — clean.
- [ ] After merge: restart Pepper's daemon and relaunch her session; verify in #pepper-upgrade with a real Discord round-trip:
  - **#54**: routine ack does not wake, queue stays clean across restart.
  - **#67**: round-trip uses `consume` + `reply` (2 calls); existing tools still work alongside.
  - **Headline**: before/after agent-core call count per round-trip (target: 5 → 2).

## Out of scope (per Pepper's note)

- Push-based architecture (idea #1 from the bus-redesign roadmap) — separate scope.
- Wake schema changes — wake stays `INBOX: pending (<endpoint>)`.
- Deprecating any existing tool.
- Deep-merge for transport metadata namespaces — flagged in instructions, deferred until someone hits it.

## New tests

- `test_claude_code_mcp_auto_ack.py` — flipped + renamed `test_green_ack_without_registered_outbound_is_auto_cleared`, added `test_green_ack_after_simulated_restart_is_auto_cleared` and `test_green_ack_with_no_in_reply_to_still_pushes` (integrity-guard coverage).
- `test_claude_code_mcp_consume_reply.py` — 16 new tests covering shape parity, auto_ack True/False, max_items, batched-shape ack walking, atomic publish+ack, urgency default + auto + explicit, shallow metadata merge, cache fallback after consume, unknown-id error, missing-ack-timer registration, additivity of existing tools, and cache-population from queue path.