### PR TITLE
feat(core): endpoints.d + jobs.d conf.d-style merging (#75)

### DIFF
--- a/packages/agent-core-hatchery/pyproject.toml
+++ b/packages/agent-core-hatchery/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-core-hatchery"
+version = "0.0.0"
+description = "Bootstrap system for hatching new agent-core beings (placeholder; Phase 2 fills in deps + entry points)."
+requires-python = ">=3.12"
+dependencies = []
+
+[tool.hatch.build.targets.wheel]
+bypass-selection = true

--- a/packages/core/src/agent_core/bus/runner.py
+++ b/packages/core/src/agent_core/bus/runner.py
@@ -46,6 +46,22 @@ def _validate_http(http_cfg: dict, has_auth_hook: bool) -> None:
 
 async def build_bus_from_config(path: Path) -> tuple[Bus, HTTPHost | None]:
     raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    # Conf.d-style merge: every <config_dir>/endpoints.d/*.yaml fragment
+    # contributes its `endpoints:` list to the merged set. Sorted glob
+    # ensures deterministic load order. Fragments may not override
+    # bus/http/bus_hooks/mcp_audit. Endpoint name collisions surface
+    # via existing endpoint registration code (loud failure).
+    fragments_dir = Path(path).parent / "endpoints.d"
+    if fragments_dir.is_dir():
+        for fragment_path in sorted(fragments_dir.glob("*.yaml")):
+            fragment = yaml.safe_load(fragment_path.read_text(encoding="utf-8")) or {}
+            fragment_endpoints = fragment.get("endpoints", []) or []
+            if not isinstance(fragment_endpoints, list):
+                raise BusBootError(
+                    f"endpoints.d fragment {fragment_path.name!r}: "
+                    f"'endpoints' must be a list, got {type(fragment_endpoints).__name__}"
+                )
+            raw.setdefault("endpoints", []).extend(fragment_endpoints)
     plugin_manager = create_plugin_manager()
     plugin_manager.hook.validate_config(raw_config=raw)
     endpoint_types = get_endpoint_types(plugin_manager)
@@ -167,7 +183,10 @@ async def build_bus_from_config(path: Path) -> tuple[Bus, HTTPHost | None]:
             endpoint_config=entry,
             services=services,
         )
-        bus.register(EndpointSpec(endpoint=instance, description=entry.get("description", "")))
+        try:
+            bus.register(EndpointSpec(endpoint=instance, description=entry.get("description", "")))
+        except ValueError as exc:
+            raise BusBootError(str(exc)) from exc
 
     # Cross-endpoint wiring (T19 — cutover #09 follow-up). Once every
     # endpoint in the yaml has been constructed and registered on the bus

--- a/packages/core/src/agent_core/endpoints/scheduler.py
+++ b/packages/core/src/agent_core/endpoints/scheduler.py
@@ -51,6 +51,10 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+class SchedulerConfigError(Exception):
+    """Raised when seed-jobs YAML or jobs.d fragments are malformed."""
+
+
 def _validate_envelope_shape(
     envelope_kind: str,
     prompt: str | None,

--- a/packages/core/src/agent_core/endpoints/scheduler.py
+++ b/packages/core/src/agent_core/endpoints/scheduler.py
@@ -194,6 +194,25 @@ def load_seed_jobs(yaml_path: Path) -> dict[str, JobDef]:
     if not yaml_path.exists():
         return {}
     raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+    # Conf.d-style merge: every <yaml_path_dir>/jobs.d/*.yaml fragment
+    # contributes its top-level job-name keys. Naming collisions are
+    # loud errors — caller renames (hatcher prefixes with being name).
+    fragments_dir = yaml_path.parent / "jobs.d"
+    if fragments_dir.is_dir():
+        for fragment_path in sorted(fragments_dir.glob("*.yaml")):
+            fragment = yaml.safe_load(fragment_path.read_text(encoding="utf-8")) or {}
+            if not isinstance(fragment, dict):
+                raise SchedulerConfigError(
+                    f"jobs.d fragment {fragment_path.name!r}: "
+                    f"top-level must be a mapping, got {type(fragment).__name__}"
+                )
+            for job_name, job_data in fragment.items():
+                if job_name in raw:
+                    raise SchedulerConfigError(
+                        f"jobs.d fragment {fragment_path.name!r}: "
+                        f"job name {job_name!r} collides with existing job"
+                    )
+                raw[job_name] = job_data
     return {name: JobDef(**spec) for name, spec in raw.items()}
 
 

--- a/packages/core/tests/bus/fixtures/endpoints_d/endpoints.d/a.yaml
+++ b/packages/core/tests/bus/fixtures/endpoints_d/endpoints.d/a.yaml
@@ -1,0 +1,4 @@
+endpoints:
+  - type: builtin.stub
+    name: fragment-a-stub
+    description: "From fragment a"

--- a/packages/core/tests/bus/fixtures/endpoints_d/endpoints.d/b.yaml
+++ b/packages/core/tests/bus/fixtures/endpoints_d/endpoints.d/b.yaml
@@ -1,0 +1,4 @@
+endpoints:
+  - type: builtin.stub
+    name: fragment-b-stub
+    description: "From fragment b"

--- a/packages/core/tests/bus/fixtures/endpoints_d/main.yaml
+++ b/packages/core/tests/bus/fixtures/endpoints_d/main.yaml
@@ -1,0 +1,11 @@
+bus:
+  storage_path: ":memory:"
+
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+
+endpoints:
+  - type: builtin.stub
+    name: main-stub
+    description: "From main yaml"

--- a/packages/core/tests/bus/fixtures/endpoints_d_collision/endpoints.d/dup.yaml
+++ b/packages/core/tests/bus/fixtures/endpoints_d_collision/endpoints.d/dup.yaml
@@ -1,0 +1,4 @@
+endpoints:
+  - type: builtin.stub
+    name: dup-stub
+    description: "Collides with main"

--- a/packages/core/tests/bus/fixtures/endpoints_d_collision/main.yaml
+++ b/packages/core/tests/bus/fixtures/endpoints_d_collision/main.yaml
@@ -1,0 +1,9 @@
+bus:
+  storage_path: ":memory:"
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints:
+  - type: builtin.stub
+    name: dup-stub
+    description: "From main"

--- a/packages/core/tests/bus/fixtures/endpoints_d_malformed/endpoints.d/bad.yaml
+++ b/packages/core/tests/bus/fixtures/endpoints_d_malformed/endpoints.d/bad.yaml
@@ -1,0 +1,1 @@
+endpoints: "not a list"

--- a/packages/core/tests/bus/fixtures/endpoints_d_malformed/main.yaml
+++ b/packages/core/tests/bus/fixtures/endpoints_d_malformed/main.yaml
@@ -1,0 +1,6 @@
+bus:
+  storage_path: ":memory:"
+http:
+  bind_host: 127.0.0.1
+  bind_port: 0
+endpoints: []

--- a/packages/core/tests/bus/test_runner_endpoints_d.py
+++ b/packages/core/tests/bus/test_runner_endpoints_d.py
@@ -1,0 +1,63 @@
+"""Tests for endpoints.d/ conf.d-style merging in build_bus_from_config."""
+
+from pathlib import Path
+
+import pytest
+
+from agent_core.bus.runner import BusBootError, build_bus_from_config
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.mark.asyncio
+async def test_endpoints_d_happy_path_merges_alphabetically():
+    """All endpoints from main + endpoints.d/*.yaml are present in the built bus.
+
+    Fragments load in sorted-glob order (a.yaml before b.yaml), main first.
+    """
+    config_path = FIXTURES / "endpoints_d" / "main.yaml"
+
+    bus, _http = await build_bus_from_config(config_path)
+    try:
+        endpoint_names = {ep.name for ep in bus._endpoints()}
+        assert endpoint_names == {"main-stub", "fragment-a-stub", "fragment-b-stub"}
+    finally:
+        await bus.stop()
+
+
+@pytest.mark.asyncio
+async def test_endpoints_d_collision_raises_loudly():
+    """A fragment endpoint with the same name as one already loaded must fail loudly."""
+    config_path = FIXTURES / "endpoints_d_collision" / "main.yaml"
+
+    with pytest.raises(BusBootError, match="dup-stub"):
+        await build_bus_from_config(config_path)
+
+
+@pytest.mark.asyncio
+async def test_endpoints_d_malformed_fragment_raises_with_filename():
+    """A fragment whose `endpoints:` is not a list must error naming the file."""
+    config_path = FIXTURES / "endpoints_d_malformed" / "main.yaml"
+
+    with pytest.raises(BusBootError, match="bad.yaml"):
+        await build_bus_from_config(config_path)
+
+
+@pytest.mark.asyncio
+async def test_no_endpoints_d_dir_is_silent_noop(tmp_path):
+    """If no endpoints.d/ subdir exists alongside the main yaml, no error, no fragments loaded."""
+    main_yaml = tmp_path / "agent_core.yaml"
+    main_yaml.write_text(
+        'bus:\n  storage_path: ":memory:"\n'
+        "http:\n  bind_host: 127.0.0.1\n  bind_port: 0\n"
+        "endpoints:\n"
+        "  - type: builtin.stub\n"
+        "    name: only-stub\n"
+        '    description: "Solo"\n'
+    )
+
+    bus, _http = await build_bus_from_config(main_yaml)
+    try:
+        assert {ep.name for ep in bus._endpoints()} == {"only-stub"}
+    finally:
+        await bus.stop()

--- a/packages/core/tests/endpoints/fixtures/jobs_d/jobs.d/extra.yaml
+++ b/packages/core/tests/endpoints/fixtures/jobs_d/jobs.d/extra.yaml
@@ -1,0 +1,11 @@
+fragment-job:
+  trigger: cron
+  timezone: "America/New_York"
+  schedule:
+    hour: 22
+    minute: 0
+  target: stub
+  envelope_kind: Event
+  payload:
+    type: Heartbeat
+    data: {}

--- a/packages/core/tests/endpoints/fixtures/jobs_d/jobs.yaml
+++ b/packages/core/tests/endpoints/fixtures/jobs_d/jobs.yaml
@@ -1,0 +1,11 @@
+main-job:
+  trigger: cron
+  timezone: "America/New_York"
+  schedule:
+    hour: 23
+    minute: 59
+  target: stub
+  envelope_kind: Event
+  payload:
+    type: Heartbeat
+    data: {}

--- a/packages/core/tests/endpoints/fixtures/jobs_d_collision/jobs.d/dup.yaml
+++ b/packages/core/tests/endpoints/fixtures/jobs_d_collision/jobs.d/dup.yaml
@@ -1,0 +1,9 @@
+shared-name:
+  trigger: cron
+  timezone: "America/New_York"
+  schedule:
+    hour: 2
+    minute: 0
+  target: stub
+  envelope_kind: Event
+  payload: {type: Heartbeat, data: {}}

--- a/packages/core/tests/endpoints/fixtures/jobs_d_collision/jobs.yaml
+++ b/packages/core/tests/endpoints/fixtures/jobs_d_collision/jobs.yaml
@@ -1,0 +1,9 @@
+shared-name:
+  trigger: cron
+  timezone: "America/New_York"
+  schedule:
+    hour: 1
+    minute: 0
+  target: stub
+  envelope_kind: Event
+  payload: {type: Heartbeat, data: {}}

--- a/packages/core/tests/endpoints/fixtures/jobs_d_malformed/jobs.d/bad.yaml
+++ b/packages/core/tests/endpoints/fixtures/jobs_d_malformed/jobs.d/bad.yaml
@@ -1,0 +1,1 @@
+- this should be a mapping not a list

--- a/packages/core/tests/endpoints/fixtures/jobs_d_malformed/jobs.yaml
+++ b/packages/core/tests/endpoints/fixtures/jobs_d_malformed/jobs.yaml
@@ -1,0 +1,7 @@
+keeper:
+  trigger: cron
+  timezone: "America/New_York"
+  schedule: {hour: 0, minute: 0}
+  target: stub
+  envelope_kind: Event
+  payload: {type: Heartbeat, data: {}}

--- a/packages/core/tests/endpoints/test_scheduler_jobs_d.py
+++ b/packages/core/tests/endpoints/test_scheduler_jobs_d.py
@@ -1,0 +1,42 @@
+"""Tests for jobs.d/ conf.d-style merging in load_seed_jobs."""
+
+from pathlib import Path
+
+import pytest
+
+from agent_core.endpoints.scheduler import SchedulerConfigError, load_seed_jobs
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_jobs_d_happy_path_merges_main_and_fragment():
+    jobs_yaml = FIXTURES / "jobs_d" / "jobs.yaml"
+    jobs = load_seed_jobs(jobs_yaml)
+    assert set(jobs.keys()) == {"main-job", "fragment-job"}
+
+
+def test_jobs_d_collision_raises_loudly():
+    jobs_yaml = FIXTURES / "jobs_d_collision" / "jobs.yaml"
+    with pytest.raises(SchedulerConfigError, match="shared-name"):
+        load_seed_jobs(jobs_yaml)
+
+
+def test_jobs_d_malformed_fragment_raises_with_filename():
+    jobs_yaml = FIXTURES / "jobs_d_malformed" / "jobs.yaml"
+    with pytest.raises(SchedulerConfigError, match="bad.yaml"):
+        load_seed_jobs(jobs_yaml)
+
+
+def test_no_jobs_d_dir_is_silent_noop(tmp_path):
+    jobs_yaml = tmp_path / "jobs.yaml"
+    jobs_yaml.write_text(
+        "solo-job:\n"
+        "  trigger: cron\n"
+        '  timezone: "America/New_York"\n'
+        "  schedule: {hour: 0, minute: 0}\n"
+        "  target: stub\n"
+        "  envelope_kind: Event\n"
+        "  payload: {type: Heartbeat, data: {}}\n"
+    )
+    jobs = load_seed_jobs(jobs_yaml)
+    assert set(jobs.keys()) == {"solo-job"}

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ members = [
     "agent-core-channel",
     "agent-core-credentials",
     "agent-core-discord",
+    "agent-core-hatchery",
     "agent-core-notify",
     "agent-core-webcam",
 ]
@@ -109,6 +110,7 @@ dependencies = [
     { name = "anyio" },
     { name = "httpx" },
     { name = "mcp" },
+    { name = "pyyaml" },
     { name = "typer" },
 ]
 
@@ -117,6 +119,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mcp", specifier = ">=1.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "typer", specifier = ">=0.12" },
 ]
 
@@ -155,6 +158,11 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
+
+[[package]]
+name = "agent-core-hatchery"
+version = "0.0.0"
+source = { editable = "packages/agent-core-hatchery" }
 
 [[package]]
 name = "agent-core-notify"


### PR DESCRIPTION
## Summary

- Adds optional `endpoints.d/*.yaml` loading to `build_bus_from_config`. Fragments contribute additive entries to the `endpoints:` list. Sorted glob load order, loud failure on malformed (non-list `endpoints:`) or collision (now translated to `BusBootError` from the existing `ValueError` path).
- Adds optional `jobs.d/*.yaml` loading to `load_seed_jobs` with the same semantics. New `SchedulerConfigError` exception class for fragment-config failures.
- 8 new tests covering happy path, collision, malformed, no-fragments-dir for both surfaces.
- Ships a stub `packages/agent-core-hatchery/pyproject.toml` so the uv workspace resolves (Pepper's source-material commit on main added the directory; without a pyproject the workspace glob `packages/*` chokes). Phase 2 fills in real deps + entry points.

## Why

Prerequisite for PR-2 (`packages/agent-core-hatchery/`). The hatcher writes per-being config fragments to `endpoints.d/` and `jobs.d/` rather than editing daemon-shared single-file YAML in place. This PR is the daemon-side support for that pattern.

See the design spec: `docs/superpowers/specs/2026-05-09-issue-75-agent-core-hatchery-design.md` (rev 2).

## Out of scope

- Pepper's existing endpoints stay declared inline in `~/.agent-core/agent_core.yaml`. A separate post-Deb-validation PR can move them into `endpoints.d/pepper.yaml` for symmetry. Per the "Pepper hands-off until proven" memory rule, no migration in this PR.
- No new dependencies in `packages/core/`.

## Diff stats

256 insertions, 1 deletion across 20 files. Split: 44 lines of implementation in `runner.py` + `scheduler.py`, ~105 lines of tests, ~107 lines of YAML fixtures, plus the stub `pyproject.toml` and `uv.lock` entry.

## Test plan

- [x] All 8 new tests pass.
- [x] Full \`packages/core/\` suite: 658 passed, 2 skipped, 0 failures. Pre-existing single-file deployments unaffected.

## Notes

- Commit \`b9cf3dd\` has a stray \`@\` symbol in the subject line — PowerShell heredoc artifact from the implementing subagent. Cosmetic only; commit content is correct. Squash-on-merge would clean it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)