### PR TITLE
feat: emit tools/list_changed after deferred-mounter drain (#37)

### DIFF
--- a/packages/core/changelog.d/37.added.md
+++ b/packages/core/changelog.d/37.added.md
@@ -1,0 +1,8 @@
+`ClaudeCodeMCPEndpoint.start()` now emits MCP
+`notifications/tools/list_changed` once after all deferred tool mounters
+drain (issue #37). Connected MCP clients that respect the protocol-level
+notification — including Claude Code, per Pepper's confirmation on
+2026-05-09 — re-run `tools/list` on receipt and pick up the new tool
+surface without an `/exit + relaunch`. Static registries (no deferred
+mounters) skip the notification. Sessions that raise during the push
+are unregistered, mirroring the existing channel-push pattern.

--- a/packages/core/src/agent_core/endpoints/claude_code_mcp.py
+++ b/packages/core/src/agent_core/endpoints/claude_code_mcp.py
@@ -595,6 +595,10 @@ class ClaudeCodeMCPEndpoint:
         without an ``/exit + relaunch``. Fired once after deferred tool
         mounters drain in :meth:`start`.
 
+        Any future code path that mutates the tool surface outside the
+        deferred-mounter drain (none today) should call this method after
+        the mutation is complete.
+
         Sessions that raise during the push are unregistered, mirroring the
         channel-push behaviour in :meth:`_fire_after_debounce`.
         """

--- a/packages/core/src/agent_core/endpoints/claude_code_mcp.py
+++ b/packages/core/src/agent_core/endpoints/claude_code_mcp.py
@@ -573,10 +573,56 @@ class ClaudeCodeMCPEndpoint:
         # (FastMCP tools are additive), so re-firing them would either
         # raise on duplicate tool names or silently shadow the prior
         # registration — neither is what callers expect.
+        any_mounter_fired = False
         while self.deferred_tool_mounters:
             mounter = self.deferred_tool_mounters.pop(0)
             mounter(bus)
+            any_mounter_fired = True
+        # Issue #37: after deferred mounters mutate the tool surface, push
+        # one batched notifications/tools/list_changed to every connected
+        # session so MCP clients re-enumerate their tool cache. Static
+        # registries (no deferred mounters) skip the notification — no
+        # spurious wakes.
+        if any_mounter_fired:
+            await self._notify_tools_list_changed()
         log.info("ClaudeCodeMCPEndpoint(name=%s) started at mount=%s", self.name, self.mount)
+
+    async def _notify_tools_list_changed(self) -> None:
+        """Push MCP ``notifications/tools/list_changed`` to all connected sessions.
+
+        Standard server→client notification — supporting clients re-run
+        ``tools/list`` on receipt and pick up the latest tool surface
+        without an ``/exit + relaunch``. Fired once after deferred tool
+        mounters drain in :meth:`start`.
+
+        Sessions that raise during the push are unregistered, mirroring the
+        channel-push behaviour in :meth:`_fire_after_debounce`.
+        """
+        sessions = list(self._sessions)
+        if not sessions:
+            log.info(
+                "endpoint '%s': tools/list_changed has no active session audience",
+                self.name,
+            )
+            return
+        notification = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/tools/list_changed",
+            params={},
+        )
+        message = SessionMessage(message=JSONRPCMessage(notification))
+        for session in sessions:
+            try:
+                await session.send_message(message)
+            except Exception:
+                log.warning(
+                    "endpoint '%s': tools/list_changed push to session %d failed; "
+                    "unregistering",
+                    self.name,
+                    id(session),
+                    exc_info=True,
+                )
+                self._unregister_session(session)
 
     async def deliver(self, envelope: Envelope) -> None:
         """Push the envelope to the connected agent.

--- a/packages/core/tests/test_claude_code_mcp_tools_list_changed.py
+++ b/packages/core/tests/test_claude_code_mcp_tools_list_changed.py
@@ -1,0 +1,157 @@
+"""Issue #37: emit notifications/tools/list_changed after deferred mounters drain.
+
+The endpoint drains ``deferred_tool_mounters`` during ``start()`` (each mounter
+typically registers tools onto the FastMCP server). Connected MCP sessions
+cache ``tools/list`` from session-init and won't see the new tools without
+the standard MCP ``notifications/tools/list_changed`` push.
+
+Pepper confirmed (2026-05-09) that her Claude Code session does receive and
+act on this notification — invalidating the original won't-fix reasoning
+that closed this issue on 2026-05-08. Reopened, fixing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastmcp import FastMCP
+from mcp.shared.session import SessionMessage
+
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+
+
+class _RecordingSession:
+    def __init__(self, fail_with: Exception | None = None) -> None:
+        self.sent: list[Any] = []
+        self._fail_with = fail_with
+
+    async def send_message(self, message) -> None:
+        assert isinstance(message, SessionMessage)
+        if self._fail_with is not None:
+            raise self._fail_with
+        self.sent.append(message)
+
+
+class _StubHandle:
+    async def ack(self, envelope_id: str) -> None: ...
+
+    async def publish(self, envelope, to=None) -> None: ...
+
+    async def nack(self, envelope_id: str, requeue: bool = True) -> None: ...
+
+    def endpoints(self) -> list:
+        return []
+
+
+def _is_tools_list_changed(message: SessionMessage) -> bool:
+    notif = getattr(message.message.root, "method", None)
+    return notif == "notifications/tools/list_changed"
+
+
+@pytest.mark.asyncio
+async def test_start_emits_tools_list_changed_after_deferred_mounters_drain() -> None:
+    """A session connected before start() must receive a single
+    notifications/tools/list_changed after the deferred mounters drain."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    session = _RecordingSession()
+    ep._register_session(session)
+
+    mounter_calls: list[FastMCP] = []
+
+    def _mounter(bus) -> None:
+        mounter_calls.append(bus)
+
+    ep.deferred_tool_mounters.append(_mounter)
+
+    await ep.start(_StubHandle())  # type: ignore[arg-type]
+
+    assert len(mounter_calls) == 1
+    matching = [m for m in session.sent if _is_tools_list_changed(m)]
+    assert len(matching) == 1, (
+        f"expected exactly one tools/list_changed; got {len(matching)} of {len(session.sent)} total"
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_does_not_emit_tools_list_changed_with_no_deferred_mounters() -> None:
+    """Static registry — no deferred mounters means no spurious notification."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    session = _RecordingSession()
+    ep._register_session(session)
+    assert ep.deferred_tool_mounters == []
+
+    await ep.start(_StubHandle())  # type: ignore[arg-type]
+
+    matching = [m for m in session.sent if _is_tools_list_changed(m)]
+    assert matching == []
+
+
+@pytest.mark.asyncio
+async def test_tools_list_changed_fires_once_for_multiple_mounters() -> None:
+    """User preference: batched-once-after-all rather than per-mounter."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    session = _RecordingSession()
+    ep._register_session(session)
+
+    fired: list[str] = []
+
+    def _make_mounter(label: str):
+        def _m(bus) -> None:
+            fired.append(label)
+
+        return _m
+
+    ep.deferred_tool_mounters.extend(
+        [_make_mounter("a"), _make_mounter("b"), _make_mounter("c")]
+    )
+
+    await ep.start(_StubHandle())  # type: ignore[arg-type]
+
+    assert fired == ["a", "b", "c"]
+    matching = [m for m in session.sent if _is_tools_list_changed(m)]
+    assert len(matching) == 1
+
+
+@pytest.mark.asyncio
+async def test_tools_list_changed_fans_out_to_all_sessions() -> None:
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    s1 = _RecordingSession()
+    s2 = _RecordingSession()
+    ep._register_session(s1)
+    ep._register_session(s2)
+
+    ep.deferred_tool_mounters.append(lambda bus: None)
+    await ep.start(_StubHandle())  # type: ignore[arg-type]
+
+    assert any(_is_tools_list_changed(m) for m in s1.sent)
+    assert any(_is_tools_list_changed(m) for m in s2.sent)
+
+
+@pytest.mark.asyncio
+async def test_tools_list_changed_unregisters_failing_session() -> None:
+    """Mirrors the channel-push pattern: a session that raises during the
+    push gets unregistered so it doesn't accumulate dead state."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    bad = _RecordingSession(fail_with=RuntimeError("session is dead"))
+    good = _RecordingSession()
+    ep._register_session(bad)
+    ep._register_session(good)
+
+    ep.deferred_tool_mounters.append(lambda bus: None)
+    await ep.start(_StubHandle())  # type: ignore[arg-type]
+
+    assert bad not in ep._sessions
+    assert good in ep._sessions
+    assert any(_is_tools_list_changed(m) for m in good.sent)
+
+
+@pytest.mark.asyncio
+async def test_tools_list_changed_no_audience_is_safe() -> None:
+    """No connected sessions at drain time → no error, no crash."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    assert ep._sessions == set()
+
+    ep.deferred_tool_mounters.append(lambda bus: None)
+    await ep.start(_StubHandle())  # type: ignore[arg-type]
+    # If we got here without raising, the no-audience path is safe.

--- a/packages/core/tests/test_claude_code_mcp_tools_list_changed.py
+++ b/packages/core/tests/test_claude_code_mcp_tools_list_changed.py
@@ -52,7 +52,12 @@ def _is_tools_list_changed(message: SessionMessage) -> bool:
 @pytest.mark.asyncio
 async def test_start_emits_tools_list_changed_after_deferred_mounters_drain() -> None:
     """A session connected before start() must receive a single
-    notifications/tools/list_changed after the deferred mounters drain."""
+    notifications/tools/list_changed after the deferred mounters drain.
+
+    Also pins the wire shape: jsonrpc="2.0", method=
+    notifications/tools/list_changed, params={}. Pepper's Claude Code
+    session was verified against this shape on 2026-05-09 — changing the
+    shape risks breaking already-verified clients."""
     ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
     session = _RecordingSession()
     ep._register_session(session)
@@ -71,6 +76,11 @@ async def test_start_emits_tools_list_changed_after_deferred_mounters_drain() ->
     assert len(matching) == 1, (
         f"expected exactly one tools/list_changed; got {len(matching)} of {len(session.sent)} total"
     )
+
+    notif = matching[0].message.root
+    assert notif.jsonrpc == "2.0"
+    assert notif.method == "notifications/tools/list_changed"
+    assert notif.params == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #37 (reopened today). After `ClaudeCodeMCPEndpoint.start()` finishes draining `deferred_tool_mounters`, push one MCP `notifications/tools/list_changed` to every connected session. Clients re-enumerate their tool cache on receipt.

## Background — why reopen

#37 was closed as won't-fix on 2026-05-08 with three reasons:

1. No mid-session registry mutations exist today.
2. **Claude Code's stale-cache surface isn't the MCP `tools/list` cache** — it's the session-start system-reminder.
3. The original symptom (Pepper missing briefs tools on the 2026-05-06 cutover) was unconfirmable.

Today (2026-05-09) Pepper confirmed her Claude Code session **does** receive and act on `notifications/tools/list_changed`. That invalidates reason #2 — the protocol-level notification is load-bearing on her end. Reason #1 still partly applies (mounters drain once at `bus.start()`), but the notification is still useful at that drain point: any session connected when deferred mounters finish (e.g., a relay reconnecting during startup) picks up the new surface without an `/exit + relaunch`. It's also the right primitive to have wired before any future hot-add path.

## Implementation

- `start()` tracks whether any deferred mounter ran. If yes, calls a new `_notify_tools_list_changed()` once after the drain loop.
- `_notify_tools_list_changed()` builds a `JSONRPCNotification(method="notifications/tools/list_changed", params={})` wrapped in `SessionMessage`, fans it out to every session in `self._sessions`, and unregisters any session that raises during the push (mirrors `_fire_after_debounce`'s existing pattern).
- **Batched, not per-mounter** — single re-enumeration on the client side, per the user's preference and MCP spec semantics.
- **No notification on static registries** — no spurious wakes when nothing actually changed.
- **Safe with no audience** — empty session set is a logged no-op.

## Test plan

- [x] `uv run pytest packages/core/tests packages/agent-core-discord/tests packages/agent-core-channel/tests` — **821 passed, 3 skipped** (was 815; +6 new tests).
- [x] `uv run ruff check` — clean.
- [x] `uv run mypy packages/core/src/agent_core/endpoints/claude_code_mcp.py` — clean.
- [ ] Post-merge: restart the daemon. Pepper relaunches her session (or — if Pepper can keep her session through the daemon restart and the relay reconnects mid-startup-with-a-deferred-mounter — verify she sees an in-session re-enumeration without `/exit`). Report via #pepper-upgrade.

## New tests (`test_claude_code_mcp_tools_list_changed.py`)

- `test_start_emits_tools_list_changed_after_deferred_mounters_drain` — single mounter, single notification.
- `test_start_does_not_emit_tools_list_changed_with_no_deferred_mounters` — static registry, no notification.
- `test_tools_list_changed_fires_once_for_multiple_mounters` — batched semantics.
- `test_tools_list_changed_fans_out_to_all_sessions` — every connected session gets it.
- `test_tools_list_changed_unregisters_failing_session` — bad session raises, gets unregistered, good session still gets the notification.
- `test_tools_list_changed_no_audience_is_safe` — no sessions = log + return, no crash.

## Out of scope (per the original issue)

- Notifying on endpoint *removal*.
- Cross-process MCP cache invalidation for non-agent clients.
- Per-tool change diffs (MCP only specs whole-list reload).