### PR TITLE
feat(#64): wire discord-pepper file-attachment path through to upload

### DIFF
--- a/docs/superpowers/plans/2026-05-12-issue-64-discord-attachments.md
+++ b/docs/superpowers/plans/2026-05-12-issue-64-discord-attachments.md
@@ -1,0 +1,1010 @@
+# Issue #64 — Wire discord-pepper file-attachment path (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the existing `TextMessagePayload.attachments` schema field through `_deliver_text_message` to discord.py's file-upload path, with tight per-element Pydantic validation that fails synchronously at publish time.
+
+**Architecture:** Bus-side `FileAttachment(path: str, extra='allow')` model on `TextMessagePayload`. Translation at the bus↔verb boundary in `_deliver_text_message` (single line: `files = [a.path for a in payload.attachments]`, passed to existing `_SendArgs.files: list[str]`). `_send` (`endpoint.py:1203–1221`) is unchanged. `FakeMessage` extended to model attachment roundtrip for testable assertions.
+
+**Tech Stack:** Python 3.12+, Pydantic v2 (`BaseModel`, `Field`, `ConfigDict`), `pytest`/`pytest-asyncio`, `discord.py` 2.x. Use `uv run --no-sync pytest` (not bare pytest). Conventional commit style, no `Co-Authored-By` trailer.
+
+**Branch:** `feat/issue-64-discord-attachments` (already created off main, spec committed at `f347664`).
+
+---
+
+## Phase 1 — Schema (bus envelope)
+
+### Task 1: Add `FileAttachment` model with required path + extra-allow
+
+**Files:**
+- Modify: `packages/core/src/agent_core/bus/envelope.py` (header imports, add class after `AcknowledgmentPayload` or before `TextMessagePayload` — keep it together with `TextMessagePayload`)
+- Create: `packages/core/tests/bus/test_file_attachment_schema.py`
+
+- [ ] **Step 1: Write the failing tests for FileAttachment alone (model not yet wired to TextMessagePayload)**
+
+```python
+"""Tests for FileAttachment Pydantic model (#64)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agent_core.bus.envelope import FileAttachment
+
+
+def test_file_attachment_requires_path():
+    """Missing `path` raises ValidationError at publish time."""
+    with pytest.raises(ValidationError):
+        FileAttachment()
+
+
+def test_file_attachment_rejects_empty_string_path():
+    """Empty `path` rejected by Field(min_length=1)."""
+    with pytest.raises(ValidationError):
+        FileAttachment(path="")
+
+
+def test_file_attachment_allows_extra_fields():
+    """extra='allow' lets aspirational fields land without schema migration."""
+    attachment = FileAttachment(path="/abs/file.pdf", filename="renamed.pdf")
+    assert attachment.path == "/abs/file.pdf"
+    # filename available via model_extra (Pydantic v2 extra-allow mechanism)
+    assert attachment.model_extra is not None
+    assert attachment.model_extra.get("filename") == "renamed.pdf"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-sync pytest packages/core/tests/bus/test_file_attachment_schema.py -v`
+
+Expected: 3 tests collected, all FAIL with `ImportError` (FileAttachment doesn't exist yet).
+
+- [ ] **Step 3: Add `FileAttachment` to envelope.py**
+
+In `packages/core/src/agent_core/bus/envelope.py`, locate the existing import block (lines 11-14). It already imports `BaseModel, ConfigDict, Field, model_validator` from `pydantic`. Good — no import changes needed.
+
+Add `FileAttachment` right above `TextMessagePayload` (before line 17):
+
+```python
+class FileAttachment(BaseModel):
+    """File attachment on a TextMessage envelope.
+
+    `path` is the local filesystem path discord-pepper reads via
+    `discord.File(path)`. Validation runs at envelope publish time so
+    typos / missing keys surface synchronously at the publishing
+    agent's send() call, not as a later yellow Ack from the adapter.
+
+    `extra='allow'` permits aspirational fields (filename override,
+    description, spoiler) to pass validation; the adapter currently
+    only consumes `path`. New fields wire to the adapter incrementally,
+    named-symptom-bound.
+    """
+
+    path: str = Field(min_length=1)
+    model_config = ConfigDict(extra="allow")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --no-sync pytest packages/core/tests/bus/test_file_attachment_schema.py -v`
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agent_core/bus/envelope.py packages/core/tests/bus/test_file_attachment_schema.py
+git commit -m "feat(envelope): FileAttachment model with required path (#64)"
+```
+
+---
+
+### Task 2: Wire `FileAttachment` into `TextMessagePayload.attachments`
+
+**Files:**
+- Modify: `packages/core/src/agent_core/bus/envelope.py:17–20`
+- Modify: `packages/core/tests/bus/test_file_attachment_schema.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/tests/bus/test_file_attachment_schema.py`:
+
+```python
+from agent_core.bus.envelope import TextMessagePayload
+
+
+def test_text_message_payload_defaults_attachments_empty():
+    """Backward compat: existing publishes without `attachments` still validate."""
+    payload = TextMessagePayload(text="hi")
+    assert payload.attachments == []
+
+
+def test_text_message_payload_typo_in_attachment_key_raises_at_publish():
+    """Named-symptom regression lock: a typo in the attachment dict key
+    surfaces at envelope-construction time, synchronously to the agent's
+    publish call, not as a later yellow Ack.
+    """
+    with pytest.raises(ValidationError):
+        TextMessagePayload(
+            text="hi",
+            attachments=[{"paht": "/abs/file.pdf"}],  # typo: missing 'path'
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --no-sync pytest packages/core/tests/bus/test_file_attachment_schema.py -v`
+
+Expected: 5 collected, 3 pass (from Task 1), `test_text_message_payload_typo_in_attachment_key_raises_at_publish` FAILS because `attachments: list[dict[str, Any]]` accepts any dict; `test_text_message_payload_defaults_attachments_empty` PASSES (preexisting field already defaults to empty list).
+
+- [ ] **Step 3: Tighten the `TextMessagePayload.attachments` annotation**
+
+In `packages/core/src/agent_core/bus/envelope.py` line 20, change:
+
+```python
+class TextMessagePayload(BaseModel):
+    kind: Literal["TextMessage"] = "TextMessage"
+    text: str
+    attachments: list[dict[str, Any]] = Field(default_factory=list)
+```
+
+to:
+
+```python
+class TextMessagePayload(BaseModel):
+    kind: Literal["TextMessage"] = "TextMessage"
+    text: str
+    attachments: list[FileAttachment] = Field(default_factory=list)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --no-sync pytest packages/core/tests/bus/test_file_attachment_schema.py -v`
+
+Expected: 5 passed.
+
+Also run the broader core bus test suite to confirm no regression in other envelope tests:
+
+Run: `uv run --no-sync pytest packages/core/tests/bus -q`
+
+Expected: all green (the schema change should be backward-compatible for empty-attachments publishes and forward-compatible for properly-shaped attachments).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agent_core/bus/envelope.py packages/core/tests/bus/test_file_attachment_schema.py
+git commit -m "feat(envelope): tighten TextMessagePayload.attachments to list[FileAttachment] (#64)"
+```
+
+---
+
+## Phase 2 — Fake test infrastructure
+
+### Task 3: Extend `FakeMessage` and `FakeChannel.send` to model attachment roundtrip
+
+**Files:**
+- Modify: `packages/agent-core-discord/src/agent_core_discord/testing/fakes.py:93–193`
+- Create: `packages/agent-core-discord/tests/test_fakes_attachments.py`
+
+- [ ] **Step 1: Write the failing fake-sanity test**
+
+```python
+"""Sanity test for FakeMessage/FakeChannel attachment roundtrip (#64)."""
+
+from __future__ import annotations
+
+import discord
+import pytest
+
+from agent_core_discord.testing.fakes import FakeChannel
+
+
+@pytest.mark.asyncio
+async def test_fake_message_records_attachments_from_send_call(tmp_path):
+    """FakeChannel.send(files=[...]) returns a FakeMessage whose
+    .attachments list reflects the inputs with .filename derived from
+    each discord.File's filename attribute.
+
+    Without this fake-side modeling, handler-level tests in Phase 3
+    are toothless — they can't assert what reached Discord.
+    """
+    ch = FakeChannel(id="100")
+    # Two real files on disk (tmp_path so they auto-clean).
+    f1 = tmp_path / "alpha.pdf"
+    f1.write_bytes(b"a" * 16)
+    f2 = tmp_path / "beta.pdf"
+    f2.write_bytes(b"b" * 16)
+    discord_files = [discord.File(str(f1)), discord.File(str(f2))]
+    try:
+        msg = await ch.send(content="hi", files=discord_files)
+        assert len(msg.attachments) == 2
+        assert [a.filename for a in msg.attachments] == ["alpha.pdf", "beta.pdf"]
+    finally:
+        for df in discord_files:
+            df.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests/test_fakes_attachments.py -v`
+
+Expected: FAIL — `FakeMessage` has no `attachments` attribute.
+
+- [ ] **Step 3: Extend `FakeMessage` and `FakeChannel.send`**
+
+In `packages/agent-core-discord/src/agent_core_discord/testing/fakes.py`, add a small `FakeAttachment` class above `FakeMessage` (around line 92):
+
+```python
+class FakeAttachment:
+    """Minimal stand-in for discord.Attachment on a fake message.
+
+    Models only the fields tests assert on (`filename`, `url`); expand
+    named per the test-fakes-mirror-real-strictly discipline.
+    """
+
+    def __init__(self, *, filename: str, url: str = ""):
+        self.filename = filename
+        self.url = url
+```
+
+Extend `FakeMessage.__init__` (line 93–105) to accept and store an `attachments` parameter:
+
+```python
+class FakeMessage:
+    def __init__(
+        self,
+        *,
+        id: str,
+        channel_id: str,
+        content: str = "",
+        author=None,
+        poll: FakePoll | None = None,
+        attachments: list[FakeAttachment] | None = None,
+    ):
+        self.id = id
+        self.channel_id = channel_id
+        self.content = content
+        # ... preserve existing init body ...
+        self.attachments = attachments or []
+```
+
+Make sure to preserve the rest of `FakeMessage.__init__` unchanged — only add the new parameter and the `self.attachments = ...` line. If the existing init does more, keep it intact.
+
+Then extend `FakeChannel.send` (line 171–193) to populate `attachments` on the returned `FakeMessage`:
+
+```python
+async def send(
+    self,
+    content: str | None = None,
+    *,
+    embeds: list | None = None,
+    reference: Any = None,
+    files: list | None = None,
+    poll: Any = None,
+) -> FakeMessage:
+    new_id = f"new-{len(self.sent) + 1}"
+    attachments: list[FakeAttachment] = []
+    for f in files or []:
+        # discord.File.filename is the resolved upload filename
+        # (basename of the path when not overridden).
+        fn = getattr(f, "filename", "")
+        attachments.append(FakeAttachment(filename=fn))
+    msg = FakeMessage(
+        id=new_id,
+        channel_id=self.id,
+        content=content or "",
+        attachments=attachments,
+    )
+    self._messages[new_id] = msg
+    self.sent.append(
+        {
+            "content": content,
+            "embeds": embeds,
+            "reference": reference,
+            "files": files,
+            "poll": poll,
+            "message_id": new_id,
+        }
+    )
+    return msg
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests/test_fakes_attachments.py -v`
+
+Expected: PASS.
+
+Run the broader discord test suite to confirm no regression in any existing test that uses `FakeMessage` / `FakeChannel`:
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests -x -q`
+
+Expected: all green. If any test fails because it was passing a positional argument to `FakeMessage` or relying on missing-`attachments` behavior, adapt those tests minimally to the new signature.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agent-core-discord/src/agent_core_discord/testing/fakes.py packages/agent-core-discord/tests/test_fakes_attachments.py
+git commit -m "feat(testing): model attachment roundtrip in FakeMessage/FakeChannel (#64)"
+```
+
+---
+
+## Phase 3 — Handler wire-up
+
+### Task 4: Wire `payload.attachments` → `_SendArgs.files` in `_deliver_text_message`
+
+**Files:**
+- Modify: `packages/agent-core-discord/src/agent_core_discord/endpoint.py:691–696`
+- Modify: `packages/agent-core-discord/tests/test_endpoint_outbound.py` (append the single-attachment happy-path test)
+
+- [ ] **Step 1: Write the failing happy-path test**
+
+Append to `packages/agent-core-discord/tests/test_endpoint_outbound.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_text_message_with_single_attachment_uploads_to_discord(monkeypatch, tmp_path):
+    """Issue #64 named-symptom regression lock: payload.attachments=[{path: ...}]
+    reaches Discord via channel.send(files=[discord.File(...)]).
+    """
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    pdf = tmp_path / "briefing.pdf"
+    pdf.write_bytes(b"%PDF-1.4 fake content")
+    from agent_core.bus.envelope import Envelope, TextMessagePayload, FileAttachment
+    from datetime import UTC, datetime
+    try:
+        env = Envelope(
+            id="msg-attach", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="briefing attached",
+                attachments=[FileAttachment(path=str(pdf))],
+            ),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        # Outbound landed.
+        assert len(ch.sent) == 1
+        assert ch.sent[0]["content"] == "briefing attached"
+        # files arg was populated on the channel.send call.
+        sent_files = ch.sent[0]["files"]
+        assert sent_files is not None and len(sent_files) == 1
+        # FakeMessage exposes the attachment with basename filename.
+        msg = ch._messages[ch.sent[0]["message_id"]]
+        assert len(msg.attachments) == 1
+        assert msg.attachments[0].filename == "briefing.pdf"
+        # No error ack published.
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert all(not a.payload.note.lower().startswith("error:") for a in acks)
+    finally:
+        await ep.stop()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_text_message_with_single_attachment_uploads_to_discord -v`
+
+Expected: FAIL — `_deliver_text_message` doesn't read `payload.attachments`, so `ch.sent[0]["files"]` is `None`.
+
+- [ ] **Step 3: Add the wire-up to `_deliver_text_message`**
+
+In `packages/agent-core-discord/src/agent_core_discord/endpoint.py`, locate the `_SendArgs(...)` construction at lines 691–696:
+
+```python
+        args = _SendArgs(
+            channel_id=str(channel_id),
+            text=text_for_send,
+            embeds=embeds_data,
+            reply_to=reply_to,
+        )
+        return await self._send(args)
+```
+
+Add the `files` derivation just above the `_SendArgs(...)` line (after the existing `text_for_send` resolution at line 687–689):
+
+```python
+        # Translate bus-side FileAttachment list to verb-side files list.
+        # Tight FileAttachment validation already ran at envelope publish
+        # time, so payload.attachments is a list of validated models.
+        files = [a.path for a in envelope.payload.attachments] or None
+
+        args = _SendArgs(
+            channel_id=str(channel_id),
+            text=text_for_send,
+            embeds=embeds_data,
+            reply_to=reply_to,
+            files=files,
+        )
+        return await self._send(args)
+```
+
+The `or None` keeps `_SendArgs.files` as `None` when no attachments are present — matches the existing signature default and avoids passing an empty list into the existing chunking logic.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_text_message_with_single_attachment_uploads_to_discord -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agent-core-discord/src/agent_core_discord/endpoint.py packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "feat(discord): wire payload.attachments through _deliver_text_message (#64)"
+```
+
+---
+
+### Task 5: Multi-attachment with order preservation
+
+**Files:**
+- Modify: `packages/agent-core-discord/tests/test_endpoint_outbound.py` (append)
+
+- [ ] **Step 1: Write the test**
+
+```python
+@pytest.mark.asyncio
+async def test_text_message_with_multiple_attachments_uploads_all(monkeypatch, tmp_path):
+    """Multi-file delivery preserves input order on the way to Discord."""
+    import os
+
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    paths = []
+    for name in ("alpha.pdf", "beta.pdf", "gamma.pdf"):
+        p = tmp_path / name
+        p.write_bytes(b"data")
+        paths.append(str(p))
+    from agent_core.bus.envelope import Envelope, TextMessagePayload, FileAttachment
+    from datetime import UTC, datetime
+    try:
+        env = Envelope(
+            id="msg-multi", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="three files",
+                attachments=[FileAttachment(path=p) for p in paths],
+            ),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        msg = ch._messages[ch.sent[0]["message_id"]]
+        assert len(msg.attachments) == 3
+        # Order preserved end-to-end.
+        assert [a.filename for a in msg.attachments] == [
+            os.path.basename(p) for p in paths
+        ]
+    finally:
+        await ep.stop()
+```
+
+- [ ] **Step 2: Run test to verify it passes (should be green-first via Task 4's wire-up)**
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_text_message_with_multiple_attachments_uploads_all -v`
+
+Expected: PASS green-first. The wire-up uses a list comprehension that preserves order; the fake stores in the order received.
+
+If it fails, the wire-up has an ordering bug or the fake is not preserving order — fix before commit.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "test(discord): lock multi-attachment ordering invariant (#64)"
+```
+
+---
+
+### Task 6: Basename filename derivation lock
+
+**Files:**
+- Modify: `packages/agent-core-discord/tests/test_endpoint_outbound.py` (append)
+
+- [ ] **Step 1: Write the test**
+
+```python
+@pytest.mark.asyncio
+async def test_text_message_attachment_uses_basename_as_filename(monkeypatch, tmp_path):
+    """discord.File(path) defaults filename to os.path.basename(path).
+    Lock this default so a future refactor that strips file extension or
+    rewrites the filename is loud, not silent.
+    """
+    import os
+
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    deep_path = tmp_path / "deeply" / "nested" / "weird name.pdf"
+    deep_path.parent.mkdir(parents=True)
+    deep_path.write_bytes(b"x")
+    from agent_core.bus.envelope import Envelope, TextMessagePayload, FileAttachment
+    from datetime import UTC, datetime
+    try:
+        env = Envelope(
+            id="msg-basename", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="basename check",
+                attachments=[FileAttachment(path=str(deep_path))],
+            ),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        msg = ch._messages[ch.sent[0]["message_id"]]
+        assert msg.attachments[0].filename == os.path.basename(str(deep_path))
+        assert msg.attachments[0].filename == "weird name.pdf"
+    finally:
+        await ep.stop()
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_text_message_attachment_uses_basename_as_filename -v`
+
+Expected: PASS green-first.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "test(discord): lock discord.File basename-as-filename default (#64)"
+```
+
+---
+
+### Task 7: File-not-found yields yellow Ack error
+
+**Files:**
+- Modify: `packages/agent-core-discord/tests/test_endpoint_outbound.py` (append)
+
+- [ ] **Step 1: Write the test**
+
+```python
+@pytest.mark.asyncio
+async def test_text_message_attachment_file_not_found_yields_yellow_ack_error(monkeypatch):
+    """Nonexistent path → discord.File raises FileNotFoundError →
+    existing _send exception path catches → yellow Ack with note prefix
+    'error:'. No Discord message published.
+    """
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    from agent_core.bus.envelope import Envelope, TextMessagePayload, FileAttachment
+    from datetime import UTC, datetime
+    try:
+        env = Envelope(
+            id="msg-missing", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="missing file",
+                attachments=[FileAttachment(path="/this/path/does/not/exist.pdf")],
+            ),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        # No Discord message published (the send never happened).
+        assert len(ch.sent) == 0
+        # Yellow Ack with error prefix.
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert len(acks) == 1
+        assert acks[0].urgency == "yellow"
+        assert acks[0].payload.note.lower().startswith("error:")
+    finally:
+        await ep.stop()
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_text_message_attachment_file_not_found_yields_yellow_ack_error -v`
+
+Expected: PASS green-first. The existing `_send` already catches construction errors on `discord.File(path)` and the broader `_deliver_text_message` error path at `endpoint.py:630–634` produces the yellow Ack.
+
+If it fails, inspect the actual exception type raised — `discord.File` may raise something other than `FileNotFoundError` depending on the discord.py version. Either way, the test's assertion is on the yellow-Ack shape, not the exception type — so adapt the test only if the assertion needs adjustment.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "test(discord): lock file-not-found yellow-Ack path for attachments (#64)"
+```
+
+---
+
+### Task 8: Too-large file yields yellow Ack error (mock HTTPException)
+
+**Files:**
+- Modify: `packages/agent-core-discord/tests/test_endpoint_outbound.py` (append)
+
+- [ ] **Step 1: Write the test**
+
+```python
+@pytest.mark.asyncio
+async def test_text_message_attachment_too_large_yields_yellow_ack_error(monkeypatch, tmp_path):
+    """Discord's 25 MB cap surfaces as discord.HTTPException from
+    channel.send. Existing exception path routes to yellow Ack.
+    Locks the routing for a documented mode (Section 2 error table row).
+    """
+    import discord
+
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+
+    # Patch ch.send to raise HTTPException as if Discord rejected the upload.
+    async def _raise_too_large(*args, **kwargs):
+        # discord.HTTPException requires a response-like object; minimal stub.
+        class _Resp:
+            status = 413
+            reason = "Request Entity Too Large"
+        raise discord.HTTPException(_Resp(), "Payload Too Large")
+
+    monkeypatch.setattr(ch, "send", _raise_too_large)
+
+    big = tmp_path / "huge.pdf"
+    big.write_bytes(b"x" * 16)  # actual file size doesn't matter — the mock decides
+    from agent_core.bus.envelope import Envelope, TextMessagePayload, FileAttachment
+    from datetime import UTC, datetime
+    try:
+        env = Envelope(
+            id="msg-big", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="oversized",
+                attachments=[FileAttachment(path=str(big))],
+            ),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert len(acks) == 1
+        assert acks[0].urgency == "yellow"
+        assert acks[0].payload.note.lower().startswith("error:")
+    finally:
+        await ep.stop()
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_text_message_attachment_too_large_yields_yellow_ack_error -v`
+
+Expected: PASS green-first via the existing exception path.
+
+If `discord.HTTPException` constructor signature differs from the stub above (depends on discord.py version), adjust the `_Resp` stub or use `discord.errors.HTTPException` directly. The assertion shape stays the same.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "test(discord): lock too-large HTTPException yellow-Ack routing (#64)"
+```
+
+---
+
+### Task 9: Embed + files coexistence
+
+**Files:**
+- Modify: `packages/agent-core-discord/tests/test_endpoint_outbound.py` (append)
+
+- [ ] **Step 1: Write the test**
+
+```python
+@pytest.mark.asyncio
+async def test_send_embed_plus_files_coexist_on_text_message_envelope(monkeypatch, tmp_path):
+    """A TextMessage envelope carrying both metadata.discord.embeds AND
+    payload.attachments composes into one channel.send call with both
+    keyword args populated. Locks the coexistence invariant — a future
+    branch that picks embeds-or-files would silently re-introduce the
+    #64 file-discard symptom for embed-bearing sends.
+    """
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    pdf = tmp_path / "with_embed.pdf"
+    pdf.write_bytes(b"data")
+    from agent_core.bus.envelope import Envelope, TextMessagePayload, FileAttachment
+    from datetime import UTC, datetime
+    try:
+        env = Envelope(
+            id="msg-both", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="text + embed + file",
+                attachments=[FileAttachment(path=str(pdf))],
+            ),
+            metadata={
+                "discord": {
+                    "channel_id": "500",
+                    "embeds": [{"title": "embed title", "description": "embed body"}],
+                }
+            },
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 1
+        sent = ch.sent[0]
+        assert sent["content"] == "text + embed + file"
+        assert sent["embeds"] is not None and len(sent["embeds"]) == 1
+        assert sent["embeds"][0]["title"] == "embed title"
+        assert sent["files"] is not None and len(sent["files"]) == 1
+        # No error ack.
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert all(not a.payload.note.lower().startswith("error:") for a in acks)
+    finally:
+        await ep.stop()
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_send_embed_plus_files_coexist_on_text_message_envelope -v`
+
+Expected: PASS green-first. `_send` constructs `channel.send(content=..., embeds=..., files=...)` with all three keyword arguments without branching.
+
+If it fails, `_send` is picking one of {text-only, embed-only, files-only}. Pepper's spec Section 2 note: this would re-introduce the named symptom for embed-bearing sends, so fix by removing the branch — keep them composable.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "test(discord): lock embeds+files coexistence on TextMessage envelope (#64)"
+```
+
+---
+
+## Phase 4 — Regression locks
+
+### Task 10: Text-only message unchanged when `attachments` empty
+
+**Files:**
+- Modify: `packages/agent-core-discord/tests/test_endpoint_outbound.py` (append)
+
+- [ ] **Step 1: Write the test**
+
+```python
+@pytest.mark.asyncio
+async def test_text_only_message_unchanged_when_attachments_empty(monkeypatch):
+    """The most common send path: no attachments field set, no files
+    parameter touched on channel.send. Backward-compat regression lock
+    for the pre-#64 path.
+    """
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    from agent_core.bus.envelope import Envelope, TextMessagePayload
+    from datetime import UTC, datetime
+    try:
+        env = Envelope(
+            id="msg-text-only", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(text="plain text"),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 1
+        sent = ch.sent[0]
+        assert sent["content"] == "plain text"
+        # files arg is None (not []) — preserves the pre-#64 absent-argument shape.
+        assert sent["files"] is None
+        msg = ch._messages[sent["message_id"]]
+        assert msg.attachments == []
+    finally:
+        await ep.stop()
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_text_only_message_unchanged_when_attachments_empty -v`
+
+Expected: PASS green-first. The `or None` in Task 4's wire-up ensures empty-attachments produces `files=None`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "test(discord): regression lock — text-only send unchanged (#64)"
+```
+
+---
+
+### Task 11: Existing `send` verb `_SendArgs.files` path unchanged
+
+**Files:**
+- Modify: `packages/agent-core-discord/tests/test_endpoint_outbound.py` (append)
+
+- [ ] **Step 1: Write the test**
+
+```python
+@pytest.mark.asyncio
+async def test_existing_send_verb_files_param_unchanged(monkeypatch, tmp_path):
+    """Verb-side `_SendArgs.files: list[str]` path unaffected by the
+    bus-side `payload.attachments: list[FileAttachment]` schema change.
+    Locks the translation-at-boundary invariant — if a future refactor
+    accidentally widens _SendArgs.files into list[FileAttachment] or
+    couples the two surfaces, this fires.
+    """
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    pdf = tmp_path / "via-tool.pdf"
+    pdf.write_bytes(b"x")
+    try:
+        # send verb takes channel_id + text + files: list[str] directly.
+        env = _envelope(
+            "e", "agent-test", "discord-test",
+            _toolcall("send", {
+                "channel_id": "500",
+                "text": "verb-side send",
+                "files": [str(pdf)],
+            }),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 1
+        assert ch.sent[0]["content"] == "verb-side send"
+        assert ch.sent[0]["files"] is not None
+        msg = ch._messages[ch.sent[0]["message_id"]]
+        assert len(msg.attachments) == 1
+        assert msg.attachments[0].filename == "via-tool.pdf"
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert all(not a.payload.note.lower().startswith("error:") for a in acks)
+    finally:
+        await ep.stop()
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `uv run --no-sync pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_existing_send_verb_files_param_unchanged -v`
+
+Expected: PASS green-first. The `send` verb's `_SendArgs.files: list[str]` shape was unchanged by Phase 1; the translation happens only on the TextMessage envelope path.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "test(discord): regression lock — send verb files param unchanged (#64)"
+```
+
+---
+
+## Phase 5 — Ship
+
+### Task 12: Full gate + Pepper end-of-ticket ping + push + PR + merge
+
+- [ ] **Step 1: Run the full quality gate**
+
+Run: `just check`
+
+Expected: lint clean (ruff), typecheck clean (mypy), import contracts clean (`lint-imports`), all tests pass. The new test count should be ~14 above the prior baseline (5 schema + 1 fake + 6 handler + 2 regression = 14).
+
+If any failures: fix and recommit before proceeding. Do not push red.
+
+- [ ] **Step 2: End-of-ticket status ping to Pepper**
+
+Per the working norm Pepper named earlier this session (`memory: project_pepper_end_of_ticket_status_ping.md`), surface end-of-ticket status to Pepper within ~30 min of the last commit, before push. Use `mcp__agent-core__send(to="pepper", kind="TextMessage", payload={kind: "TextMessage", text: "..."})`:
+
+Suggested shape:
+
+```
+🪶 → 🌶️: #64 implementation complete. Branch `feat/issue-64-discord-attachments`
+ready to push. Full gate green: <N> tests passing, lint/mypy/contracts clean.
+14 new tests across 4 groups. About to push + open PR + merge to main per
+Jeff's standing authorization for #64. Last chance to flag anything before
+PR opens. 🪶
+```
+
+Wait briefly (~60s) for Pepper's response. If she flags anything, address before proceeding. If silent, proceed — the contract says surface state, not block on response.
+
+- [ ] **Step 3: Push the branch**
+
+Run: `git push -u origin feat/issue-64-discord-attachments`
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "feat(#64): wire discord-pepper file-attachment path through to upload" --body "$(cat <<'EOF'
+## Summary
+
+- Add `FileAttachment(path: str, extra='allow')` Pydantic model to `agent_core.bus.envelope`. Tighten `TextMessagePayload.attachments` from `list[dict[str, Any]]` to `list[FileAttachment]` so typos and shape errors surface synchronously at the publishing agent's `send()` call.
+- Wire `payload.attachments` through `_deliver_text_message` to the existing `_SendArgs.files: list[str]` path — a single-line translation at the bus↔verb boundary. `_send` (discord.File construction, upload, multi-file batching) is unchanged.
+- Extend `FakeMessage` / `FakeChannel.send` to model attachment roundtrip so handler tests can assert what reached Discord.
+
+Closes #64.
+
+The corrected failure-mode framing (per criterion check with Pepper, 2026-05-12): the original issue body's `"phantom message_ids"` framing was a misdescription. The actual bug was that `_deliver_text_message` silently discarded `payload.attachments` before any upload was attempted — the message_ids returned were real (text-only) sends. This PR wires the unimplemented feature; verification machinery for the unrelated `"Discord said success but file didn't render"` failure mode is deferred to followup pending a named instance.
+
+## Spec & plan
+
+- Spec: `docs/superpowers/specs/2026-05-12-issue-64-discord-attachments-design.md`
+- Plan: `docs/superpowers/plans/2026-05-12-issue-64-discord-attachments.md`
+
+## Test plan
+
+- [x] `FileAttachment` schema unit tests cover required-path, empty-string rejection, extra-fields allowance, payload defaults, typo regression lock.
+- [x] `FakeMessage`/`FakeChannel.send` sanity test for attachment roundtrip.
+- [x] Handler integration tests: single-attachment happy path, multi-attachment ordering, basename filename, file-not-found yellow-Ack, too-large yellow-Ack (mocked HTTPException), embed+files coexistence.
+- [x] Regression locks: text-only send unchanged, verb-side `_SendArgs.files` path unchanged.
+- [x] `just check` green: lint, typecheck, contracts, full test suite.
+
+## Deferred to followups (out of scope, see spec "Followups")
+
+- Path-allowlist / sandbox for discord-pepper file uploads (pre-existing read-access surface inherited from `send` verb; trigger: untrusted-being endpoints or threat-model change).
+- Upload-result verification machinery (`status: degraded`, `delivered_files`, verify-after-send; trigger: a named symptom of Discord-API-misbehavior).
+- `filename` override field on `FileAttachment` (currently derives basename via `discord.File` default; trigger: named symptom for renaming-at-send).
+- Expand `describe_endpoint` for `discord-pepper` with per-verb schemas including attachments shape.
+- Unify `_SendArgs.files` and `payload.attachments` shapes (currently N=1 of translation pattern; trigger: N=2 in another endpoint).
+EOF
+)"
+```
+
+- [ ] **Step 5: Merge to main**
+
+Per Jeff's standing authorization for high-priority work this cycle, and matching the merge style used for #83 (PR #85) — classic merge commit + branch delete:
+
+```bash
+gh pr merge <PR_NUMBER> --merge --delete-branch
+```
+
+Confirm with:
+
+```bash
+gh pr view <PR_NUMBER> --json state,mergedAt,mergeCommit
+gh issue view 64 --json state,closedAt
+```
+
+Expected: PR `MERGED`, issue `CLOSED`.
+
+- [ ] **Step 6: End-of-ticket close ping to Pepper**
+
+After merge lands, send a closing ping per the working norm:
+
+```
+🪶 → 🌶️: #64 shipped. PR #<N> merged at <sha>, issue #64 closed.
+<N> tests green. Next: surface #84 ordering or other directive.
+```
+
+---
+
+## Self-Review
+
+After writing the full plan, checked against the spec:
+
+**Spec coverage:**
+- Architecture (translation at handler entry, FileAttachment with `extra='allow'`, sync publish-time validation): Tasks 1, 2, 4.
+- Components (envelope.py, endpoint.py, fakes.py): Tasks 1-2, 4, 3.
+- Data flow (steps 1–7 in spec): Tasks 1-2 (steps 1-3), Task 4 (steps 4-5), existing `_send` (steps 5-6), existing Ack path (step 7).
+- Error handling table (5 rows): Tasks 1-2 (rows 1-2, sync ValidationError), Task 7 (row 3, FileNotFoundError), Task 8 (row 4, HTTPException too-large; row 5 rate-limit shares routing).
+- Pre-existing semantics inherited: documented in spec, not separately tested per the spec's "out-of-scope test classes" reasoning.
+- Security Considerations: documented in spec; no test (the named-symptom-bound discipline says don't lock the surface we want to change later).
+- Testing groups 1-4 (14 tests): Tasks 1 (3 tests Group 1), 2 (2 tests Group 1), 3 (1 test Group 4), 4-9 (6 tests Group 2), 10-11 (2 tests Group 3) — total 14. ✓
+- Followups (5 items): all listed in PR body and spec.
+- Implementation order: Tasks 1–11 match the spec's TDD order (schema → fake → wire → regression → gate → ship).
+
+**Placeholder scan:** No TBDs, no "implement later", no "similar to Task N", no "fill in details". Every code block contains real code.
+
+**Type consistency:**
+- `FileAttachment(path: str, extra='allow')`: consistent in Tasks 1, 2, and all handler tests that import it.
+- `_SendArgs.files: list[str] | None`: consistent throughout (Task 4 explicitly uses `or None` to preserve the optional shape).
+- `FakeMessage.attachments: list[FakeAttachment]`: consistent.
+- `FakeAttachment.filename: str`: consistent.
+
+No issues found. Plan stands.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-12-issue-64-discord-attachments.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, two-stage review (spec compliance + code quality) between each. Same flow used successfully for #83.
+2. **Inline Execution** — Execute tasks in this session via `superpowers:executing-plans`, batch with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-12-issue-64-discord-attachments-design.md
+++ b/docs/superpowers/specs/2026-05-12-issue-64-discord-attachments-design.md
@@ -1,0 +1,219 @@
+# Issue #64 — discord-pepper file-attachment path wire-up (Design)
+
+> **Status:** Drafted 2026-05-12. Pending spec-review approval from Pepper (principal-on-this-stream).
+>
+> **Issue:** [#64](https://github.com/jeffrichley/agent_core/issues/64) — `discord-pepper: file-attachment path silently fails (ack reports sent with phantom message_ids; PDF not actually attached)`.
+>
+> **Scope:** Wire the existing `TextMessagePayload.attachments` schema field through `_deliver_text_message` to discord.py's file-upload path. The field is defined on the bus envelope but the discord-pepper adapter silently discards it. This design wires it, with element-level Pydantic validation (`FileAttachment` model) that fails synchronously at publish time so typos surface at the agent's `send()` call rather than as a later yellow Ack.
+
+## Problem
+
+`TextMessagePayload.attachments` exists in `packages/core/src/agent_core/bus/envelope.py:20` as `list[dict[str, Any]]` (default empty list). The bus validates this field on publish, the adapter receives it on the envelope — but `_deliver_text_message` in `packages/agent-core-discord/src/agent_core_discord/endpoint.py:638–697` never reads `payload.attachments`. It extracts `text`, `metadata.discord.channel_id`, `metadata.discord.reply_to`, `metadata.discord.embeds`, and constructs `_SendArgs(...)` **without `files=`**. The attachments list is silently discarded before any upload step is attempted.
+
+The corrected failure-mode framing (per criterion check with Pepper, 2026-05-12): the original issue body described *"phantom message_ids"* and *"Discord API claimed success while the file silently failed."* That framing was a misdescription. The reality is **the adapter never tried to upload.** The `Acknowledgment` returned `status: sent` with real (not phantom) `message_ids` because the text-only `channel.send(content=...)` call did succeed — and that was the only call made. The attachment payload was discarded at the bus↔verb seam before any Discord API call.
+
+**Concrete lived instances**, 2026-05-08:
+- WHOI trip briefing PDF (881 KB) sent to `#job-niwc`. Ack `status: sent`, real `message_id`. Jeff confirmed: text visible, **no PDF attached** (because no upload was attempted).
+- WAR PDF (14 KB) sent to `#pepper-chat` twice. Same shape both times.
+
+The fix is unimplemented-feature-completion, not error-recovery. Verification machinery (verify-after-send, `status: degraded`, `delivered_files` field) was originally proposed in the issue body for a Discord-API-misbehavior scenario that has no named instance. Deferred to followup pending such an instance.
+
+## Out of scope
+
+- **Upload-result verification machinery.** `status: degraded`, `delivered_files: list[str]` on Ack payload, verify-after-send Discord re-fetch. Discord.py's `channel.send(file=...)` raises on HTTP 5xx, rate-limit, and file-too-big failures; the existing error path in `_deliver_text_message` catches and yellow-acks appropriately. The verification proposals were solving for *"Discord said success but didn't actually deliver"* — a scenario with no current named instance. Followup tracked.
+- **Path-allowlist or chroot-style sandbox for discord-pepper file uploads.** Pre-existing read-access surface inherited from the `send` verb. Pepper's lived bug doesn't touch this. Followup pending (a) untrusted-being endpoints, or (b) threat-model change.
+- **`filename` override field on `FileAttachment`.** `discord.File(path)` defaults the upload filename to `os.path.basename(path)`. No named symptom for renaming-at-send. Add when a named case for path-anonymization or display-name-override arrives.
+- **Unifying `_SendArgs.files: list[str]` and `payload.attachments: list[FileAttachment]` shapes.** Translation lives at the handler boundary in this design. If N=2 of this translation pattern surfaces, consider unifying. Currently N=1.
+- **`describe_endpoint` per-verb schema expansion.** `mcp__agent-core__describe_endpoint(name="discord-pepper")` returns a short description today; expanding it to cover per-verb schemas including the attachments shape is a separate documentation effort. Followup tracked.
+- **Aspirational `FileAttachment` fields** (`filename`, `description`, `spoiler`, `voice_message`, etc. from discord.py). `extra='allow'` on the Pydantic model permits them to pass validation today; the adapter only consumes `path`. Wiring additional fields is incremental, named-symptom-bound.
+
+## Design
+
+### Architecture
+
+Two-shape translation at the bus↔verb boundary:
+
+- **Bus side** (`agent_core.bus.envelope`): tight Pydantic `FileAttachment` model. `path` required, `min_length=1`. `extra='allow'` so aspirational fields (per spec convention; see #83's loose-on-producer discipline) don't force coordinated bus migrations. Validation runs synchronously at publish time, so typos and shape errors fail at the publishing agent's `send()` call with a Pydantic stack trace pointing at the bad call.
+- **Verb side** (`agent-core-discord` adapter, `_SendArgs.files: list[str]`): unchanged. The existing `_send` verb and all current callers (the `send` ToolInvocation tool, existing agents using `_SendArgs.files`) keep their string-list shape and behavior.
+- **Translation point**: a single line in `_deliver_text_message` extracts `files = [a.path for a in payload.attachments]` and passes through to `_SendArgs(files=files)`.
+
+No new modules, no new verbs, no new namespaces. The translation lives at the natural seam where bus contract meets verb contract.
+
+### Components
+
+**1.** `packages/core/src/agent_core/bus/envelope.py` — add `FileAttachment`, tighten the `attachments` annotation on `TextMessagePayload`:
+
+```python
+class FileAttachment(BaseModel):
+    path: str = Field(min_length=1)
+    model_config = ConfigDict(extra="allow")
+
+
+class TextMessagePayload(BaseModel):
+    kind: Literal["TextMessage"] = "TextMessage"
+    text: str
+    attachments: list[FileAttachment] = Field(default_factory=list)
+```
+
+The `default_factory=list` preserves backward compat: existing publishes without `attachments` continue to validate.
+
+**2.** `packages/agent-core-discord/src/agent_core_discord/endpoint.py` — wire-up in `_deliver_text_message` (line ~638–697):
+
+After the existing extract of `text`, `channel_id`, `reply_to`, `embeds`, add:
+
+```python
+files = [a.path for a in payload.attachments]
+```
+
+And pass `files=files` into the existing `_SendArgs(...)` construction. `_send` (line ~1203–1221) already handles `discord.File(path)` construction and multi-file batching — no changes there.
+
+**3.** `packages/agent-core-discord/src/agent_core_discord/testing/fakes.py` — extend `FakeChannel.send` (line ~171–193) to model the attachment round-trip. Currently it accepts `files: list | None` as a parameter but doesn't reflect it on the returned `FakeMessage`. After change:
+
+- `FakeMessage` exposes an `attachments` list.
+- Each element exposes at minimum `.filename` (derived from the input path's basename, matching `discord.File`'s default behavior on the real client).
+- Per the `test_fakes_mirror_real_strictly` working norm: model only the shape tests assert on; expand named.
+
+Three files touched. No new files in production code; one new test file (Group 1 schema tests, see Testing).
+
+### Data flow
+
+Happy path:
+
+```
+1. Agent calls mcp__agent-core__send(
+     to="discord-pepper", kind="TextMessage",
+     payload={
+       "kind": "TextMessage",
+       "text": "Briefing attached.",
+       "attachments": [{"path": "/abs/path/briefing.pdf"}]
+     },
+     metadata={"discord": {"channel_id": "..."}}
+   )
+
+2. Bus: Pydantic constructs TextMessagePayload.
+   For each dict in attachments, FileAttachment validates path (required, min_length=1).
+   Typo / missing path / empty string raises ValidationError synchronously at the
+   publishing agent's send() call. Bus refuses to enqueue invalid envelopes.
+
+3. Bus delivers validated envelope to discord-pepper.
+
+4. _deliver_text_message handler:
+     text/channel_id/reply_to/embeds: extracted as today.
+     NEW: files = [a.path for a in payload.attachments].
+     _SendArgs(channel_id, text, reply_to, embeds, files=files).
+     await self._send(args).
+
+5. _send (existing): [discord.File(p) for p in args.files]; rejects HTTP URLs upfront.
+   channel.send(content=..., embeds=..., files=...). Files attach to first chunk only
+   when text is multi-chunked.
+
+6. Discord returns Message objects; _send returns {"status": "sent", "message_ids": [...]}.
+
+7. _deliver_text_message publishes green Acknowledgment with note=json.dumps(result).
+```
+
+Topic-override invariant: when the agent sets `metadata.discord.channel_id` explicitly (as #83 covers), routing uses that channel. The attachment list is delivered to whatever channel resolution produces — channel resolution and attachment delivery are orthogonal.
+
+### Error handling
+
+All failure modes route through existing paths. No new code, no new ack shape, no new urgency tier.
+
+| Failure | Where it surfaces | Severity |
+|---|---|---|
+| Malformed dict (typo like `{paht: ...}`, missing `path`) | Sync `ValidationError` at agent's `send()` call. Stack trace at agent. | Synchronous to agent |
+| Empty/whitespace path | Same — `Field(min_length=1)` rejects at validation time | Synchronous to agent |
+| Path doesn't exist on disk | `discord.File(path)` raises `FileNotFoundError` → existing `_send` exception path → `_ToolError` → yellow Ack with `note="error: ..."` | Yellow Ack |
+| File too large (Discord 25 MB) | `discord.HTTPException` via discord.py → same exception path | Yellow Ack |
+| Rate-limit / Discord 5xx | discord.py raises → same exception path | Yellow Ack |
+
+**Explicitly NOT modeled:** *"Discord API claimed success but file didn't actually render."* No named instance. Verification machinery deferred to followup.
+
+#### Pre-existing semantics inherited
+
+The wire-up inherits these properties from `_send`'s existing behavior — naming them so a future audit doesn't assume #64 introduced them:
+
+- **Relative paths** resolve against the daemon process's cwd. No absolute-path constraint enforced.
+- **Symlinks** are followed (Python's standard file-open behavior).
+- **Multi-file partial failure**: discord.py treats `channel.send(files=[...])` as all-or-nothing on the batch. If any `discord.File(path)` raises before `send()` is called, no files attach for that message.
+- **First-chunk-only**: when text exceeds Discord's per-message length and `_send` chunks the message, files attach to the first chunk only. Subsequent chunks are text-only.
+
+These are stable, documented, and not changed by this work.
+
+### Security considerations
+
+`payload.attachments[].path` is forwarded to `discord.File(path)`, which opens the file in the daemon process's filesystem context. **Any agent that can publish a `TextMessage` envelope to `discord-pepper` can cause the daemon to upload any file the daemon process has read access to** — including `~/.ssh/id_ed25519`, `~/.gbrain/config.json` (Supabase pooler URL with credentials), `~/.pepper/.env`, the SQLite scheduler DB, `/etc/passwd`, etc.
+
+This surface is **pre-existing on the `send` ToolInvocation path** (`_SendArgs.files: list[str]` already accepts arbitrary local paths from agents). #64's wire-up inherits the property; it does not introduce or widen it. The current threat model (trusted-being endpoints only) absorbs the risk.
+
+**Mitigation deferred to followup** (see Followups #1): a path-allowlist or chroot-style sandbox becomes warranted when (a) untrusted-being endpoints are added, or (b) the threat model otherwise changes. Until then, the trust boundary is the agent-bus admission control.
+
+## Testing
+
+Fourteen tests across four groups. Each test names a specific behavior tied to either a named symptom (Pepper's lived experience) or a named documented mode (this design's contract).
+
+### Group 1: Schema validation (5 tests, new file)
+
+File: `packages/core/tests/bus/test_file_attachment_schema.py`
+
+- `test_file_attachment_requires_path` — `FileAttachment()` raises `ValidationError`.
+- `test_file_attachment_rejects_empty_string_path` — `FileAttachment(path="")` raises (catches `Field(min_length=1)`).
+- `test_file_attachment_allows_extra_fields` — `FileAttachment(path="/x", filename="y")` validates; locks the `extra='allow'` aspirational-field tolerance.
+- `test_text_message_payload_defaults_attachments_empty` — `TextMessagePayload(text="hi")` validates with empty `attachments` list; backward compat.
+- `test_text_message_payload_typo_in_attachment_key_raises_at_publish` — `{"text": "hi", "attachments": [{"paht": "/x"}]}` raises `ValidationError`. Named-symptom regression lock.
+
+### Group 2: Handler wire-up (6 tests, append)
+
+File: `packages/agent-core-discord/tests/test_endpoint_outbound.py`
+
+- `test_text_message_with_single_attachment_uploads_to_discord` — happy path: PDF path → `channel.send` receives `files` containing the expected file.
+- `test_text_message_with_multiple_attachments_uploads_all` — two-to-three paths land; **order preserved** (`assert [a.filename for a in fake_msg.attachments] == [os.path.basename(p) for p in input_paths]`).
+- `test_text_message_attachment_uses_basename_as_filename` — `FakeMessage.attachments[0].filename == os.path.basename(path)`. Locks the `discord.File` default behavior at the test boundary.
+- `test_text_message_attachment_file_not_found_yields_yellow_ack_error` — nonexistent path → yellow Ack `note.startswith("error:")`; no Discord message published.
+- `test_text_message_attachment_too_large_yields_yellow_ack_error` — mock `channel.send` to raise `discord.HTTPException` (413 or similar) → yellow Ack via existing exception path. Locks routing for the documented mode (not pinned to a lived symptom; the bar is lower for tests-on-documented-modes).
+- `test_send_embed_plus_files_coexist_on_text_message_envelope` — payload with `text` + `metadata.discord.embeds` + `payload.attachments` compose into a single `channel.send` with all three keyword arguments populated. Locks the coexistence invariant.
+
+### Group 3: Regression locks (2 tests, same file)
+
+- `test_text_only_message_unchanged_when_attachments_empty` — the most common send path keeps working with no attachments field touched. Backward compat.
+- `test_existing_send_verb_files_param_unchanged` — verb-side `_SendArgs.files: list[str]` path unaffected by the bus-side schema change. Locks the translation-at-boundary invariant — if a future refactor leaks the new shape into `_SendArgs`, this test fires.
+
+### Group 4: Fake extension sanity (1 test)
+
+File: `packages/agent-core-discord/tests/test_fakes.py` (if exists) or fold into Group 2.
+
+- `test_fake_message_records_attachments_from_send_call` — `FakeChannel.send(files=[...])` returns a `FakeMessage` whose `attachments` list reflects the inputs with `.filename` derived from basename. Without this, the Group 2 assertions are toothless.
+
+### Out-of-scope test classes (explicitly considered, decided against)
+
+- **File-on-first-chunk-only-when-text-multi-chunked.** Pre-existing `_send` behavior, unchanged by this work. Covered by the *Pre-existing semantics inherited* subsection.
+- **Path-is-a-directory / broken-symlink.** Same exception shape as `FileNotFoundError`; runtime error path is locked by test 4. Adding redundant tests for the same path is YAGNI.
+- **Cross-platform / special-char path handling.** Python's path machinery handles. No named symptom.
+- **Concurrent multi-file race conditions.** Out of scope; same shape as #83's cache-concurrency discussion.
+
+The restraint here is part of the discipline: the temptation to *"since we're touching tests, let's add ten more"* is the cheap-while-touching alarm from #83's Q2 (cache extraction). Fourteen tests tied to documented behaviors is the right scope.
+
+## Followups (out of scope for #64)
+
+Tracked for separate tickets, each named-trigger-bound:
+
+1. **Path-allowlist / sandbox for discord-pepper file uploads.** Pre-existing read-access surface inherited from the `send` verb. **Trigger:** addition of untrusted-being endpoint, or threat-model change.
+2. **Upload-result verification machinery.** `status: degraded`, `delivered_files: list[str]` on Ack payload, verify-after-send Discord re-fetch. **Trigger:** a named symptom of *"Discord API claimed success but file didn't render."* No current instances.
+3. **`filename` override field on `FileAttachment`.** Currently derives basename via `discord.File`'s default. **Trigger:** a named symptom for renaming-at-send (e.g., anonymizing a source path before posting, display-name override).
+4. **Expand `mcp__agent-core__describe_endpoint` for `discord-pepper`** to include per-verb schemas — payload shapes, attachment formats, required vs optional fields. The short description returns today; expansion is documentation work that doesn't block #64.
+5. **Unifying `_SendArgs.files` and `payload.attachments` shape.** Translation lives at the handler boundary today. **Trigger:** N=2 of this translation pattern in another endpoint.
+
+## Implementation order
+
+TDD, bite-sized per `writing-plans` discipline:
+
+1. **Schema first.** Add `FileAttachment` + wire to `TextMessagePayload.attachments` in `agent_core.bus.envelope`. Write Group 1 tests (5 schema validation tests). Red → green via the new model.
+2. **Fake extension.** Extend `FakeMessage.attachments` to model the round-trip. Write Group 4 sanity test. Red → green.
+3. **Handler wire-up.** Read `payload.attachments` in `_deliver_text_message`, translate to `_SendArgs.files`. Write Group 2 tests (6 handler-integration tests). Red → green.
+4. **Regression locks.** Group 3 tests (2 tests). Should pass green-first; if they fail, the wire-up has a backward-compat bug.
+5. **Full gate.** `just check` green: lint, mypy, contracts, all tests.
+6. **End-of-ticket status ping to Pepper** (per the working norm) before push.
+7. **PR + merge.**
+
+## Open questions for spec review
+
+None. Every design decision resolved through Q1 (named-vs-speculative scope), Q2 (schema tightness), Q3 (translation routing), and Section 1–4 refinements.

--- a/docs/superpowers/specs/2026-05-12-issue-64-discord-attachments-design.md
+++ b/docs/superpowers/specs/2026-05-12-issue-64-discord-attachments-design.md
@@ -121,7 +121,8 @@ All failure modes route through existing paths. No new code, no new ack shape, n
 | Failure | Where it surfaces | Severity |
 |---|---|---|
 | Malformed dict (typo like `{paht: ...}`, missing `path`) | Sync `ValidationError` at agent's `send()` call. Stack trace at agent. | Synchronous to agent |
-| Empty/whitespace path | Same — `Field(min_length=1)` rejects at validation time | Synchronous to agent |
+| Empty path string | Same — `Field(min_length=1)` rejects at validation time | Synchronous to agent |
+| Whitespace-only path | Passes `min_length=1`; falls through to disk-resolution; `discord.File` raises `FileNotFoundError` → yellow Ack via existing exception path. Not caught at validation (whitespace-strip not specified as named-symptom-bound). | Yellow Ack |
 | Path doesn't exist on disk | `discord.File(path)` raises `FileNotFoundError` → existing `_send` exception path → `_ToolError` → yellow Ack with `note="error: ..."` | Yellow Ack |
 | File too large (Discord 25 MB) | `discord.HTTPException` via discord.py → same exception path | Yellow Ack |
 | Rate-limit / Discord 5xx | discord.py raises → same exception path | Yellow Ack |

--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -688,11 +688,17 @@ class DiscordEndpoint:
         if embeds_data and not text_for_send:
             text_for_send = None
 
+        # Translate bus-side FileAttachment list to verb-side files list.
+        # Tight FileAttachment validation already ran at envelope publish
+        # time, so payload.attachments is a list of validated models.
+        files = [a.path for a in envelope.payload.attachments] or None
+
         args = _SendArgs(
             channel_id=str(channel_id),
             text=text_for_send,
             embeds=embeds_data,
             reply_to=reply_to,
+            files=files,
         )
         return await self._send(args)
 

--- a/packages/agent-core-discord/src/agent_core_discord/testing/fakes.py
+++ b/packages/agent-core-discord/src/agent_core_discord/testing/fakes.py
@@ -90,6 +90,18 @@ class FakePoll:
         return self._is_finalised
 
 
+class FakeAttachment:
+    """Minimal stand-in for discord.Attachment on a fake message.
+
+    Models only the fields tests assert on (`filename`, `url`); expand
+    named per the test-fakes-mirror-real-strictly discipline.
+    """
+
+    def __init__(self, *, filename: str, url: str = ""):
+        self.filename = filename
+        self.url = url
+
+
 class FakeMessage:
     def __init__(
         self,
@@ -99,12 +111,14 @@ class FakeMessage:
         content: str = "",
         author=None,
         poll: FakePoll | None = None,
+        attachments: list[FakeAttachment] | None = None,
     ):
         self.id = id
         self.channel_id = channel_id
         self.content = content
         self.author = author
         self.poll = poll
+        self.attachments = attachments or []
         self.reactions: list[str] = []
         self.edits: list[dict[str, Any]] = []
 
@@ -178,7 +192,18 @@ class FakeChannel:
         poll: Any = None,
     ) -> FakeMessage:
         new_id = f"new-{len(self.sent) + 1}"
-        msg = FakeMessage(id=new_id, channel_id=self.id, content=content or "")
+        attachments: list[FakeAttachment] = []
+        for f in files or []:
+            # discord.File.filename is the resolved upload filename
+            # (basename of the path when not overridden).
+            fn = getattr(f, "filename", "")
+            attachments.append(FakeAttachment(filename=fn))
+        msg = FakeMessage(
+            id=new_id,
+            channel_id=self.id,
+            content=content or "",
+            attachments=attachments,
+        )
         self._messages[new_id] = msg
         self.sent.append(
             {

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -2010,3 +2010,39 @@ async def test_text_message_with_multiple_attachments_uploads_all(monkeypatch, t
         ]
     finally:
         await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_text_message_attachment_uses_basename_as_filename(monkeypatch, tmp_path):
+    """discord.File(path) defaults filename to os.path.basename(path).
+    Lock this default so a future refactor that strips file extension or
+    rewrites the filename is loud, not silent.
+    """
+    import os
+    from datetime import UTC, datetime
+
+    from agent_core.bus.envelope import Envelope, FileAttachment, TextMessagePayload
+
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    deep_path = tmp_path / "deeply" / "nested" / "weird name.pdf"
+    deep_path.parent.mkdir(parents=True)
+    deep_path.write_bytes(b"x")
+    try:
+        env = Envelope(
+            id="msg-basename", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="basename check",
+                attachments=[FileAttachment(path=str(deep_path))],
+            ),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        msg = ch._messages[ch.sent[0]["message_id"]]
+        assert msg.attachments[0].filename == os.path.basename(str(deep_path))
+        assert msg.attachments[0].filename == "weird name.pdf"
+    finally:
+        await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -2204,3 +2204,38 @@ async def test_text_only_message_unchanged_when_attachments_empty(monkeypatch):
         assert msg.attachments == []
     finally:
         await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_existing_send_verb_files_param_unchanged(monkeypatch, tmp_path):
+    """Verb-side `_SendArgs.files: list[str]` path unaffected by the
+    bus-side `payload.attachments: list[FileAttachment]` schema change.
+    Locks the translation-at-boundary invariant — if a future refactor
+    accidentally widens _SendArgs.files into list[FileAttachment] or
+    couples the two surfaces, this fires.
+    """
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    pdf = tmp_path / "via-tool.pdf"
+    pdf.write_bytes(b"x")
+    try:
+        env = _envelope(
+            "e", "agent-test", "discord-test",
+            _toolcall("send", {
+                "channel_id": "500",
+                "text": "verb-side send",
+                "files": [str(pdf)],
+            }),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 1
+        assert ch.sent[0]["content"] == "verb-side send"
+        assert ch.sent[0]["files"] is not None
+        msg = ch._messages[ch.sent[0]["message_id"]]
+        assert len(msg.attachments) == 1
+        assert msg.attachments[0].filename == "via-tool.pdf"
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert all(not a.payload.note.lower().startswith("error:") for a in acks)
+    finally:
+        await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -1932,3 +1932,45 @@ async def test_auto_echo_hard_errors_uniformly_across_verbs(
         )
     finally:
         await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_text_message_with_single_attachment_uploads_to_discord(monkeypatch, tmp_path):
+    """Issue #64 named-symptom regression lock: payload.attachments=[{path: ...}]
+    reaches Discord via channel.send(files=[discord.File(...)]).
+    """
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    pdf = tmp_path / "briefing.pdf"
+    pdf.write_bytes(b"%PDF-1.4 fake content")
+    from datetime import UTC, datetime
+
+    from agent_core.bus.envelope import Envelope, FileAttachment, TextMessagePayload
+    try:
+        env = Envelope(
+            id="msg-attach", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="briefing attached",
+                attachments=[FileAttachment(path=str(pdf))],
+            ),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        # Outbound landed.
+        assert len(ch.sent) == 1
+        assert ch.sent[0]["content"] == "briefing attached"
+        # files arg was populated on the channel.send call.
+        sent_files = ch.sent[0]["files"]
+        assert sent_files is not None and len(sent_files) == 1
+        # FakeMessage exposes the attachment with basename filename.
+        msg = ch._messages[ch.sent[0]["message_id"]]
+        assert len(msg.attachments) == 1
+        assert msg.attachments[0].filename == "briefing.pdf"
+        # No error ack published.
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert all(not a.payload.note.lower().startswith("error:") for a in acks)
+    finally:
+        await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -33,6 +33,7 @@ from agent_core_discord.testing.fakes import (
 from agent_core.bus.envelope import (
     EndpointInfo,
     Envelope,
+    FileAttachment,
     TextMessagePayload,
     ToolInvocationPayload,
 )
@@ -2126,5 +2127,48 @@ async def test_text_message_attachment_too_large_yields_yellow_ack_error(monkeyp
         assert len(acks) == 1
         assert acks[0].urgency == "yellow"
         assert acks[0].payload.note.lower().startswith("error:")
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_send_embed_plus_files_coexist_on_text_message_envelope(monkeypatch, tmp_path):
+    """A TextMessage envelope carrying both metadata.discord.embeds AND
+    payload.attachments composes into one channel.send call with both
+    keyword args populated. Locks the coexistence invariant — a future
+    branch that picks embeds-or-files would silently re-introduce the
+    #64 file-discard symptom for embed-bearing sends.
+    """
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    pdf = tmp_path / "with_embed.pdf"
+    pdf.write_bytes(b"data")
+    try:
+        env = Envelope(
+            id="msg-both", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="text + embed + file",
+                attachments=[FileAttachment(path=str(pdf))],
+            ),
+            metadata={
+                "discord": {
+                    "channel_id": "500",
+                    "embeds": [{"title": "embed title", "description": "embed body"}],
+                }
+            },
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 1
+        sent = ch.sent[0]
+        assert sent["content"] == "text + embed + file"
+        assert sent["embeds"] is not None and len(sent["embeds"]) == 1
+        assert sent["embeds"][0].title == "embed title"
+        assert sent["files"] is not None and len(sent["files"]) == 1
+        # No error ack.
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert all(not a.payload.note.lower().startswith("error:") for a in acks)
     finally:
         await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -2081,3 +2081,50 @@ async def test_text_message_attachment_file_not_found_yields_yellow_ack_error(mo
         assert acks[0].payload.note.lower().startswith("error:")
     finally:
         await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_text_message_attachment_too_large_yields_yellow_ack_error(monkeypatch, tmp_path):
+    """Discord's 25 MB cap surfaces as discord.HTTPException from
+    channel.send. Existing exception path routes to yellow Ack.
+    Locks the routing for a documented mode (Section 2 error table row).
+    """
+    import discord
+
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+
+    # Patch ch.send to raise HTTPException as if Discord rejected the upload.
+    async def _raise_too_large(*args, **kwargs):
+        # discord.HTTPException requires a response-like object; minimal stub.
+        class _Resp:
+            status = 413
+            reason = "Request Entity Too Large"
+        raise discord.HTTPException(_Resp(), "Payload Too Large")
+
+    monkeypatch.setattr(ch, "send", _raise_too_large)
+
+    big = tmp_path / "huge.pdf"
+    big.write_bytes(b"x" * 16)
+    from datetime import UTC, datetime
+
+    from agent_core.bus.envelope import Envelope, FileAttachment, TextMessagePayload
+    try:
+        env = Envelope(
+            id="msg-big", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="oversized",
+                attachments=[FileAttachment(path=str(big))],
+            ),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert len(acks) == 1
+        assert acks[0].urgency == "yellow"
+        assert acks[0].payload.note.lower().startswith("error:")
+    finally:
+        await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -1974,3 +1974,39 @@ async def test_text_message_with_single_attachment_uploads_to_discord(monkeypatc
         assert all(not a.payload.note.lower().startswith("error:") for a in acks)
     finally:
         await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_text_message_with_multiple_attachments_uploads_all(monkeypatch, tmp_path):
+    """Multi-file delivery preserves input order on the way to Discord."""
+    import os
+
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    paths = []
+    for name in ("alpha.pdf", "beta.pdf", "gamma.pdf"):
+        p = tmp_path / name
+        p.write_bytes(b"data")
+        paths.append(str(p))
+    from agent_core.bus.envelope import FileAttachment
+    try:
+        env = Envelope(
+            id="msg-multi", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="three files",
+                attachments=[FileAttachment(path=p) for p in paths],
+            ),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        msg = ch._messages[ch.sent[0]["message_id"]]
+        assert len(msg.attachments) == 3
+        # Order preserved end-to-end.
+        assert [a.filename for a in msg.attachments] == [
+            os.path.basename(p) for p in paths
+        ]
+    finally:
+        await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -2046,3 +2046,38 @@ async def test_text_message_attachment_uses_basename_as_filename(monkeypatch, tm
         assert msg.attachments[0].filename == "weird name.pdf"
     finally:
         await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_text_message_attachment_file_not_found_yields_yellow_ack_error(monkeypatch):
+    """Nonexistent path → discord.File raises FileNotFoundError →
+    existing _send exception path catches → yellow Ack with note prefix
+    'error:'. No Discord message published.
+    """
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    from datetime import UTC, datetime
+
+    from agent_core.bus.envelope import Envelope, FileAttachment, TextMessagePayload
+    try:
+        env = Envelope(
+            id="msg-missing", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(
+                text="missing file",
+                attachments=[FileAttachment(path="/this/path/does/not/exist.pdf")],
+            ),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        # No Discord message published (the send never happened).
+        assert len(ch.sent) == 0
+        # Yellow Ack with error prefix.
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert len(acks) == 1
+        assert acks[0].urgency == "yellow"
+        assert acks[0].payload.note.lower().startswith("error:")
+    finally:
+        await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -2172,3 +2172,35 @@ async def test_send_embed_plus_files_coexist_on_text_message_envelope(monkeypatc
         assert all(not a.payload.note.lower().startswith("error:") for a in acks)
     finally:
         await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_text_only_message_unchanged_when_attachments_empty(monkeypatch):
+    """The most common send path: no attachments field set, no files
+    parameter touched on channel.send. Backward-compat regression lock
+    for the pre-#64 path.
+    """
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="500")
+    fake.add_channel(ch)
+    from datetime import UTC, datetime
+
+    from agent_core.bus.envelope import Envelope, TextMessagePayload
+    try:
+        env = Envelope(
+            id="msg-text-only", correlation_id="c", from_="agent-test", to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(text="plain text"),
+            metadata={"discord": {"channel_id": "500"}},
+            created_at=datetime.now(UTC),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 1
+        sent = ch.sent[0]
+        assert sent["content"] == "plain text"
+        # files arg is None (not []) — preserves the pre-#64 absent-argument shape.
+        assert sent["files"] is None
+        msg = ch._messages[sent["message_id"]]
+        assert msg.attachments == []
+    finally:
+        await ep.stop()

--- a/packages/agent-core-discord/tests/test_fakes_attachments.py
+++ b/packages/agent-core-discord/tests/test_fakes_attachments.py
@@ -1,0 +1,31 @@
+"""Sanity test for FakeMessage/FakeChannel attachment roundtrip (#64)."""
+
+from __future__ import annotations
+
+import discord
+import pytest
+from agent_core_discord.testing.fakes import FakeChannel
+
+
+@pytest.mark.asyncio
+async def test_fake_message_records_attachments_from_send_call(tmp_path):
+    """FakeChannel.send(files=[...]) returns a FakeMessage whose
+    .attachments list reflects the inputs with .filename derived from
+    each discord.File's filename attribute.
+
+    Without this fake-side modeling, handler-level tests in Phase 3
+    are toothless — they can't assert what reached Discord.
+    """
+    ch = FakeChannel(id="100")
+    f1 = tmp_path / "alpha.pdf"
+    f1.write_bytes(b"a" * 16)
+    f2 = tmp_path / "beta.pdf"
+    f2.write_bytes(b"b" * 16)
+    discord_files = [discord.File(str(f1)), discord.File(str(f2))]
+    try:
+        msg = await ch.send(content="hi", files=discord_files)
+        assert len(msg.attachments) == 2
+        assert [a.filename for a in msg.attachments] == ["alpha.pdf", "beta.pdf"]
+    finally:
+        for df in discord_files:
+            df.close()

--- a/packages/core/src/agent_core/bus/envelope.py
+++ b/packages/core/src/agent_core/bus/envelope.py
@@ -14,6 +14,24 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
+class FileAttachment(BaseModel):
+    """File attachment on a TextMessage envelope.
+
+    `path` is the local filesystem path discord-pepper reads via
+    `discord.File(path)`. Validation runs at envelope publish time so
+    typos / missing keys surface synchronously at the publishing
+    agent's send() call, not as a later yellow Ack from the adapter.
+
+    `extra='allow'` permits aspirational fields (filename override,
+    description, spoiler) to pass validation; the adapter currently
+    only consumes `path`. New fields wire to the adapter incrementally,
+    named-symptom-bound.
+    """
+
+    path: str = Field(min_length=1)
+    model_config = ConfigDict(extra="allow")
+
+
 class TextMessagePayload(BaseModel):
     kind: Literal["TextMessage"] = "TextMessage"
     text: str

--- a/packages/core/src/agent_core/bus/envelope.py
+++ b/packages/core/src/agent_core/bus/envelope.py
@@ -35,7 +35,7 @@ class FileAttachment(BaseModel):
 class TextMessagePayload(BaseModel):
     kind: Literal["TextMessage"] = "TextMessage"
     text: str
-    attachments: list[dict[str, Any]] = Field(default_factory=list)
+    attachments: list[FileAttachment] = Field(default_factory=list)
 
 
 class EventPayload(BaseModel):

--- a/packages/core/tests/bus/test_file_attachment_schema.py
+++ b/packages/core/tests/bus/test_file_attachment_schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from agent_core.bus.envelope import FileAttachment
+from agent_core.bus.envelope import FileAttachment, TextMessagePayload
 
 
 def test_file_attachment_requires_path():
@@ -27,3 +27,21 @@ def test_file_attachment_allows_extra_fields():
     # filename available via model_extra (Pydantic v2 extra-allow mechanism)
     assert attachment.model_extra is not None
     assert attachment.model_extra.get("filename") == "renamed.pdf"
+
+
+def test_text_message_payload_defaults_attachments_empty():
+    """Backward compat: existing publishes without `attachments` still validate."""
+    payload = TextMessagePayload(text="hi")
+    assert payload.attachments == []
+
+
+def test_text_message_payload_typo_in_attachment_key_raises_at_publish():
+    """Named-symptom regression lock: a typo in the attachment dict key
+    surfaces at envelope-construction time, synchronously to the agent's
+    publish call, not as a later yellow Ack.
+    """
+    with pytest.raises(ValidationError):
+        TextMessagePayload(
+            text="hi",
+            attachments=[{"paht": "/abs/file.pdf"}],  # typo: missing 'path'
+        )

--- a/packages/core/tests/bus/test_file_attachment_schema.py
+++ b/packages/core/tests/bus/test_file_attachment_schema.py
@@ -1,0 +1,29 @@
+"""Tests for FileAttachment Pydantic model (#64)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agent_core.bus.envelope import FileAttachment
+
+
+def test_file_attachment_requires_path():
+    """Missing `path` raises ValidationError at publish time."""
+    with pytest.raises(ValidationError):
+        FileAttachment()
+
+
+def test_file_attachment_rejects_empty_string_path():
+    """Empty `path` rejected by Field(min_length=1)."""
+    with pytest.raises(ValidationError):
+        FileAttachment(path="")
+
+
+def test_file_attachment_allows_extra_fields():
+    """extra='allow' lets aspirational fields land without schema migration."""
+    attachment = FileAttachment(path="/abs/file.pdf", filename="renamed.pdf")
+    assert attachment.path == "/abs/file.pdf"
+    # filename available via model_extra (Pydantic v2 extra-allow mechanism)
+    assert attachment.model_extra is not None
+    assert attachment.model_extra.get("filename") == "renamed.pdf"

--- a/packages/core/tests/test_bus_tail_summaries.py
+++ b/packages/core/tests/test_bus_tail_summaries.py
@@ -20,7 +20,10 @@ from agent_core.bus_tail.summaries import SUMMARIZERS, summarize_payload
 
 
 def test_summarize_text_message_returns_shape_only():
-    payload = TextMessagePayload(text="hello world", attachments=[{"a": 1}, {"b": 2}])
+    payload = TextMessagePayload(
+        text="hello world",
+        attachments=[{"path": "/a.pdf"}, {"path": "/b.pdf"}],
+    )
     summary = SUMMARIZERS["TextMessage"](payload)
     assert summary == {"text_length": 11, "attachment_count": 2}
     # No raw text value leaks.


### PR DESCRIPTION
## Summary

- Add `FileAttachment(path: str, extra='allow')` Pydantic model to `agent_core.bus.envelope`. Tighten `TextMessagePayload.attachments` from `list[dict[str, Any]]` to `list[FileAttachment]` so typos and shape errors surface synchronously at the publishing agent's `send()` call.
- Wire `payload.attachments` through `_deliver_text_message` to the existing `_SendArgs.files: list[str]` path — a single-line translation at the bus↔verb boundary. `_send` (discord.File construction, upload, multi-file batching) is unchanged.
- Extend `FakeMessage` / `FakeChannel.send` to model attachment roundtrip so handler tests can assert what reached Discord.

Closes #64.

The corrected failure-mode framing (per criterion check with Pepper, 2026-05-12): the original issue body's *"phantom message_ids"* framing was a misdescription. The actual bug was that `_deliver_text_message` silently discarded `payload.attachments` before any upload was attempted — the message_ids returned were real (text-only) sends. This PR wires the unimplemented feature. Verification machinery for the unrelated *"Discord said success but file didn't render"* failure mode is deferred to a followup pending a named instance.

## Spec & plan

- Spec: \`docs/superpowers/specs/2026-05-12-issue-64-discord-attachments-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-12-issue-64-discord-attachments.md\`

## Test plan

- [x] \`FileAttachment\` schema unit tests cover required-path, empty-string rejection, extra-fields allowance, payload defaults, typo regression lock.
- [x] \`FakeMessage\`/\`FakeChannel.send\` sanity test for attachment roundtrip.
- [x] Handler integration tests: single-attachment happy path, multi-attachment ordering, basename filename, file-not-found yellow-Ack, too-large yellow-Ack (mocked HTTPException), embed+files coexistence.
- [x] Regression locks: text-only send unchanged, verb-side \`_SendArgs.files\` path unchanged.
- [x] One bus-tail fixture update (test was feeding fake-shape dicts; schema tightening surfaced it; pure fixture data fix, summarizer behavior unchanged).
- [x] \`just check\` green: 1033 passed / 5 skipped, lint/mypy/contracts all clean.

## Deferred to followups (out of scope, see spec "Followups")

- Path-allowlist / sandbox for discord-pepper file uploads (pre-existing read-access surface inherited from \`send\` verb; trigger: untrusted-being endpoints or threat-model change).
- Upload-result verification machinery (\`status: degraded\`, \`delivered_files\`, verify-after-send; trigger: a named symptom of Discord-API-misbehavior).
- \`filename\` override field on \`FileAttachment\` (currently derives basename via \`discord.File\` default; trigger: named symptom for renaming-at-send).
- Expand \`describe_endpoint\` for \`discord-pepper\` with per-verb schemas including attachments shape.
- Unify \`_SendArgs.files\` and \`payload.attachments\` shapes (currently N=1 of translation pattern; trigger: N=2 in another endpoint).