### PR TITLE
feat(daemon): venv isolation from workspace uv sync (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Core infrastructure for AI agents. Consolidates memory, knowledge compilation, a
 uv sync
 ```
 
+- **Running the bus daemon:** see [docs/setup/daemon.md](docs/setup/daemon.md) for the one-time setup and the `daemon refresh` daily flow.
+
 ## Memory Compiler
 
 Automatic conversation capture and knowledge base compilation powered by Claude Code hooks. See `memory-compiler/AGENTS.md` for the full technical reference.

--- a/docs/setup/daemon.md
+++ b/docs/setup/daemon.md
@@ -60,6 +60,17 @@ stays stopped and the error surfaces. Fix the underlying issue and re-run
 
 > **Note:** `daemon refresh` assumes a prior `daemon install` has already been run and recorded your `--extra` choice in the stamp file. If this is your first time setting up the daemon, run `daemon install --extra <x>` (e.g., `--extra cu130`) first — otherwise `refresh` will install with no extras (CPU-only torch).
 
+> **Live agent sessions must be restarted after a bounce.** `daemon refresh`
+> (and `install`/`start`/`stop`, and any crash) restarts the daemon process.
+> A new daemon process has no memory of prior MCP session IDs, so any
+> **already-running** Claude Code agent session (Pepper, testbot) is orphaned:
+> its tool calls fail with `Session not found`, and neither retrying nor
+> `/mcp reconnect` recovers it — only a full restart of that agent's Claude
+> Code session re-initializes the MCP connection. Agent work product is on
+> disk (vault/memory), independent of the bus, so nothing is lost — but plan
+> to restart any live agent session after a `daemon refresh`. Tracked in
+> [#91](https://github.com/jeffrichley/agent_core/issues/91).
+
 ## Why this exists
 
 Before this change, the daemon ran from `<workspace>/.venv/Scripts/python.exe`
@@ -95,6 +106,7 @@ fresh.
 ## Related
 
 - [#79](https://github.com/jeffrichley/agent_core/issues/79) — the issue that motivated this.
+- [#91](https://github.com/jeffrichley/agent_core/issues/91) — daemon bounce orphans live agent MCP sessions (restart agents after `refresh`).
 - `docs/superpowers/specs/2026-05-15-daemon-venv-isolation-design.md` — the design.
 - `agent_core.daemon.cli` — supervisor code.
 - `agent_core.daemon.install` — install orchestration.

--- a/docs/setup/daemon.md
+++ b/docs/setup/daemon.md
@@ -58,6 +58,8 @@ If `daemon install` fails (uv error, missing workspace, etc.), the daemon
 stays stopped and the error surfaces. Fix the underlying issue and re-run
 `daemon refresh`.
 
+> **Note:** `daemon refresh` assumes a prior `daemon install` has already been run and recorded your `--extra` choice in the stamp file. If this is your first time setting up the daemon, run `daemon install --extra <x>` (e.g., `--extra cu130`) first — otherwise `refresh` will install with no extras (CPU-only torch).
+
 ## Why this exists
 
 Before this change, the daemon ran from `<workspace>/.venv/Scripts/python.exe`

--- a/docs/setup/daemon.md
+++ b/docs/setup/daemon.md
@@ -1,0 +1,98 @@
+# Daemon setup and refresh workflow
+
+The agent-core bus daemon supervises every endpoint (bus, Discord adapters,
+scheduler, briefs, webcam, voice). To keep it stable while you iterate on
+workspace code, the daemon runs from its **own** venv at
+`~/.agent-core/.venv/` — not from the workspace's `.venv/`. This isolates
+the daemon process from `uv sync` activity in the workspace.
+
+## One-time setup
+
+```bash
+# Stop any running daemon first.
+agent-core daemon stop
+
+# Populate ~/.agent-core/.venv/ from the workspace.
+# --extra cu130 picks the CUDA torch wheels for GPU voice synthesis.
+# Use --extra cpu on machines without a GPU, or omit on machines that
+# don't run the voice endpoint.
+agent-core daemon install --extra cu130
+
+# Start the daemon — it now runs from ~/.agent-core/.venv/.
+agent-core daemon start
+
+# Verify.
+agent-core daemon status
+```
+
+`daemon status` should show:
+
+```
+daemon is running (PID: NNNNN)
+running from: ~/.agent-core/.venv/Scripts/python.exe   (or bin/python on POSIX)
+installed at: <timestamp>
+installed sha: <git short hash>
+```
+
+If you see `(fallback — vulnerable to uv sync; run \`agent-core daemon install\`)`
+next to `running from`, the daemon venv is missing and the supervisor fell
+back to the workspace venv. Run `daemon install` and `daemon refresh`.
+
+## Daily flow: picking up new code
+
+When you've made changes to agent-core (or pulled new code) and want the
+daemon to run them:
+
+```bash
+agent-core daemon refresh
+```
+
+This does three things in order:
+1. `daemon stop` — kills the running daemon.
+2. `daemon install` — re-runs `uv sync --frozen --no-editable --no-dev` against
+   the workspace. Uses the extra you specified at install time (stamped in
+   `~/.agent-core/.daemon-install-stamp.json`).
+3. `daemon start` — relaunches the daemon from the refreshed venv.
+
+If `daemon install` fails (uv error, missing workspace, etc.), the daemon
+stays stopped and the error surfaces. Fix the underlying issue and re-run
+`daemon refresh`.
+
+## Why this exists
+
+Before this change, the daemon ran from `<workspace>/.venv/Scripts/python.exe`
+(Windows) or `<workspace>/.venv/bin/python` (POSIX). On Windows, `uv sync`
+uses unlink-then-relink semantics that disrupt running processes holding open
+files in `.venv/`. Adding a workspace member re-resolved the lockfile and
+rewrote every package's editable `.pth` file, silently killing the running
+daemon. Pepper went offline mid-session on 2026-05-10 from exactly this.
+
+The fix: install the daemon non-editable, into a venv outside the workspace
+tree. `uv sync` cannot reach it because there are no `.pth` files pointing
+at workspace source.
+
+## Disk cost
+
+The full workspace install with `--extra cu130` is ~6–7 GB (mostly torch
+CUDA wheels). One-time. `daemon refresh` is a delta operation on the lockfile
+diff; usually fast.
+
+To reclaim the space, `rm -rf ~/.agent-core/.venv` then `daemon install`
+fresh.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `daemon is currently running` on install | Daemon supervises something | `daemon refresh` |
+| `couldn't find workspace root` | Running `install` outside the repo | `cd` into the agent-core repo |
+| `uv not found on PATH` | uv not installed | https://docs.astral.sh/uv/getting-started/installation/ |
+| `daemon venv may be stale` | `uv.lock` moved since last install | `daemon refresh` |
+| `fallback — vulnerable to uv sync` | `~/.agent-core/.venv/` not present | `daemon install` |
+
+## Related
+
+- [#79](https://github.com/jeffrichley/agent_core/issues/79) — the issue that motivated this.
+- `docs/superpowers/specs/2026-05-15-daemon-venv-isolation-design.md` — the design.
+- `agent_core.daemon.cli` — supervisor code.
+- `agent_core.daemon.install` — install orchestration.

--- a/docs/superpowers/plans/2026-05-15-daemon-venv-isolation.md
+++ b/docs/superpowers/plans/2026-05-15-daemon-venv-isolation.md
@@ -1,0 +1,1724 @@
+# Daemon ↔ Workspace Venv Isolation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Isolate the bus daemon's Python runtime from the workspace's `.venv/` so `uv sync` in the workspace cannot disrupt a running Pepper or testbot.
+
+**Architecture:** Daemon runs from `~/.agent-core/.venv/`, a non-editable, lockfile-frozen venv populated by `agent-core daemon install`. The supervisor prefers that interpreter and falls back to `sys.executable` when it's absent (today's behavior). A new `daemon refresh` bundles stop/install/start for daily code-pickup.
+
+**Tech Stack:** Python 3.12, Typer (CLI), `uv` (venv + dependency manager), `subprocess` (uv invocation), `psutil` (existing PID-liveness via `daemon.supervisor`), pytest + `typer.testing.CliRunner`.
+
+**Spec:** `docs/superpowers/specs/2026-05-15-daemon-venv-isolation-design.md`
+**Issue:** [#79](https://github.com/jeffrichley/agent_core/issues/79)
+**Branch:** `feat/issue-79-daemon-venv-spec` (spec already committed; implementation lands on this same branch).
+
+---
+
+## Task 1: Add `_daemon_python()` helper, thread through `daemon start`
+
+**Files:**
+- Modify: `packages/core/src/agent_core/daemon/cli.py`
+- Test:   `packages/core/tests/test_daemon_cli.py`
+
+This task introduces the interpreter-resolution helper and uses it in `start()`. Without a daemon venv on disk, behavior is identical to today (fallback path). All later tasks depend on this helper existing.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the end of `packages/core/tests/test_daemon_cli.py`:
+
+```python
+from agent_core.daemon.cli import _daemon_python
+
+
+def test_daemon_python_returns_sys_executable_when_venv_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    # No ~/.agent-core/.venv/ exists in tmp_path.
+    import sys
+
+    assert _daemon_python() == sys.executable
+
+
+def test_daemon_python_returns_daemon_venv_python_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    import sys
+
+    if sys.platform == "win32":
+        venv_python = tmp_path / ".venv" / "Scripts" / "python.exe"
+    else:
+        venv_python = tmp_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("# placeholder")
+
+    assert _daemon_python() == str(venv_python)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pytest packages/core/tests/test_daemon_cli.py::test_daemon_python_returns_sys_executable_when_venv_missing packages/core/tests/test_daemon_cli.py::test_daemon_python_returns_daemon_venv_python_when_present -v
+```
+
+Expected: FAIL with `ImportError` (cannot import name `_daemon_python` from `agent_core.daemon.cli`).
+
+- [ ] **Step 3: Add the helper to `cli.py`**
+
+In `packages/core/src/agent_core/daemon/cli.py`, after the existing `_log_path()` function, add:
+
+```python
+def _daemon_python() -> str:
+    """Return the daemon's preferred interpreter, with fallback.
+
+    Prefers `~/.agent-core/.venv/Scripts/python.exe` (Windows) or
+    `~/.agent-core/.venv/bin/python` (POSIX) when present; falls back
+    to `sys.executable` (today's behavior) when the daemon venv is
+    missing. This keeps the supervisor working unchanged on machines
+    that haven't run `agent-core daemon install` yet.
+    """
+    if sys.platform == "win32":
+        candidate = _home() / ".venv" / "Scripts" / "python.exe"
+    else:
+        candidate = _home() / ".venv" / "bin" / "python"
+    return str(candidate) if candidate.exists() else sys.executable
+```
+
+Then in `start()` (around line 73), change:
+
+```python
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "agent_core.cli", "bus", "run", "--config", str(cfg)],
+```
+
+to:
+
+```python
+    proc = subprocess.Popen(
+        [_daemon_python(), "-m", "agent_core.cli", "bus", "run", "--config", str(cfg)],
+```
+
+- [ ] **Step 4: Run the two new tests + existing daemon CLI tests**
+
+```
+pytest packages/core/tests/test_daemon_cli.py -v
+```
+
+Expected: PASS for the two new tests AND all 5 existing tests (including the e2e `test_start_writes_pid_file_and_stop_kills`, which still works because `_daemon_python()` falls back to `sys.executable` in the tmp_path that has no daemon venv).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agent_core/daemon/cli.py packages/core/tests/test_daemon_cli.py
+git commit -m "feat(daemon): _daemon_python() helper with sys.executable fallback (#79)"
+```
+
+---
+
+## Task 2: Workspace root discovery in `install.py`
+
+**Files:**
+- Create: `packages/core/src/agent_core/daemon/install.py`
+- Create: `packages/core/tests/test_daemon_install.py`
+
+Pure function that locates the workspace root by ascending from a starting path until it finds a `pyproject.toml` containing `[tool.uv.workspace]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/core/tests/test_daemon_install.py`:
+
+```python
+"""Unit tests for `agent_core.daemon.install`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_core.daemon.install import WorkspaceNotFoundError, find_workspace_root
+
+
+def test_find_workspace_root_walks_up_to_pyproject(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "pyproject.toml").write_text(
+        "[tool.uv.workspace]\nmembers = [\"packages/*\"]\n",
+        encoding="utf-8",
+    )
+    deep = workspace / "packages" / "core" / "src" / "agent_core"
+    deep.mkdir(parents=True)
+
+    assert find_workspace_root(deep) == workspace
+
+
+def test_find_workspace_root_ignores_non_workspace_pyproject(tmp_path: Path) -> None:
+    """A pyproject.toml without [tool.uv.workspace] is not a workspace root."""
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    (inner / "pyproject.toml").write_text("[project]\nname = \"x\"\n", encoding="utf-8")
+
+    outer = tmp_path
+    (outer / "pyproject.toml").write_text(
+        "[tool.uv.workspace]\nmembers = [\"inner\"]\n",
+        encoding="utf-8",
+    )
+
+    assert find_workspace_root(inner) == outer
+
+
+def test_find_workspace_root_raises_when_absent(tmp_path: Path) -> None:
+    with pytest.raises(WorkspaceNotFoundError, match="workspace"):
+        find_workspace_root(tmp_path)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pytest packages/core/tests/test_daemon_install.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'agent_core.daemon.install'`.
+
+- [ ] **Step 3: Create `install.py` with the helper**
+
+Create `packages/core/src/agent_core/daemon/install.py`:
+
+```python
+"""Daemon venv install logic — pure functions, no I/O beyond filesystem.
+
+`cli.py` wires these into the `agent-core daemon install` and
+`agent-core daemon refresh` typer commands. Keeping the install logic
+out of the CLI module makes it directly unit-testable.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+class WorkspaceNotFoundError(RuntimeError):
+    """Raised when find_workspace_root cannot locate a workspace pyproject.toml."""
+
+
+def find_workspace_root(start: Path) -> Path:
+    """Ascend from `start` until a `pyproject.toml` with `[tool.uv.workspace]` is found.
+
+    The agent-core repo's root `pyproject.toml` declares the workspace; we
+    use that as the install target.
+    """
+    candidate = start.resolve()
+    while True:
+        pyproject = candidate / "pyproject.toml"
+        if pyproject.exists():
+            try:
+                data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+            except tomllib.TOMLDecodeError:
+                data = {}
+            if "workspace" in data.get("tool", {}).get("uv", {}):
+                return candidate
+        parent = candidate.parent
+        if parent == candidate:
+            raise WorkspaceNotFoundError(
+                f"couldn't find workspace root above {start} "
+                "(no pyproject.toml with [tool.uv.workspace] found). "
+                "Run `agent-core daemon install` from within the agent-core repo."
+            )
+        candidate = parent
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+pytest packages/core/tests/test_daemon_install.py -v
+```
+
+Expected: PASS (all 3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agent_core/daemon/install.py packages/core/tests/test_daemon_install.py
+git commit -m "feat(daemon): workspace root discovery for install command (#79)"
+```
+
+---
+
+## Task 3: Install stamp file I/O
+
+**Files:**
+- Modify: `packages/core/src/agent_core/daemon/install.py`
+- Modify: `packages/core/tests/test_daemon_install.py`
+
+The stamp file at `~/.agent-core/.daemon-install-stamp.json` records install metadata: timestamp, git sha, python version, extra, lockfile hash.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/core/tests/test_daemon_install.py`:
+
+```python
+from agent_core.daemon.install import (
+    STAMP_FILENAME,
+    InstallStamp,
+    read_stamp,
+    write_stamp,
+)
+
+
+def test_write_then_read_stamp_round_trips(tmp_path: Path) -> None:
+    stamp = InstallStamp(
+        installed_at="2026-05-15T19:31:04Z",
+        installed_sha="42713d7",
+        python_version="3.12.5",
+        extra="cu130",
+        uv_lock_hash="sha256:abc",
+    )
+    write_stamp(tmp_path, stamp)
+
+    assert (tmp_path / STAMP_FILENAME).exists()
+    assert read_stamp(tmp_path) == stamp
+
+
+def test_read_stamp_returns_none_when_missing(tmp_path: Path) -> None:
+    assert read_stamp(tmp_path) is None
+
+
+def test_read_stamp_returns_none_when_corrupt(tmp_path: Path) -> None:
+    (tmp_path / STAMP_FILENAME).write_text("not json", encoding="utf-8")
+    assert read_stamp(tmp_path) is None
+
+
+def test_read_stamp_returns_none_when_missing_fields(tmp_path: Path) -> None:
+    (tmp_path / STAMP_FILENAME).write_text(
+        '{"installed_at": "2026-05-15T19:31:04Z"}', encoding="utf-8"
+    )
+    assert read_stamp(tmp_path) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pytest packages/core/tests/test_daemon_install.py -v
+```
+
+Expected: FAIL with `ImportError` on `STAMP_FILENAME`/`InstallStamp`/`read_stamp`/`write_stamp`.
+
+- [ ] **Step 3: Add stamp logic to `install.py`**
+
+Append to `packages/core/src/agent_core/daemon/install.py`:
+
+```python
+import json
+from dataclasses import asdict, dataclass
+
+STAMP_FILENAME = ".daemon-install-stamp.json"
+
+
+@dataclass(frozen=True)
+class InstallStamp:
+    """Captures what was installed into the daemon venv, when, and from where."""
+
+    installed_at: str  # ISO 8601 UTC
+    installed_sha: str  # git rev-parse HEAD at install time
+    python_version: str  # e.g., "3.12.5"
+    extra: str | None  # uv extra name, or None
+    uv_lock_hash: str  # sha256 of uv.lock at install time
+
+
+def write_stamp(home: Path, stamp: InstallStamp) -> None:
+    """Write the install stamp to <home>/.daemon-install-stamp.json."""
+    home.mkdir(parents=True, exist_ok=True)
+    (home / STAMP_FILENAME).write_text(
+        json.dumps(asdict(stamp), indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_stamp(home: Path) -> InstallStamp | None:
+    """Read the install stamp. None on missing, corrupt, or schema-incomplete."""
+    path = home / STAMP_FILENAME
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    try:
+        return InstallStamp(
+            installed_at=data["installed_at"],
+            installed_sha=data["installed_sha"],
+            python_version=data["python_version"],
+            extra=data.get("extra"),
+            uv_lock_hash=data["uv_lock_hash"],
+        )
+    except (KeyError, TypeError):
+        return None
+```
+
+Move the `import json` to the top of the file with the other imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+pytest packages/core/tests/test_daemon_install.py -v
+```
+
+Expected: PASS (7 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agent_core/daemon/install.py packages/core/tests/test_daemon_install.py
+git commit -m "feat(daemon): install stamp file read/write (#79)"
+```
+
+---
+
+## Task 4: uv-command builder
+
+**Files:**
+- Modify: `packages/core/src/agent_core/daemon/install.py`
+- Modify: `packages/core/tests/test_daemon_install.py`
+
+Pure function that returns the `uv sync` command and environment dict. Testable without running uv.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/core/tests/test_daemon_install.py`:
+
+```python
+from agent_core.daemon.install import build_uv_sync_command
+
+
+def test_build_uv_sync_command_basic(tmp_path: Path) -> None:
+    venv = tmp_path / ".venv"
+    cmd, env_overrides = build_uv_sync_command(venv=venv, extra=None)
+    assert cmd == ["uv", "sync", "--frozen", "--no-editable", "--no-dev"]
+    assert env_overrides == {"UV_PROJECT_ENVIRONMENT": str(venv)}
+
+
+def test_build_uv_sync_command_with_extra(tmp_path: Path) -> None:
+    venv = tmp_path / ".venv"
+    cmd, env_overrides = build_uv_sync_command(venv=venv, extra="cu130")
+    assert cmd == [
+        "uv",
+        "sync",
+        "--frozen",
+        "--no-editable",
+        "--no-dev",
+        "--extra",
+        "cu130",
+    ]
+    assert env_overrides == {"UV_PROJECT_ENVIRONMENT": str(venv)}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pytest packages/core/tests/test_daemon_install.py::test_build_uv_sync_command_basic packages/core/tests/test_daemon_install.py::test_build_uv_sync_command_with_extra -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'build_uv_sync_command'`.
+
+- [ ] **Step 3: Add the builder to `install.py`**
+
+Append to `packages/core/src/agent_core/daemon/install.py`:
+
+```python
+def build_uv_sync_command(
+    *, venv: Path, extra: str | None
+) -> tuple[list[str], dict[str, str]]:
+    """Build the `uv sync` command list and env overrides for daemon install.
+
+    --frozen        → install against the workspace's uv.lock verbatim.
+    --no-editable   → workspace members go in as wheels; no .pth shims.
+                      This is what makes the daemon venv immune to
+                      `uv sync` in the workspace tree.
+    --no-dev        → skip the workspace's dev dependency group.
+    --extra <x>     → optional uv extra (e.g., cu130, cpu).
+
+    UV_PROJECT_ENVIRONMENT redirects uv's install target to the daemon venv
+    instead of the workspace's `.venv/`.
+    """
+    cmd: list[str] = ["uv", "sync", "--frozen", "--no-editable", "--no-dev"]
+    if extra is not None:
+        cmd += ["--extra", extra]
+    env_overrides = {"UV_PROJECT_ENVIRONMENT": str(venv)}
+    return cmd, env_overrides
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+pytest packages/core/tests/test_daemon_install.py -v
+```
+
+Expected: PASS (9 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agent_core/daemon/install.py packages/core/tests/test_daemon_install.py
+git commit -m "feat(daemon): build_uv_sync_command pure builder (#79)"
+```
+
+---
+
+## Task 5: `run_install()` orchestrator
+
+**Files:**
+- Modify: `packages/core/src/agent_core/daemon/install.py`
+- Modify: `packages/core/tests/test_daemon_install.py`
+
+Composes Tasks 2–4 into the actual install: runs `uv venv`, runs `uv sync`, writes the stamp file. Subprocess mocked in tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/core/tests/test_daemon_install.py`:
+
+```python
+import hashlib
+import subprocess
+import sys
+from unittest.mock import MagicMock
+
+from agent_core.daemon.install import UvNotFoundError, run_install
+
+
+def _make_workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "pyproject.toml").write_text(
+        "[tool.uv.workspace]\nmembers = [\"packages/*\"]\n", encoding="utf-8"
+    )
+    (workspace / "uv.lock").write_text("# fake lock\n", encoding="utf-8")
+    return workspace
+
+
+def test_run_install_invokes_uv_venv_then_uv_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _make_workspace(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        result = MagicMock()
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr("agent_core.daemon.install.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "agent_core.daemon.install._git_head_sha", lambda _ws: "abc1234"
+    )
+
+    run_install(home=home, workspace=workspace, extra="cu130", python_version="3.12")
+
+    # First call: uv venv ... --python 3.12
+    assert calls[0][:2] == ["uv", "venv"]
+    assert "--python" in calls[0]
+    assert "3.12" in calls[0]
+    # Second call: uv sync --frozen --no-editable --no-dev --extra cu130
+    assert calls[1] == [
+        "uv",
+        "sync",
+        "--frozen",
+        "--no-editable",
+        "--no-dev",
+        "--extra",
+        "cu130",
+    ]
+
+
+def test_run_install_writes_stamp_with_lock_hash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _make_workspace(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    monkeypatch.setattr(
+        "agent_core.daemon.install.subprocess.run",
+        lambda cmd, **kwargs: MagicMock(returncode=0),
+    )
+    monkeypatch.setattr(
+        "agent_core.daemon.install._git_head_sha", lambda _ws: "abc1234"
+    )
+
+    run_install(home=home, workspace=workspace, extra=None, python_version="3.12")
+
+    stamp = read_stamp(home)
+    assert stamp is not None
+    assert stamp.installed_sha == "abc1234"
+    assert stamp.extra is None
+    # uv_lock_hash matches sha256 of the lock file content
+    expected_hash = (
+        "sha256:"
+        + hashlib.sha256((workspace / "uv.lock").read_bytes()).hexdigest()
+    )
+    assert stamp.uv_lock_hash == expected_hash
+
+
+def test_run_install_raises_uv_not_found_on_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _make_workspace(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "uv")
+
+    monkeypatch.setattr("agent_core.daemon.install.subprocess.run", fake_run)
+
+    with pytest.raises(UvNotFoundError, match="uv not found on PATH"):
+        run_install(home=home, workspace=workspace, extra=None, python_version="3.12")
+
+
+def test_run_install_raises_on_uv_sync_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _make_workspace(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    def fake_run(cmd, **kwargs):
+        # `uv venv` succeeds, `uv sync` fails.
+        if cmd[:2] == ["uv", "sync"]:
+            return MagicMock(returncode=1, stderr="resolution error")
+        return MagicMock(returncode=0)
+
+    monkeypatch.setattr("agent_core.daemon.install.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "agent_core.daemon.install._git_head_sha", lambda _ws: "abc1234"
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        run_install(home=home, workspace=workspace, extra=None, python_version="3.12")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pytest packages/core/tests/test_daemon_install.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'run_install'` / `UvNotFoundError`.
+
+- [ ] **Step 3: Add `run_install()` and helpers**
+
+Append to `packages/core/src/agent_core/daemon/install.py`:
+
+```python
+import hashlib
+import subprocess
+import sys
+from datetime import datetime, timezone
+import os
+
+
+class UvNotFoundError(RuntimeError):
+    """Raised when `uv` is not on PATH."""
+
+
+def _git_head_sha(workspace: Path) -> str:
+    """Return the short HEAD sha of the workspace repo, or 'unknown'."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, FileNotFoundError):
+        return "unknown"
+    if result.returncode != 0:
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def compute_lock_hash(workspace: Path) -> str:
+    """SHA-256 of the workspace's uv.lock, prefixed with `sha256:`. Public:
+    `cli.py`'s `daemon status` reuses this for the lock-drift check.
+    """
+    lock = workspace / "uv.lock"
+    digest = hashlib.sha256(lock.read_bytes()).hexdigest()
+    return f"sha256:{digest}"
+
+
+def run_install(
+    *,
+    home: Path,
+    workspace: Path,
+    extra: str | None,
+    python_version: str,
+) -> InstallStamp:
+    """Populate `<home>/.venv/` and write the install stamp. Idempotent."""
+    venv = home / ".venv"
+
+    # Step 1: create / refresh the venv with the pinned Python.
+    venv_cmd = ["uv", "venv", str(venv), "--python", python_version]
+    try:
+        result = subprocess.run(venv_cmd, capture_output=True, text=True, check=False)
+    except FileNotFoundError as exc:
+        raise UvNotFoundError(
+            "uv not found on PATH — install uv first: "
+            "https://docs.astral.sh/uv/getting-started/installation/"
+        ) from exc
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, venv_cmd, output=result.stdout, stderr=result.stderr
+        )
+
+    # Step 2: uv sync into that venv.
+    sync_cmd, env_overrides = build_uv_sync_command(venv=venv, extra=extra)
+    env = {**os.environ, **env_overrides}
+    sync_result = subprocess.run(
+        sync_cmd, cwd=workspace, env=env, capture_output=True, text=True, check=False
+    )
+    if sync_result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            sync_result.returncode,
+            sync_cmd,
+            output=sync_result.stdout,
+            stderr=sync_result.stderr,
+        )
+
+    # Step 3: stamp it.
+    stamp = InstallStamp(
+        installed_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        installed_sha=_git_head_sha(workspace),
+        python_version=python_version,
+        extra=extra,
+        uv_lock_hash=compute_lock_hash(workspace),
+    )
+    write_stamp(home, stamp)
+    return stamp
+```
+
+Make sure the file's top-level imports block contains everything used so far. The final import block in `install.py` after this task should be:
+
+```python
+import hashlib
+import json
+import os
+import subprocess
+import tomllib
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+pytest packages/core/tests/test_daemon_install.py -v
+```
+
+Expected: PASS (13 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agent_core/daemon/install.py packages/core/tests/test_daemon_install.py
+git commit -m "feat(daemon): run_install orchestrator (uv venv + uv sync + stamp) (#79)"
+```
+
+---
+
+## Task 6: `daemon install` CLI command
+
+**Files:**
+- Modify: `packages/core/src/agent_core/daemon/cli.py`
+- Modify: `packages/core/tests/test_daemon_cli.py`
+
+Typer command that parses args, refuses while the daemon is running, discovers the workspace, and calls `run_install()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/core/tests/test_daemon_cli.py`:
+
+```python
+from unittest.mock import MagicMock
+
+
+def test_install_refuses_when_daemon_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    pid_file = tmp_path / "daemon.pid"
+    pid_file.write_text(str(os.getpid()))  # current process is alive
+    result = runner.invoke(daemon_app, ["install"])
+    assert result.exit_code == 1
+    assert "currently running" in result.stdout.lower()
+    assert "refresh" in result.stdout.lower()
+
+
+def test_install_invokes_run_install_with_args(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    captured: dict = {}
+
+    fake_stamp = MagicMock(
+        installed_sha="abc1234",
+        extra="cu130",
+        python_version="3.12",
+        installed_at="2026-05-15T19:31:04Z",
+    )
+
+    def fake_run_install(*, home, workspace, extra, python_version):
+        captured["home"] = home
+        captured["workspace"] = workspace
+        captured["extra"] = extra
+        captured["python_version"] = python_version
+        return fake_stamp
+
+    monkeypatch.setattr("agent_core.daemon.cli.run_install", fake_run_install)
+    monkeypatch.setattr(
+        "agent_core.daemon.cli.find_workspace_root",
+        lambda _start: tmp_path / "fake-workspace",
+    )
+
+    result = runner.invoke(daemon_app, ["install", "--extra", "cu130"])
+    assert result.exit_code == 0, result.stdout
+    assert captured["home"] == tmp_path
+    assert captured["workspace"] == tmp_path / "fake-workspace"
+    assert captured["extra"] == "cu130"
+    assert captured["python_version"] == "3.12"
+    assert "abc1234" in result.stdout  # stamp sha echoed
+
+
+def test_install_reports_workspace_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+
+    def raise_not_found(_start):
+        from agent_core.daemon.install import WorkspaceNotFoundError
+
+        raise WorkspaceNotFoundError("can't find workspace")
+
+    monkeypatch.setattr("agent_core.daemon.cli.find_workspace_root", raise_not_found)
+
+    result = runner.invoke(daemon_app, ["install"])
+    assert result.exit_code == 1
+    assert "workspace" in result.stdout.lower()
+
+
+def test_install_reports_uv_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+
+    def fake_run_install(*, home, workspace, extra, python_version):
+        from agent_core.daemon.install import UvNotFoundError
+
+        raise UvNotFoundError("uv not found on PATH")
+
+    monkeypatch.setattr("agent_core.daemon.cli.run_install", fake_run_install)
+    monkeypatch.setattr(
+        "agent_core.daemon.cli.find_workspace_root",
+        lambda _start: tmp_path / "fake-workspace",
+    )
+
+    result = runner.invoke(daemon_app, ["install"])
+    assert result.exit_code == 1
+    assert "uv not found" in result.stdout.lower()
+```
+
+Add `import os` at the top of the test file if not already imported.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pytest packages/core/tests/test_daemon_cli.py -v
+```
+
+Expected: FAIL — `install` subcommand doesn't exist yet.
+
+- [ ] **Step 3: Add the `install` command to `cli.py`**
+
+In `packages/core/src/agent_core/daemon/cli.py`, add at the top of the file (with existing imports):
+
+```python
+from agent_core.daemon.install import (
+    UvNotFoundError,
+    WorkspaceNotFoundError,
+    find_workspace_root,
+    run_install,
+)
+```
+
+Then add this command after the existing `status()` command:
+
+```python
+@app.command()
+def install(
+    extra: str | None = typer.Option(
+        None, "--extra", help="uv extra to install (e.g., cu130, cpu)."
+    ),
+    python_version: str = typer.Option(
+        "3.12", "--python", help="Python version to pin the daemon venv to."
+    ),
+) -> None:
+    """Populate ~/.agent-core/.venv/ from the workspace (non-editable, frozen)."""
+    pid_file = _pid_path()
+    existing = read_pid(pid_file)
+    if existing is not None and is_alive(existing):
+        console.print(
+            f"[red]daemon is currently running (PID {existing}).[/red]\n"
+            "   • Run [bold]agent-core daemon stop[/bold] and re-run install, or\n"
+            "   • Run [bold]agent-core daemon refresh[/bold] to stop/install/start in one step."
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        workspace = find_workspace_root(Path(__file__).parent)
+    except WorkspaceNotFoundError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    home = _home()
+    home.mkdir(parents=True, exist_ok=True)
+
+    try:
+        stamp = run_install(
+            home=home,
+            workspace=workspace,
+            extra=extra,
+            python_version=python_version,
+        )
+    except UvNotFoundError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    console.print(
+        f"[green]daemon venv installed[/green] "
+        f"(sha {stamp.installed_sha}, python {stamp.python_version}"
+        + (f", extra {stamp.extra}" if stamp.extra else "")
+        + f", at {stamp.installed_at})"
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+pytest packages/core/tests/test_daemon_cli.py -v
+```
+
+Expected: PASS (4 new tests + 7 existing tests = 11 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agent_core/daemon/cli.py packages/core/tests/test_daemon_cli.py
+git commit -m "feat(daemon): daemon install CLI command (#79)"
+```
+
+---
+
+## Task 7: `daemon refresh` CLI command
+
+**Files:**
+- Modify: `packages/core/src/agent_core/daemon/cli.py`
+- Modify: `packages/core/tests/test_daemon_cli.py`
+
+Bundles stop → install → start. If install fails, start is not called.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/core/tests/test_daemon_cli.py`:
+
+```python
+def test_refresh_calls_stop_install_start_in_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    order: list[str] = []
+
+    def fake_stop() -> None:
+        order.append("stop")
+
+    def fake_install(extra: str | None = None, python_version: str = "3.12") -> None:
+        order.append(f"install:extra={extra}")
+
+    def fake_start() -> None:
+        order.append("start")
+
+    monkeypatch.setattr("agent_core.daemon.cli.stop", fake_stop)
+    monkeypatch.setattr("agent_core.daemon.cli.install", fake_install)
+    monkeypatch.setattr("agent_core.daemon.cli.start", fake_start)
+
+    result = runner.invoke(daemon_app, ["refresh", "--extra", "cu130"])
+    assert result.exit_code == 0, result.stdout
+    assert order == ["stop", "install:extra=cu130", "start"]
+
+
+def test_refresh_aborts_start_when_install_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    order: list[str] = []
+
+    def fake_stop() -> None:
+        order.append("stop")
+
+    def fake_install(extra: str | None = None, python_version: str = "3.12") -> None:
+        order.append("install")
+        raise typer.Exit(code=1)
+
+    def fake_start() -> None:
+        order.append("start")  # must not be called
+
+    monkeypatch.setattr("agent_core.daemon.cli.stop", fake_stop)
+    monkeypatch.setattr("agent_core.daemon.cli.install", fake_install)
+    monkeypatch.setattr("agent_core.daemon.cli.start", fake_start)
+
+    result = runner.invoke(daemon_app, ["refresh"])
+    assert result.exit_code != 0
+    assert "start" not in order
+    assert order == ["stop", "install"]
+
+
+def test_refresh_reuses_stamped_extra_when_no_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When --extra is omitted, refresh passes the stamped extra to install."""
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    # Write a stamp with extra='cu130'
+    from agent_core.daemon.install import InstallStamp, write_stamp
+
+    write_stamp(
+        tmp_path,
+        InstallStamp(
+            installed_at="2026-05-15T19:31:04Z",
+            installed_sha="abc1234",
+            python_version="3.12",
+            extra="cu130",
+            uv_lock_hash="sha256:abc",
+        ),
+    )
+
+    captured: dict = {}
+
+    def fake_install(extra: str | None = None, python_version: str = "3.12") -> None:
+        captured["extra"] = extra
+
+    monkeypatch.setattr("agent_core.daemon.cli.stop", lambda: None)
+    monkeypatch.setattr("agent_core.daemon.cli.install", fake_install)
+    monkeypatch.setattr("agent_core.daemon.cli.start", lambda: None)
+
+    result = runner.invoke(daemon_app, ["refresh"])
+    assert result.exit_code == 0
+    assert captured["extra"] == "cu130"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pytest packages/core/tests/test_daemon_cli.py -v
+```
+
+Expected: FAIL — `refresh` subcommand doesn't exist yet.
+
+- [ ] **Step 3: Add `refresh` to `cli.py`**
+
+Add the import near the top with the other install imports:
+
+```python
+from agent_core.daemon.install import (
+    UvNotFoundError,
+    WorkspaceNotFoundError,
+    find_workspace_root,
+    read_stamp,         # <-- new
+    run_install,
+)
+```
+
+Add this command at the end of `cli.py`:
+
+```python
+@app.command()
+def refresh(
+    extra: str | None = typer.Option(
+        None,
+        "--extra",
+        help="uv extra to install. Defaults to the stamped extra from the last install.",
+    ),
+    python_version: str = typer.Option(
+        "3.12", "--python", help="Python version to pin the daemon venv to."
+    ),
+) -> None:
+    """Stop daemon → reinstall daemon venv → start daemon. Bundled lifecycle."""
+    if extra is None:
+        stamp = read_stamp(_home())
+        if stamp is not None:
+            extra = stamp.extra
+
+    stop()
+    install(extra=extra, python_version=python_version)
+    start()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+pytest packages/core/tests/test_daemon_cli.py -v
+```
+
+Expected: PASS (3 new + 11 existing = 14 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agent_core/daemon/cli.py packages/core/tests/test_daemon_cli.py
+git commit -m "feat(daemon): daemon refresh CLI command (#79)"
+```
+
+---
+
+## Task 8: `daemon status` diagnostics
+
+**Files:**
+- Modify: `packages/core/src/agent_core/daemon/cli.py`
+- Modify: `packages/core/tests/test_daemon_cli.py`
+
+Adds three lines to `daemon status`: running-from interpreter, stamp metadata, lock-drift warning.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/core/tests/test_daemon_cli.py`:
+
+```python
+def test_status_shows_fallback_warning_when_no_daemon_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When _daemon_python falls back to sys.executable, status warns."""
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    # Daemon is "running" — write a PID for the current process so is_alive=True
+    (tmp_path / "daemon.pid").write_text(str(os.getpid()))
+
+    result = runner.invoke(daemon_app, ["status"])
+    assert result.exit_code == 0
+    assert "fallback" in result.stdout.lower()
+    assert "vulnerable to uv sync" in result.stdout.lower()
+
+
+def test_status_no_warning_when_daemon_venv_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    (tmp_path / "daemon.pid").write_text(str(os.getpid()))
+
+    if sys.platform == "win32":
+        venv_python = tmp_path / ".venv" / "Scripts" / "python.exe"
+    else:
+        venv_python = tmp_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("# placeholder")
+
+    result = runner.invoke(daemon_app, ["status"])
+    assert result.exit_code == 0
+    assert "fallback" not in result.stdout.lower()
+
+
+def test_status_shows_stamp_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from agent_core.daemon.install import InstallStamp, write_stamp
+
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    (tmp_path / "daemon.pid").write_text(str(os.getpid()))
+    write_stamp(
+        tmp_path,
+        InstallStamp(
+            installed_at="2026-05-15T19:31:04Z",
+            installed_sha="abc1234",
+            python_version="3.12",
+            extra="cu130",
+            uv_lock_hash="sha256:deadbeef",
+        ),
+    )
+
+    result = runner.invoke(daemon_app, ["status"])
+    assert "abc1234" in result.stdout
+    assert "2026-05-15" in result.stdout
+
+
+def test_status_flags_lock_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from agent_core.daemon.install import InstallStamp, write_stamp
+
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    (tmp_path / "daemon.pid").write_text(str(os.getpid()))
+    # Stamp says the lock was hash "stale-hash"; workspace lock has different content.
+    write_stamp(
+        tmp_path,
+        InstallStamp(
+            installed_at="2026-05-15T19:31:04Z",
+            installed_sha="abc1234",
+            python_version="3.12",
+            extra=None,
+            uv_lock_hash="sha256:STALE",
+        ),
+    )
+
+    # Fake workspace with a uv.lock whose hash is different.
+    fake_ws = tmp_path / "fake-workspace"
+    fake_ws.mkdir()
+    (fake_ws / "uv.lock").write_text("# new content\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "agent_core.daemon.cli.find_workspace_root", lambda _start: fake_ws
+    )
+
+    result = runner.invoke(daemon_app, ["status"])
+    assert "stale" in result.stdout.lower() or "refresh" in result.stdout.lower()
+
+
+def test_status_handles_missing_workspace_gracefully(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """status must not crash if workspace discovery fails — drift check is optional."""
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    (tmp_path / "daemon.pid").write_text(str(os.getpid()))
+
+    def raise_not_found(_start):
+        from agent_core.daemon.install import WorkspaceNotFoundError
+
+        raise WorkspaceNotFoundError("no workspace")
+
+    monkeypatch.setattr("agent_core.daemon.cli.find_workspace_root", raise_not_found)
+
+    result = runner.invoke(daemon_app, ["status"])
+    assert result.exit_code == 0  # still succeeds
+```
+
+Make sure `import sys` and `import os` are at the top of the test file.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pytest packages/core/tests/test_daemon_cli.py -v
+```
+
+Expected: FAIL — status doesn't have the new diagnostic lines yet.
+
+- [ ] **Step 3: Extend `status()` in `cli.py`**
+
+Replace the existing `status()` command with this version:
+
+```python
+@app.command()
+def status() -> None:
+    """Report daemon liveness and tail the log."""
+    pid_file = _pid_path()
+    log_file = _log_path()
+    pid = read_pid(pid_file)
+
+    if pid is None:
+        console.print("[yellow]daemon is not running[/yellow]")
+        return
+    if not is_alive(pid):
+        console.print("[yellow]daemon is not running (stale PID file removed)[/yellow]")
+        remove_pid(pid_file)
+        return
+
+    console.print(f"[green]daemon is running (PID: {pid})[/green]")
+
+    # Diagnostic: which interpreter the supervisor would use today.
+    daemon_py = _daemon_python()
+    suffix = ""
+    if daemon_py == sys.executable:
+        suffix = (
+            " [dim red](fallback — vulnerable to uv sync; "
+            "run `agent-core daemon install`)[/dim red]"
+        )
+    console.print(f"running from: {daemon_py}{suffix}")
+
+    # Diagnostic: stamp metadata, if present.
+    stamp = read_stamp(_home())
+    if stamp is not None:
+        console.print(f"installed at: {stamp.installed_at}")
+        console.print(f"installed sha: {stamp.installed_sha}")
+
+        # Lock-drift check (best-effort; skipped silently if workspace not findable).
+        try:
+            workspace = find_workspace_root(Path(__file__).parent)
+            current_hash = compute_lock_hash(workspace)
+            if current_hash != stamp.uv_lock_hash:
+                console.print(
+                    "[yellow]daemon venv may be stale — "
+                    "run `agent-core daemon refresh`[/yellow]"
+                )
+        except (WorkspaceNotFoundError, FileNotFoundError):
+            pass  # Lock-drift is a nice-to-have; don't fail status on workspace issues.
+
+    if log_file.exists():
+        console.print("\n[dim]--- last 20 lines of daemon.log ---[/dim]")
+        lines = log_file.read_text(encoding="utf-8", errors="replace").splitlines()
+        for line in lines[-20:]:
+            console.print(line)
+```
+
+Add `compute_lock_hash` to the install import at the top:
+
+```python
+from agent_core.daemon.install import (
+    UvNotFoundError,
+    WorkspaceNotFoundError,
+    compute_lock_hash,
+    find_workspace_root,
+    read_stamp,
+    run_install,
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+pytest packages/core/tests/test_daemon_cli.py -v
+```
+
+Expected: PASS (5 new + 14 existing = 19 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agent_core/daemon/cli.py packages/core/tests/test_daemon_cli.py
+git commit -m "feat(daemon): status diagnostics — fallback warning, stamp display, lock drift (#79)"
+```
+
+---
+
+## Task 9: Integration test against a minimal tmp workspace
+
+**Files:**
+- Create: `packages/core/tests/test_daemon_install_integration.py`
+- Modify: `pyproject.toml` (register `slow` marker)
+
+End-to-end install against a scaled-down tmp workspace. Validates orchestration with a real `uv` invocation but without pulling torch.
+
+- [ ] **Step 1: Register the `slow` pytest marker**
+
+In `pyproject.toml`, find the existing markers list:
+
+```toml
+markers = [
+    "looptime: virtual asyncio clock compaction (looptime plugin; see test docs)",
+]
+```
+
+Change to:
+
+```toml
+markers = [
+    "looptime: virtual asyncio clock compaction (looptime plugin; see test docs)",
+    "slow: tests that hit network or take >5s; skipped by default in CI",
+]
+```
+
+- [ ] **Step 2: Write the integration test**
+
+Create `packages/core/tests/test_daemon_install_integration.py`:
+
+```python
+"""End-to-end install against a minimal tmp workspace. Real uv subprocess.
+
+Skipped by default (slow); run locally with:
+    pytest packages/core/tests/test_daemon_install_integration.py -v -m slow
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from agent_core.daemon.install import read_stamp, run_install
+
+
+pytestmark = pytest.mark.slow
+
+
+def _uv_available() -> bool:
+    return shutil.which("uv") is not None
+
+
+@pytest.mark.skipif(not _uv_available(), reason="uv not on PATH")
+def test_run_install_creates_working_venv_against_minimal_workspace(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    # Minimal workspace pyproject — no torch, no agent-core. Just `iniconfig`
+    # so uv has something real to install.
+    (workspace / "pyproject.toml").write_text(
+        """
+[project]
+name = "fake-ws-root"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = ["iniconfig"]
+
+[tool.uv.workspace]
+members = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+""",
+        encoding="utf-8",
+    )
+    # Generate a lockfile so --frozen has something to install against.
+    lock_result = subprocess.run(
+        ["uv", "lock"], cwd=workspace, capture_output=True, text=True, check=False
+    )
+    assert lock_result.returncode == 0, lock_result.stderr
+
+    home = tmp_path / "agent-core-home"
+    home.mkdir()
+
+    stamp = run_install(
+        home=home,
+        workspace=workspace,
+        extra=None,
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+    )
+
+    # Venv exists and has a Python interpreter.
+    if sys.platform == "win32":
+        py = home / ".venv" / "Scripts" / "python.exe"
+    else:
+        py = home / ".venv" / "bin" / "python"
+    assert py.exists(), f"expected interpreter at {py}"
+
+    # iniconfig was installed.
+    show = subprocess.run(
+        [str(py), "-c", "import iniconfig; print(iniconfig.__name__)"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert show.returncode == 0, show.stderr
+    assert show.stdout.strip() == "iniconfig"
+
+    # Stamp file exists and matches what run_install returned.
+    on_disk = read_stamp(home)
+    assert on_disk == stamp
+
+    # Re-running run_install is idempotent (uv sync no-op).
+    stamp2 = run_install(
+        home=home,
+        workspace=workspace,
+        extra=None,
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+    )
+    # Stamp's installed_at will differ (re-stamped); installed_sha/lock_hash
+    # should match the first call.
+    assert stamp2.uv_lock_hash == stamp.uv_lock_hash
+```
+
+- [ ] **Step 3: Run the test locally**
+
+```
+pytest packages/core/tests/test_daemon_install_integration.py -v -m slow
+```
+
+Expected: PASS in roughly 10–30 seconds (uv installs `iniconfig` into the tmp venv).
+
+- [ ] **Step 4: Verify the test is skipped by default**
+
+```
+pytest packages/core/tests/test_daemon_install_integration.py -v
+```
+
+Expected: 1 test skipped (slow marker, no `-m slow` requested).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml packages/core/tests/test_daemon_install_integration.py
+git commit -m "test(daemon): integration test against minimal tmp workspace (#79)"
+```
+
+---
+
+## Task 10: Operator docs
+
+**Files:**
+- Create: `docs/setup/daemon.md`
+- Modify: `README.md` (one-line pointer)
+
+- [ ] **Step 1: Write `docs/setup/daemon.md`**
+
+Create `docs/setup/daemon.md`:
+
+```markdown
+# Daemon setup and refresh workflow
+
+The agent-core bus daemon supervises every endpoint (bus, Discord adapters,
+scheduler, briefs, webcam, voice). To keep it stable while you iterate on
+workspace code, the daemon runs from its **own** venv at
+`~/.agent-core/.venv/` — not from the workspace's `.venv/`. This isolates
+the daemon process from `uv sync` activity in the workspace.
+
+## One-time setup
+
+```bash
+# Stop any running daemon first.
+agent-core daemon stop
+
+# Populate ~/.agent-core/.venv/ from the workspace.
+# --extra cu130 picks the CUDA torch wheels for GPU voice synthesis.
+# Use --extra cpu on machines without a GPU, or omit on machines that
+# don't run the voice endpoint.
+agent-core daemon install --extra cu130
+
+# Start the daemon — it now runs from ~/.agent-core/.venv/.
+agent-core daemon start
+
+# Verify.
+agent-core daemon status
+```
+
+`daemon status` should show:
+
+```
+daemon is running (PID: NNNNN)
+running from: ~/.agent-core/.venv/Scripts/python.exe   (or bin/python on POSIX)
+installed at: <timestamp>
+installed sha: <git short hash>
+```
+
+If you see `(fallback — vulnerable to uv sync; run \`agent-core daemon install\`)`
+next to `running from`, the daemon venv is missing and the supervisor fell
+back to the workspace venv. Run `daemon install` and `daemon refresh`.
+
+## Daily flow: picking up new code
+
+When you've made changes to agent-core (or pulled new code) and want the
+daemon to run them:
+
+```bash
+agent-core daemon refresh
+```
+
+This does three things in order:
+1. `daemon stop` — kills the running daemon.
+2. `daemon install` — re-runs `uv sync --frozen --no-editable --no-dev` against
+   the workspace. Uses the extra you specified at install time (stamped in
+   `~/.agent-core/.daemon-install-stamp.json`).
+3. `daemon start` — relaunches the daemon from the refreshed venv.
+
+If `daemon install` fails (uv error, missing workspace, etc.), the daemon
+stays stopped and the error surfaces. Fix the underlying issue and re-run
+`daemon refresh`.
+
+## Why this exists
+
+Before this change, the daemon ran from `<workspace>/.venv/Scripts/python.exe`
+(Windows) or `<workspace>/.venv/bin/python` (POSIX). On Windows, `uv sync`
+uses unlink-then-relink semantics that disrupt running processes holding open
+files in `.venv/`. Adding a workspace member re-resolved the lockfile and
+rewrote every package's editable `.pth` file, silently killing the running
+daemon. Pepper went offline mid-session on 2026-05-10 from exactly this.
+
+The fix: install the daemon non-editable, into a venv outside the workspace
+tree. `uv sync` cannot reach it because there are no `.pth` files pointing
+at workspace source.
+
+## Disk cost
+
+The full workspace install with `--extra cu130` is ~6–7 GB (mostly torch
+CUDA wheels). One-time. `daemon refresh` is a delta operation on the lockfile
+diff; usually fast.
+
+To reclaim the space, `rm -rf ~/.agent-core/.venv` then `daemon install`
+fresh.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `daemon is currently running` on install | Daemon supervises something | `daemon refresh` |
+| `couldn't find workspace root` | Running `install` outside the repo | `cd` into the agent-core repo |
+| `uv not found on PATH` | uv not installed | https://docs.astral.sh/uv/getting-started/installation/ |
+| `daemon venv may be stale` | `uv.lock` moved since last install | `daemon refresh` |
+| `fallback — vulnerable to uv sync` | `~/.agent-core/.venv/` not present | `daemon install` |
+
+## Related
+
+- [#79](https://github.com/jeffrichley/agent_core/issues/79) — the issue that motivated this.
+- `docs/superpowers/specs/2026-05-15-daemon-venv-isolation-design.md` — the design.
+- `agent_core.daemon.cli` — supervisor code.
+- `agent_core.daemon.install` — install orchestration.
+```
+
+- [ ] **Step 2: Add pointer to `README.md`**
+
+Read the existing `README.md`:
+
+```
+cat README.md
+```
+
+Find the section that lists docs / setup links (or a "Getting started" / "Development" section). Add this line in the most appropriate place — typically under a "Running the daemon" or "Development" header:
+
+```markdown
+- **Running the bus daemon:** see [docs/setup/daemon.md](docs/setup/daemon.md) for the one-time setup and the `daemon refresh` daily flow.
+```
+
+If there's no obviously right section, add a "Setup" section near the top of the README:
+
+```markdown
+## Setup
+
+- **Bus daemon:** see [docs/setup/daemon.md](docs/setup/daemon.md) for the one-time setup and the `daemon refresh` daily flow.
+```
+
+- [ ] **Step 3: Verify the docs render**
+
+```
+cat docs/setup/daemon.md | head -20
+```
+
+Expected: clean markdown, no rendering artifacts.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/setup/daemon.md README.md
+git commit -m "docs(daemon): operator guide for daemon install + refresh workflow (#79)"
+```
+
+---
+
+## Task 11: Manual verification on Jeff's box (runbook only — no commit)
+
+This task is a runbook, not a code change. It is the final acceptance step
+before opening the PR.
+
+- [ ] **Step 1: Stop the currently-running daemon**
+
+```
+agent-core daemon stop
+```
+
+Expected: `daemon stopped (PID: NNNN)`.
+
+- [ ] **Step 2: Run the one-time install**
+
+From the agent-core repo root:
+
+```
+agent-core daemon install --extra cu130
+```
+
+Expected: takes 1–5 minutes, ends with `daemon venv installed (sha ..., python 3.12, extra cu130, at ...)`.
+
+- [ ] **Step 3: Verify the daemon venv contains the right packages**
+
+```
+ls ~/.agent-core/.venv/Scripts/      # Windows
+ls ~/.agent-core/.venv/Lib/site-packages/ | grep agent_core
+```
+
+Expected: `agent_core/`, `agent_core_voice/`, `agent_core_webcam/`, etc. — all workspace members installed as wheels.
+
+- [ ] **Step 4: Start the daemon and verify the new interpreter is in use**
+
+```
+agent-core daemon start
+agent-core daemon status
+```
+
+Expected: `running from: C:\Users\jeffr\.agent-core\.venv\Scripts\python.exe`. NO `fallback — vulnerable to uv sync` suffix.
+
+- [ ] **Step 5: Run a smoke MCP call to confirm everything works**
+
+In a separate terminal, exercise an endpoint — e.g., synth a short utterance via the voice MCP, or send a test message through Discord. Should round-trip cleanly.
+
+- [ ] **Step 6: The actual regression test — `uv sync` while the daemon is up**
+
+In the workspace:
+
+```
+uv sync
+```
+
+Expected: daemon stays alive (verify with `agent-core daemon status` — same PID, no crash). This is the failure mode #79 was filed to fix.
+
+- [ ] **Step 7: Daily-flow smoke**
+
+```
+agent-core daemon refresh
+```
+
+Expected: stop → install (fast no-op since nothing changed) → start. Daemon comes back up with the same metadata.
+
+- [ ] **Step 8: Document successful run in the PR description**
+
+Capture the output of `daemon status` after step 7 and paste it into the PR description as evidence of acceptance.
+
+---
+
+## After all tasks: open PR
+
+```bash
+git push -u origin feat/issue-79-daemon-venv-spec
+
+gh pr create --title "feat(daemon): venv isolation from workspace uv sync (#79)" --body "$(cat <<'EOF'
+## Summary
+
+Closes #79.
+
+The bus daemon now runs from its own venv at `~/.agent-core/.venv/`,
+populated by a new `agent-core daemon install` subcommand. The supervisor
+prefers that interpreter and falls back to `sys.executable` when the
+daemon venv is absent — so merging this PR is a no-op at runtime until
+the operator runs `daemon install`.
+
+## What's new
+
+- `agent-core daemon install [--extra <extra>] [--python <version>]` —
+  populates `~/.agent-core/.venv/` non-editable, frozen against `uv.lock`,
+  excluding dev deps. Refuses while a daemon is running. Idempotent.
+- `agent-core daemon refresh [--extra <extra>]` — stop → install → start.
+  Uses the stamped extra by default.
+- `agent-core daemon status` — adds three lines (running-from interpreter,
+  install metadata, lock-drift warning).
+
+## Test plan
+
+- [ ] All unit tests pass: `pytest packages/core/tests/test_daemon_cli.py packages/core/tests/test_daemon_install.py -v`
+- [ ] Integration test passes locally: `pytest packages/core/tests/test_daemon_install_integration.py -v -m slow`
+- [ ] Manual verification on Jeff's box completed (steps in `docs/superpowers/plans/2026-05-15-daemon-venv-isolation.md` Task 11).
+- [ ] `uv sync` in the workspace while the daemon is running does not disrupt the daemon.
+- [ ] `daemon status` output after the migration is included in this PR as evidence.
+
+## Docs
+
+- `docs/setup/daemon.md` — operator guide for the new install + refresh workflow.
+- README pointer added.
+
+## Out of scope
+
+- Daemon auto-start at boot (separate ticket).
+- Pepper Claude Code session auto-launch (separate effort).
+- Containerization (forward-compatible; future work).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-15-daemon-venv-isolation-design.md
+++ b/docs/superpowers/specs/2026-05-15-daemon-venv-isolation-design.md
@@ -1,0 +1,241 @@
+# Daemon ↔ workspace venv isolation — design
+
+**Issue:** [#79](https://github.com/jeffrichley/agent_core/issues/79) — `daemon: develop alongside a running bus daemon — uv sync silently kills Pepper`
+
+**Date:** 2026-05-15
+**Status:** Approved, awaiting implementation
+
+## Goal
+
+Make the bus daemon structurally immune to `uv sync` activity in the agent-core workspace, so that adding workspace members or refreshing dependencies during development never disrupts a running Pepper or testbot.
+
+## Background
+
+On 2026-05-10 Pepper went silently offline mid-development at 09:40 ET while implementation work was happening on `agent-core-hatchery`. The daemon process exited cleanly with no error in `daemon.log.err`. Root cause: the daemon's Python interpreter is `sys.executable` — in practice `<workspace>/.venv/Scripts/python.exe` — and `uv sync` on Windows uses unlink-then-relink semantics that disrupt processes holding open `.pth` files and memory-mapped views from `.venv/Lib/site-packages/`. Adding a workspace member triggers a full re-resolve of the lockfile, which rewrites editable `.pth` files for every workspace package. The running daemon's imports either crash or the process exits silently.
+
+This is not a theoretical risk. It happened, it cost Pepper's availability, and it will recur every time a new workspace package is added unless the daemon is structurally isolated from `.venv/`.
+
+## Non-goals
+
+- **Containerization.** Right eventual goal for multi-machine deploys; out of scope here. The design is forward-compatible: a future Docker container would carry the daemon venv as its `/app/.venv` and bind-mount `~/.agent-core/` as `/data/`.
+- **Daemon auto-start at boot.** Separate ticket. This design provides the substrate (a stable, workspace-independent daemon-venv install) that auto-start sits on; it does not implement the Task Scheduler / service wrapper.
+- **Pepper Claude Code session auto-launch.** Separate concern with its own design questions around terminal choice, attach pattern, and Claude Code preview-feature prompt handling. Tracked outside this spec.
+- **Hot-reload of daemon code on workspace change.** Wrong shape for a long-lived stateful daemon. Refresh is explicit.
+- **Editable installs in the daemon venv.** The non-editable property is what makes the isolation work; making it editable defeats the design.
+- **A separate dev-daemon on a different port.** Composable with this work later if scale demands it; not needed now.
+
+## Architecture
+
+The daemon gets its own venv at `~/.agent-core/.venv/`, populated deliberately via `agent-core daemon install`. The workspace `.venv/` becomes a dev-only environment. `uv sync` in the workspace cannot reach the daemon venv because it lives outside the workspace tree, has no `.pth` files referencing workspace paths, and is never the target of any uv operation against the workspace project.
+
+### Three new subcommands under `agent-core daemon`
+
+- **`daemon install [--extra cu130|cpu] [--python 3.12]`** — populate `~/.agent-core/.venv/` from the workspace, non-editable, with the named extra. Idempotent. Refuses if a daemon is currently running.
+- **`daemon refresh [--extra cu130|cpu]`** — convenience: `stop` → `install` → `start`. Aborts if any step fails. Reuses the extra from the install stamp if `--extra` is omitted.
+- *(No `daemon uninstall` for v1 — operator can `rm -rf ~/.agent-core/.venv/`.)*
+
+### Supervisor change
+
+`packages/core/src/agent_core/daemon/cli.py` gains a `_daemon_python()` helper:
+
+```python
+def _daemon_python() -> str:
+    """Return the daemon's preferred interpreter, with fallback."""
+    if sys.platform == "win32":
+        candidate = _home() / ".venv" / "Scripts" / "python.exe"
+    else:
+        candidate = _home() / ".venv" / "bin" / "python"
+    return str(candidate) if candidate.exists() else sys.executable
+```
+
+The existing `subprocess.Popen([sys.executable, ...])` becomes `Popen([_daemon_python(), ...])`. That is the entire runtime change.
+
+### Fallback semantics
+
+If `~/.agent-core/.venv/python` doesn't exist, the supervisor falls back silently to `sys.executable` and behavior is identical to today. Merging the PR is a no-op at runtime; migration is opt-in via `agent-core daemon install` followed by a `daemon refresh`.
+
+This choice is deliberate: today's behavior is "works most of the time; breaks during `uv sync`." It's not broken in steady-state, so a forced migration on first restart after merge would be unnecessarily aggressive.
+
+## Component details
+
+### `daemon install` mechanics
+
+The command runs two steps:
+
+```
+uv venv  ~/.agent-core/.venv  --python <pinned>
+UV_PROJECT_ENVIRONMENT=~/.agent-core/.venv \
+  uv sync --frozen --no-editable --no-dev [--extra <extra>]
+```
+
+The `--no-dev` flag excludes the workspace's dev dependency group (pytest, mypy, ruff, etc.). The daemon doesn't need those at runtime, and leaving them out keeps the install lean.
+
+The combination is the heart of the isolation:
+
+- **`--frozen`** — installs against the workspace's `uv.lock` verbatim. Reproducible: a `daemon install` today and a `daemon install` tomorrow give the same daemon if `uv.lock` hasn't moved.
+- **`--no-editable`** — workspace members are installed as wheels into `~/.agent-core/.venv/Lib/site-packages/`, not as `.pth` shims pointing at the workspace source tree. **This is what structurally prevents `uv sync` in the workspace from reaching the daemon venv.** The daemon venv has no `.pth` files referencing workspace paths; uv has no reason to touch it.
+- **`--no-dev`** — excludes dev-only dependencies (pytest, mypy, ruff). The daemon never runs tests; keeping these out shrinks the install and reduces the surface for version drift.
+- **`UV_PROJECT_ENVIRONMENT`** — tells uv "install into this venv, not the workspace's `.venv/`." Without this, uv would either refuse or sync the wrong venv.
+
+**Install scope:** full workspace + GPU extras. The daemon imports every endpoint type configured in `~/.agent-core/agent_core.yaml` (voice, webcam, discord, briefs, scheduler, handoff-jobs, stub, claude-code-mcp), so the daemon venv must contain all of them. With voice in the workspace this means cu130 torch + transformers + qwen-tts ≈ 6–7 GB on disk. This is one-time cost; refresh is a delta operation.
+
+**Workspace root discovery:** the install command ascends from `agent_core.__file__` until it finds a `pyproject.toml` containing `[tool.uv.workspace]`. If absent (e.g., `daemon install` invoked from outside the repo), it errors with a clear "couldn't find workspace root — run from within the agent-core repo."
+
+**Python version:** `--python` defaults to `3.12` (matching the workspace's `requires-python`). Pinning prevents Python version drift between dev and daemon, which would otherwise be a hidden bug surface.
+
+**Guard against in-place rewrite:** if a daemon is currently running, `daemon install` refuses with:
+
+```
+daemon is currently running (PID 24884).
+   • Run `agent-core daemon stop` and re-run install, or
+   • Run `agent-core daemon refresh` to stop/install/start in one step.
+```
+
+**Failure semantics:** install is not atomic. If `uv sync` fails partway, the venv is in a half-installed state. Retry is safe (uv sync is idempotent). No temp-dir-then-swap for v1.
+
+**Idempotency:** rerunning install on an already-populated venv is fine. uv sync is fast on no-op.
+
+### `daemon refresh` mechanics
+
+```python
+@app.command()
+def refresh(extra: str | None = None) -> None:
+    """Stop the daemon, reinstall the daemon venv, start the daemon."""
+    stop()                # idempotent — no-op if not running
+    install(extra=extra)  # uses stamped extra if --extra omitted
+    start()
+```
+
+If `install` raises, `start` is not called. The daemon stays down; the operator sees the install error and retries.
+
+### Install stamp file
+
+After a successful install, `~/.agent-core/.daemon-install-stamp.json` captures:
+
+```json
+{
+  "installed_at": "2026-05-15T19:31:04Z",
+  "installed_sha": "42713d7",
+  "python_version": "3.12.5",
+  "extra": "cu130",
+  "uv_lock_hash": "sha256:abc..."
+}
+```
+
+- `installed_sha` is read via `git rev-parse HEAD` at install time.
+- `uv_lock_hash` is sha256 of the workspace's `uv.lock` at install time.
+- `extra` lets `daemon refresh` skip the `--extra` flag when the value hasn't changed.
+
+### `daemon status` diagnostics
+
+After the existing PID/log output, three new lines:
+
+```
+running from: ~/.agent-core/.venv/Scripts/python.exe
+installed at: 2026-05-15T19:31:04Z
+installed sha: 42713d7
+```
+
+If `_daemon_python()` returned `sys.executable` (fallback path), the "running from" line gets a dim red `(fallback — vulnerable to uv sync; run \`daemon install\`)` suffix. Quiet pressure to migrate; doesn't block anything.
+
+If the stamp file's `uv_lock_hash` doesn't match the current workspace's `uv.lock`, `daemon status` adds a yellow `daemon venv may be stale — run \`agent-core daemon refresh\`` line. Status check only, never auto-refreshes.
+
+## Migration sequence
+
+One-time on Jeff's box, after the PR lands:
+
+```
+agent-core daemon stop
+agent-core daemon install --extra cu130
+agent-core daemon start
+# verify Pepper + testbot are alive
+# run a smoke MCP call
+```
+
+After that, the daily flow is:
+
+```
+agent-core daemon refresh   # picks up new daemon code; no --extra needed (stamped)
+```
+
+The daemon supervises both Pepper and testbot in a single process, so the migration flips both at once. There is no per-agent gradual rollout. Validation comes from the test suite plus a careful first-flip on Jeff's box. Per [[project_pepper_hands_off_until_proven]], the prior validation requirement applied to bus-migration cutovers; this is a runtime-isolation change that does not alter Pepper's wire behavior.
+
+## Testing
+
+### Unit tests (fast, no network)
+
+1. `_daemon_python()` returns the daemon-venv interpreter when the file exists at the expected path; returns `sys.executable` otherwise. Cross-platform branch covered via `sys.platform` monkeypatch.
+2. `daemon install` refuses when a daemon is running. Mock `is_alive=True`, assert `typer.Exit(code=1)` and the error message names both `stop` and `refresh` as remediation.
+3. `daemon install` workspace-root discovery — given a tmp tree containing a `pyproject.toml` with `[tool.uv.workspace]`, ascends correctly from a deep `agent_core.__file__` mock. Errors clearly when no workspace is found.
+4. `daemon install` issues the expected `uv venv` and `uv sync` commands (mocked subprocess). Assert `--frozen`, `--no-editable`, `UV_PROJECT_ENVIRONMENT`, and the right `--extra` propagation.
+5. `daemon install` writes the stamp file with all five fields populated. Subsequent installs update the stamp in place.
+6. `daemon refresh` calls `stop` → `install` → `start` in order. If `install` raises, `start` is never called and the exception propagates.
+7. `daemon status` renders the "fallback — vulnerable to uv sync" suffix only when `_daemon_python()` returned `sys.executable`.
+8. `daemon status` flags lock-drift when the stamp's `uv_lock_hash` doesn't match the current workspace's `uv.lock`.
+
+### Integration test (slow, network)
+
+9. `pytest.mark.slow` end-to-end install against a tmp `AGENT_CORE_HOME`. Verifies the daemon venv is fully populated against the workspace, the daemon can start from it, and the stamp file matches reality. Skipped in CI by default; runs locally before merge.
+
+### Manual verification (one-time, on Jeff's box)
+
+10. After running the migration sequence, run `uv sync` in the workspace while the daemon is up. Verify daemon heartbeat continues. Hatch a test-being or add a workspace member to reproduce the original failure mode and confirm it no longer occurs.
+
+## Edge cases
+
+- **Partial install state** (interrupted `uv sync`): `daemon refresh` re-runs cleanly because `uv sync` is idempotent. No special handling.
+- **Python version drift** (`.venv/` was created with 3.11, workspace wants 3.12): `uv sync --frozen` refuses; the uv error is already actionable ("delete the venv and reinstall").
+- **`uv` not on PATH**: subprocess raises `FileNotFoundError`. Install catches it and emits `"uv not found on PATH — install uv first: https://docs.astral.sh/uv/getting-started/installation/"`.
+- **Extra change across refreshes** (`cu130` → `cpu`): `uv sync` handles the swap natively. Stamp file is rewritten.
+- **Stale stamp** (manually edited or corrupt JSON): `daemon status` falls back to `"stamp missing/unreadable"` and skips the version diagnostics. Doesn't crash.
+
+## Acceptance criteria
+
+Mapped to the issue body's six criteria:
+
+1. **Supervisor launches from `~/.agent-core/.venv/`'s Python interpreter when present, falls back to `sys.executable` when absent.** Covered by unit test #1 + the supervisor change.
+2. **`agent-core daemon install` subcommand creates `~/.agent-core/.venv/` if missing and installs all current workspace packages non-editable. Idempotent.** Covered by tests #2–#5 + integration #9.
+3. **Running `uv sync` in the workspace while the daemon is up has zero effect on the daemon process.** Structural property of the `--no-editable` install. Verifiable by manual verification #10.
+4. **Tests cover: daemon-venv-present-and-used, daemon-venv-missing-fallback, install fresh, install idempotent.** Covered.
+5. **Docs updated with the new dev workflow.** A new `docs/setup/daemon.md` covers `daemon install` as one-time setup and `daemon refresh` as the daily flow. The repository root `README.md` gets a one-line pointer to that doc.
+6. **Pepper's existing setup is migrated cleanly: she runs from `~/.agent-core/.venv/` after the migration sequence.** Covered by manual verification #10; flipped atomically with testbot since they share a daemon.
+
+## Path to containerization (forward-compatibility note)
+
+If/when Pepper-style daemons need to ship to other machines (Cynthia, Stephanie, a server), the natural path is a Docker image. Three design choices made here translate directly:
+
+- **State directory at `~/.agent-core/`** → bind-mounted as `/data/` in the container.
+- **Daemon venv at `~/.agent-core/.venv/` outside the workspace** → lives at `/app/.venv` inside the image, baked at build time.
+- **Frozen non-editable install** → already the right semantics for a container image; the lockfile-driven install becomes the Dockerfile's `RUN uv sync --frozen --no-editable`.
+
+In other words, this design is the first step toward containerization, not orthogonal to it. The decision to defer Docker is about effort/payoff today, not about the wrong architecture.
+
+## Composes with
+
+- **[#75 (agent-core-hatchery)](https://github.com/jeffrichley/agent_core/issues/75)** — hatched beings each get their own project-scope `agent_core.yaml` and invoke `uv run agent-core hooks run X` against their project venv. Independent of the daemon-venv work but related; the hatchery's `templates/config/claude-settings.json.j2` should pin `--config <absolute-path>` to avoid the CWD-dependency bug Pepper hit on 2026-05-10.
+- **Future containerization** — see "Path to containerization" above.
+- **Future daemon auto-start at boot** — separate ticket. Task Scheduler action invokes `~/.agent-core/.venv/Scripts/agent-core.exe daemon start`. The daemon-venv design is the substrate.
+
+## Open design questions
+
+None remaining. Resolved during the 2026-05-15 brainstorm:
+
+- **Editable vs non-editable installs into the daemon venv** → non-editable (editable defeats the isolation by reintroducing `.pth` files into the daemon venv).
+- **Daemon venv Python version pinning** → yes, default `3.12`, overridable via `--python` on install.
+- **PYTHONPATH-only alternative (no second venv)** → rejected. Full second venv with non-editable install.
+- **Refresh UX** → bundled `daemon refresh` subcommand; not auto-restart in install.
+- **Install scope** → full workspace + cu130 GPU extras for Jeff's primary machine. Other machines can pick a different extra.
+- **Fallback behavior** → silent fallback to `sys.executable` when daemon venv is missing; loud warning in `daemon status`.
+
+## Out of scope
+
+- Containerization (Option 4 from the issue body).
+- A separate dev daemon on port 8790 (Option 3 from the issue body).
+- Hot-reload / file-watcher-driven restart.
+- Editable installs in the daemon venv.
+- Daemon auto-start at boot.
+- Pepper Claude Code session auto-launch.
+
+## Provenance
+
+Surfaced 2026-05-10 by Jeff during agent-core-hatchery (#75) implementation work after Pepper went offline silently mid-session. Research and options evaluation in [#79](https://github.com/jeffrichley/agent_core/issues/79). Design brainstormed 2026-05-15 with Jeff; recommendation aligns with the issue body's Option 2 (separate daemon venv) and resolves the three open design questions from the issue body.

--- a/docs/superpowers/specs/2026-05-15-daemon-venv-isolation-design.md
+++ b/docs/superpowers/specs/2026-05-15-daemon-venv-isolation-design.md
@@ -79,7 +79,7 @@ The combination is the heart of the isolation:
 
 **Install scope:** full workspace + GPU extras. The daemon imports every endpoint type configured in `~/.agent-core/agent_core.yaml` (voice, webcam, discord, briefs, scheduler, handoff-jobs, stub, claude-code-mcp), so the daemon venv must contain all of them. With voice in the workspace this means cu130 torch + transformers + qwen-tts ≈ 6–7 GB on disk. This is one-time cost; refresh is a delta operation.
 
-**Workspace root discovery:** the install command ascends from `agent_core.__file__` until it finds a `pyproject.toml` containing `[tool.uv.workspace]`. If absent (e.g., `daemon install` invoked from outside the repo), it errors with a clear "couldn't find workspace root — run from within the agent-core repo."
+**Workspace root discovery:** the install command ascends from `Path.cwd()` until it finds a `pyproject.toml` containing `[tool.uv.workspace]`. The user must invoke `daemon install` from within the agent-core repo. If the workspace root cannot be found (e.g., invoked from an unrelated directory), it errors with a clear "couldn't find workspace root — run from within the agent-core repo."
 
 **Python version:** `--python` defaults to `3.12` (matching the workspace's `requires-python`). Pinning prevents Python version drift between dev and daemon, which would otherwise be a hidden bug surface.
 
@@ -166,7 +166,7 @@ The daemon supervises both Pepper and testbot in a single process, so the migrat
 
 1. `_daemon_python()` returns the daemon-venv interpreter when the file exists at the expected path; returns `sys.executable` otherwise. Cross-platform branch covered via `sys.platform` monkeypatch.
 2. `daemon install` refuses when a daemon is running. Mock `is_alive=True`, assert `typer.Exit(code=1)` and the error message names both `stop` and `refresh` as remediation.
-3. `daemon install` workspace-root discovery — given a tmp tree containing a `pyproject.toml` with `[tool.uv.workspace]`, ascends correctly from a deep `agent_core.__file__` mock. Errors clearly when no workspace is found.
+3. `daemon install` workspace-root discovery — given a tmp tree containing a `pyproject.toml` with `[tool.uv.workspace]`, ascends correctly from a deep `Path.cwd()` mock. Errors clearly when no workspace is found.
 4. `daemon install` issues the expected `uv venv` and `uv sync` commands (mocked subprocess). Assert `--frozen`, `--no-editable`, `UV_PROJECT_ENVIRONMENT`, and the right `--extra` propagation.
 5. `daemon install` writes the stamp file with all five fields populated. Subsequent installs update the stamp in place.
 6. `daemon refresh` calls `stop` → `install` → `start` in order. If `install` raises, `start` is never called and the exception propagates.

--- a/packages/core/src/agent_core/daemon/cli.py
+++ b/packages/core/src/agent_core/daemon/cli.py
@@ -22,6 +22,7 @@ from rich.console import Console
 from agent_core.daemon.install import (
     UvNotFoundError,
     WorkspaceNotFoundError,
+    compute_lock_hash,
     find_workspace_root,
     read_stamp,
     run_install,
@@ -137,6 +138,35 @@ def status() -> None:
         return
 
     console.print(f"[green]daemon is running (PID: {pid})[/green]")
+
+    # Diagnostic: which interpreter the supervisor would use today.
+    daemon_py = _daemon_python()
+    suffix = ""
+    if daemon_py == sys.executable:
+        suffix = (
+            " [dim red](fallback — vulnerable to uv sync; "
+            "run `agent-core daemon install`)[/dim red]"
+        )
+    console.print(f"running from: {daemon_py}{suffix}")
+
+    # Diagnostic: stamp metadata, if present.
+    stamp = read_stamp(_home())
+    if stamp is not None:
+        console.print(f"installed at: {stamp.installed_at}")
+        console.print(f"installed sha: {stamp.installed_sha}")
+
+        # Lock-drift check (best-effort; skipped silently if workspace not findable).
+        try:
+            workspace = find_workspace_root(Path.cwd())
+            current_hash = compute_lock_hash(workspace)
+            if current_hash != stamp.uv_lock_hash:
+                console.print(
+                    "[yellow]daemon venv may be stale — "
+                    "run `agent-core daemon refresh`[/yellow]"
+                )
+        except (WorkspaceNotFoundError, FileNotFoundError):
+            pass  # Lock-drift is a nice-to-have; don't fail status on workspace issues.
+
     if log_file.exists():
         console.print("\n[dim]--- last 20 lines of daemon.log ---[/dim]")
         lines = log_file.read_text(encoding="utf-8", errors="replace").splitlines()

--- a/packages/core/src/agent_core/daemon/cli.py
+++ b/packages/core/src/agent_core/daemon/cli.py
@@ -23,11 +23,12 @@ from agent_core.daemon.install import (
     UvNotFoundError,
     WorkspaceNotFoundError,
     find_workspace_root,
+    read_stamp,
     run_install,
 )
 from agent_core.daemon.supervisor import is_alive, kill_tree, read_pid, remove_pid, write_pid
 
-app = typer.Typer(help="Daemon process supervision: start, stop, status.")
+app = typer.Typer(help="Daemon process supervision: start, stop, status, install, refresh.")
 console = Console()
 
 
@@ -194,3 +195,25 @@ def install(
         + (f", extra {stamp.extra}" if stamp.extra else "")
         + f", at {stamp.installed_at})"
     )
+
+
+@app.command()
+def refresh(
+    extra: str | None = typer.Option(
+        None,
+        "--extra",
+        help="uv extra to install. Defaults to the stamped extra from the last install.",
+    ),
+    python_version: str = typer.Option(
+        "3.12", "--python", help="Python version to pin the daemon venv to."
+    ),
+) -> None:
+    """Stop daemon → reinstall daemon venv → start daemon. Bundled lifecycle."""
+    if extra is None:
+        stamp = read_stamp(_home())
+        if stamp is not None:
+            extra = stamp.extra
+
+    stop()
+    install(extra=extra, python_version=python_version)
+    start()

--- a/packages/core/src/agent_core/daemon/cli.py
+++ b/packages/core/src/agent_core/daemon/cli.py
@@ -164,7 +164,7 @@ def install(
         raise typer.Exit(code=1)
 
     try:
-        workspace = find_workspace_root(Path(__file__).parent)
+        workspace = find_workspace_root(Path.cwd())
     except WorkspaceNotFoundError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
@@ -181,6 +181,11 @@ def install(
         )
     except UvNotFoundError as exc:
         console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]uv exited with code {exc.returncode}.[/red]")
+        if exc.stderr:
+            console.print(exc.stderr.rstrip())
         raise typer.Exit(code=1) from exc
 
     console.print(

--- a/packages/core/src/agent_core/daemon/cli.py
+++ b/packages/core/src/agent_core/daemon/cli.py
@@ -19,6 +19,12 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from agent_core.daemon.install import (
+    UvNotFoundError,
+    WorkspaceNotFoundError,
+    find_workspace_root,
+    run_install,
+)
 from agent_core.daemon.supervisor import is_alive, kill_tree, read_pid, remove_pid, write_pid
 
 app = typer.Typer(help="Daemon process supervision: start, stop, status.")
@@ -135,3 +141,51 @@ def status() -> None:
         lines = log_file.read_text(encoding="utf-8", errors="replace").splitlines()
         for line in lines[-20:]:
             console.print(line)
+
+
+@app.command()
+def install(
+    extra: str | None = typer.Option(
+        None, "--extra", help="uv extra to install (e.g., cu130, cpu)."
+    ),
+    python_version: str = typer.Option(
+        "3.12", "--python", help="Python version to pin the daemon venv to."
+    ),
+) -> None:
+    """Populate ~/.agent-core/.venv/ from the workspace (non-editable, frozen)."""
+    pid_file = _pid_path()
+    existing = read_pid(pid_file)
+    if existing is not None and is_alive(existing):
+        console.print(
+            f"[red]daemon is currently running (PID {existing}).[/red]\n"
+            "   • Run [bold]agent-core daemon stop[/bold] and re-run install, or\n"
+            "   • Run [bold]agent-core daemon refresh[/bold] to stop/install/start in one step."
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        workspace = find_workspace_root(Path(__file__).parent)
+    except WorkspaceNotFoundError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    home = _home()
+    home.mkdir(parents=True, exist_ok=True)
+
+    try:
+        stamp = run_install(
+            home=home,
+            workspace=workspace,
+            extra=extra,
+            python_version=python_version,
+        )
+    except UvNotFoundError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    console.print(
+        f"[green]daemon venv installed[/green] "
+        f"(sha {stamp.installed_sha}, python {stamp.python_version}"
+        + (f", extra {stamp.extra}" if stamp.extra else "")
+        + f", at {stamp.installed_at})"
+    )

--- a/packages/core/src/agent_core/daemon/cli.py
+++ b/packages/core/src/agent_core/daemon/cli.py
@@ -45,6 +45,22 @@ def _log_path() -> Path:
     return _home() / "daemon.log"
 
 
+def _daemon_python() -> str:
+    """Return the daemon's preferred interpreter, with fallback.
+
+    Prefers `~/.agent-core/.venv/Scripts/python.exe` (Windows) or
+    `~/.agent-core/.venv/bin/python` (POSIX) when present; falls back
+    to `sys.executable` (today's behavior) when the daemon venv is
+    missing. This keeps the supervisor working unchanged on machines
+    that haven't run `agent-core daemon install` yet.
+    """
+    if sys.platform == "win32":
+        candidate = _home() / ".venv" / "Scripts" / "python.exe"
+    else:
+        candidate = _home() / ".venv" / "bin" / "python"
+    return str(candidate) if candidate.exists() else sys.executable
+
+
 @app.command()
 def start() -> None:
     """Spawn `agent-core bus run` detached, write the PID file."""
@@ -71,7 +87,7 @@ def start() -> None:
     log_handle = open(log_file, "ab", buffering=0)
 
     proc = subprocess.Popen(
-        [sys.executable, "-m", "agent_core.cli", "bus", "run", "--config", str(cfg)],
+        [_daemon_python(), "-m", "agent_core.cli", "bus", "run", "--config", str(cfg)],
         stdout=log_handle,
         stderr=subprocess.STDOUT,
         stdin=subprocess.DEVNULL,

--- a/packages/core/src/agent_core/daemon/install.py
+++ b/packages/core/src/agent_core/daemon/install.py
@@ -7,9 +7,13 @@ out of the CLI module makes it directly unit-testable.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
+import subprocess
 import tomllib
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -107,3 +111,83 @@ def build_uv_sync_command(
         cmd += ["--extra", extra]
     env_overrides = {"UV_PROJECT_ENVIRONMENT": str(venv)}
     return cmd, env_overrides
+
+
+class UvNotFoundError(Exception):
+    """Raised when `uv` is not on PATH."""
+
+
+def _git_head_sha(workspace: Path) -> str:
+    """Return the short HEAD sha of the workspace repo, or 'unknown'."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, FileNotFoundError):
+        return "unknown"
+    if result.returncode != 0:
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def compute_lock_hash(workspace: Path) -> str:
+    """SHA-256 of the workspace's uv.lock, prefixed with `sha256:`. Public:
+    `cli.py`'s `daemon status` reuses this for the lock-drift check.
+    """
+    lock = workspace / "uv.lock"
+    digest = hashlib.sha256(lock.read_bytes()).hexdigest()
+    return f"sha256:{digest}"
+
+
+def run_install(
+    *,
+    home: Path,
+    workspace: Path,
+    extra: str | None,
+    python_version: str,
+) -> InstallStamp:
+    """Populate `<home>/.venv/` and write the install stamp. Idempotent."""
+    venv = home / ".venv"
+
+    # Step 1: create / refresh the venv with the pinned Python.
+    venv_cmd = ["uv", "venv", str(venv), "--python", python_version]
+    try:
+        result = subprocess.run(venv_cmd, capture_output=True, text=True, check=False)
+    except FileNotFoundError as exc:
+        raise UvNotFoundError(
+            "uv not found on PATH — install uv first: "
+            "https://docs.astral.sh/uv/getting-started/installation/"
+        ) from exc
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, venv_cmd, output=result.stdout, stderr=result.stderr
+        )
+
+    # Step 2: uv sync into that venv.
+    sync_cmd, env_overrides = build_uv_sync_command(venv=venv, extra=extra)
+    env = {**os.environ, **env_overrides}
+    sync_result = subprocess.run(
+        sync_cmd, cwd=workspace, env=env, capture_output=True, text=True, check=False
+    )
+    if sync_result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            sync_result.returncode,
+            sync_cmd,
+            output=sync_result.stdout,
+            stderr=sync_result.stderr,
+        )
+
+    # Step 3: stamp it.
+    stamp = InstallStamp(
+        installed_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        installed_sha=_git_head_sha(workspace),
+        python_version=python_version,
+        extra=extra,
+        uv_lock_hash=compute_lock_hash(workspace),
+    )
+    write_stamp(home, stamp)
+    return stamp

--- a/packages/core/src/agent_core/daemon/install.py
+++ b/packages/core/src/agent_core/daemon/install.py
@@ -7,7 +7,9 @@ out of the CLI module makes it directly unit-testable.
 
 from __future__ import annotations
 
+import json
 import tomllib
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 
@@ -39,3 +41,47 @@ def find_workspace_root(start: Path) -> Path:
                 "Run `agent-core daemon install` from within the agent-core repo."
             )
         candidate = parent
+
+
+STAMP_FILENAME = ".daemon-install-stamp.json"
+
+
+@dataclass(frozen=True)
+class InstallStamp:
+    """Captures what was installed into the daemon venv, when, and from where."""
+
+    installed_at: str  # ISO 8601 UTC
+    installed_sha: str  # git rev-parse HEAD at install time
+    python_version: str  # e.g., "3.12.5"
+    extra: str | None  # uv extra name, or None
+    uv_lock_hash: str  # sha256 of uv.lock at install time
+
+
+def write_stamp(home: Path, stamp: InstallStamp) -> None:
+    """Write the install stamp to <home>/.daemon-install-stamp.json."""
+    home.mkdir(parents=True, exist_ok=True)
+    (home / STAMP_FILENAME).write_text(
+        json.dumps(asdict(stamp), indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_stamp(home: Path) -> InstallStamp | None:
+    """Read the install stamp. None on missing, corrupt, or schema-incomplete."""
+    path = home / STAMP_FILENAME
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    try:
+        return InstallStamp(
+            installed_at=data["installed_at"],
+            installed_sha=data["installed_sha"],
+            python_version=data["python_version"],
+            extra=data.get("extra"),
+            uv_lock_hash=data["uv_lock_hash"],
+        )
+    except (KeyError, TypeError):
+        return None

--- a/packages/core/src/agent_core/daemon/install.py
+++ b/packages/core/src/agent_core/daemon/install.py
@@ -11,7 +11,7 @@ import tomllib
 from pathlib import Path
 
 
-class WorkspaceNotFoundError(RuntimeError):
+class WorkspaceNotFoundError(Exception):
     """Raised when find_workspace_root cannot locate a workspace pyproject.toml."""
 
 

--- a/packages/core/src/agent_core/daemon/install.py
+++ b/packages/core/src/agent_core/daemon/install.py
@@ -1,0 +1,41 @@
+"""Daemon venv install logic — pure functions, no I/O beyond filesystem.
+
+`cli.py` wires these into the `agent-core daemon install` and
+`agent-core daemon refresh` typer commands. Keeping the install logic
+out of the CLI module makes it directly unit-testable.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+class WorkspaceNotFoundError(RuntimeError):
+    """Raised when find_workspace_root cannot locate a workspace pyproject.toml."""
+
+
+def find_workspace_root(start: Path) -> Path:
+    """Ascend from `start` until a `pyproject.toml` with `[tool.uv.workspace]` is found.
+
+    The agent-core repo's root `pyproject.toml` declares the workspace; we
+    use that as the install target.
+    """
+    candidate = start.resolve()
+    while True:
+        pyproject = candidate / "pyproject.toml"
+        if pyproject.exists():
+            try:
+                data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+            except tomllib.TOMLDecodeError:
+                data = {}
+            if "workspace" in data.get("tool", {}).get("uv", {}):
+                return candidate
+        parent = candidate.parent
+        if parent == candidate:
+            raise WorkspaceNotFoundError(
+                f"couldn't find workspace root above {start} "
+                "(no pyproject.toml with [tool.uv.workspace] found). "
+                "Run `agent-core daemon install` from within the agent-core repo."
+            )
+        candidate = parent

--- a/packages/core/src/agent_core/daemon/install.py
+++ b/packages/core/src/agent_core/daemon/install.py
@@ -13,7 +13,7 @@ import os
 import subprocess
 import tomllib
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 
@@ -183,7 +183,7 @@ def run_install(
 
     # Step 3: stamp it.
     stamp = InstallStamp(
-        installed_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        installed_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         installed_sha=_git_head_sha(workspace),
         python_version=python_version,
         extra=extra,

--- a/packages/core/src/agent_core/daemon/install.py
+++ b/packages/core/src/agent_core/daemon/install.py
@@ -85,3 +85,25 @@ def read_stamp(home: Path) -> InstallStamp | None:
         )
     except (KeyError, TypeError):
         return None
+
+
+def build_uv_sync_command(
+    *, venv: Path, extra: str | None
+) -> tuple[list[str], dict[str, str]]:
+    """Build the `uv sync` command list and env overrides for daemon install.
+
+    --frozen        → install against the workspace's uv.lock verbatim.
+    --no-editable   → workspace members go in as wheels; no .pth shims.
+                      This is what makes the daemon venv immune to
+                      `uv sync` in the workspace tree.
+    --no-dev        → skip the workspace's dev dependency group.
+    --extra <x>     → optional uv extra (e.g., cu130, cpu).
+
+    UV_PROJECT_ENVIRONMENT redirects uv's install target to the daemon venv
+    instead of the workspace's `.venv/`.
+    """
+    cmd: list[str] = ["uv", "sync", "--frozen", "--no-editable", "--no-dev"]
+    if extra is not None:
+        cmd += ["--extra", extra]
+    env_overrides = {"UV_PROJECT_ENVIRONMENT": str(venv)}
+    return cmd, env_overrides

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -14,6 +14,8 @@ from typer.testing import CliRunner
 
 from agent_core.daemon.cli import (
     _daemon_python,
+)
+from agent_core.daemon.cli import (
     app as daemon_app,
 )
 from agent_core.daemon.supervisor import is_alive, read_pid

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -314,3 +314,107 @@ def test_refresh_reuses_stamped_extra_when_no_flag(
     result = runner.invoke(daemon_app, ["refresh"])
     assert result.exit_code == 0
     assert captured["extra"] == "cu130"
+
+
+def test_status_shows_fallback_warning_when_no_daemon_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When _daemon_python falls back to sys.executable, status warns."""
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    # Daemon is "running" — write a PID for the current process so is_alive=True
+    (tmp_path / "daemon.pid").write_text(str(os.getpid()))
+
+    result = runner.invoke(daemon_app, ["status"])
+    assert result.exit_code == 0
+    assert "fallback" in result.stdout.lower()
+    assert "vulnerable to uv sync" in result.stdout.lower()
+
+
+def test_status_no_warning_when_daemon_venv_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    (tmp_path / "daemon.pid").write_text(str(os.getpid()))
+
+    if sys.platform == "win32":
+        venv_python = tmp_path / ".venv" / "Scripts" / "python.exe"
+    else:
+        venv_python = tmp_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("# placeholder")
+
+    result = runner.invoke(daemon_app, ["status"])
+    assert result.exit_code == 0
+    assert "fallback" not in result.stdout.lower()
+
+
+def test_status_shows_stamp_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from agent_core.daemon.install import InstallStamp, write_stamp
+
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    (tmp_path / "daemon.pid").write_text(str(os.getpid()))
+    write_stamp(
+        tmp_path,
+        InstallStamp(
+            installed_at="2026-05-15T19:31:04Z",
+            installed_sha="abc1234",
+            python_version="3.12",
+            extra="cu130",
+            uv_lock_hash="sha256:deadbeef",
+        ),
+    )
+
+    result = runner.invoke(daemon_app, ["status"])
+    assert "abc1234" in result.stdout
+    assert "2026-05-15" in result.stdout
+
+
+def test_status_flags_lock_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from agent_core.daemon.install import InstallStamp, write_stamp
+
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    (tmp_path / "daemon.pid").write_text(str(os.getpid()))
+    # Stamp says the lock was hash "stale-hash"; workspace lock has different content.
+    write_stamp(
+        tmp_path,
+        InstallStamp(
+            installed_at="2026-05-15T19:31:04Z",
+            installed_sha="abc1234",
+            python_version="3.12",
+            extra=None,
+            uv_lock_hash="sha256:STALE",
+        ),
+    )
+
+    # Fake workspace with a uv.lock whose hash is different.
+    fake_ws = tmp_path / "fake-workspace"
+    fake_ws.mkdir()
+    (fake_ws / "uv.lock").write_text("# new content\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "agent_core.daemon.cli.find_workspace_root", lambda _start: fake_ws
+    )
+
+    result = runner.invoke(daemon_app, ["status"])
+    assert "stale" in result.stdout.lower() or "refresh" in result.stdout.lower()
+
+
+def test_status_handles_missing_workspace_gracefully(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """status must not crash if workspace discovery fails — drift check is optional."""
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    (tmp_path / "daemon.pid").write_text(str(os.getpid()))
+
+    def raise_not_found(_start):
+        from agent_core.daemon.install import WorkspaceNotFoundError
+
+        raise WorkspaceNotFoundError("no workspace")
+
+    monkeypatch.setattr("agent_core.daemon.cli.find_workspace_root", raise_not_found)
+
+    result = runner.invoke(daemon_app, ["status"])
+    assert result.exit_code == 0  # still succeeds

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import sys
 import time
 from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
-from agent_core.daemon.cli import app as daemon_app
+from agent_core.daemon.cli import (
+    _daemon_python,
+    app as daemon_app,
+)
 from agent_core.daemon.supervisor import is_alive, read_pid
 
 runner = CliRunner()
@@ -91,16 +95,11 @@ endpoints:
     assert not pid_file.exists()
 
 
-from agent_core.daemon.cli import _daemon_python
-
-
 def test_daemon_python_returns_sys_executable_when_venv_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
     # No ~/.agent-core/.venv/ exists in tmp_path.
-    import sys
-
     assert _daemon_python() == sys.executable
 
 
@@ -108,8 +107,6 @@ def test_daemon_python_returns_daemon_venv_python_when_present(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
-    import sys
-
     if sys.platform == "win32":
         venv_python = tmp_path / ".venv" / "Scripts" / "python.exe"
     else:

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from agent_core.daemon.cli import (
@@ -230,3 +231,86 @@ def test_install_reports_uv_exit_code(
     assert result.exit_code == 1
     assert "uv exited with code 1" in result.stdout
     assert "failed to resolve" in result.stdout
+
+
+def test_refresh_calls_stop_install_start_in_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    order: list[str] = []
+
+    def fake_stop() -> None:
+        order.append("stop")
+
+    def fake_install(extra: str | None = None, python_version: str = "3.12") -> None:
+        order.append(f"install:extra={extra}")
+
+    def fake_start() -> None:
+        order.append("start")
+
+    monkeypatch.setattr("agent_core.daemon.cli.stop", fake_stop)
+    monkeypatch.setattr("agent_core.daemon.cli.install", fake_install)
+    monkeypatch.setattr("agent_core.daemon.cli.start", fake_start)
+
+    result = runner.invoke(daemon_app, ["refresh", "--extra", "cu130"])
+    assert result.exit_code == 0, result.stdout
+    assert order == ["stop", "install:extra=cu130", "start"]
+
+
+def test_refresh_aborts_start_when_install_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    order: list[str] = []
+
+    def fake_stop() -> None:
+        order.append("stop")
+
+    def fake_install(extra: str | None = None, python_version: str = "3.12") -> None:
+        order.append("install")
+        raise typer.Exit(code=1)
+
+    def fake_start() -> None:
+        order.append("start")  # must not be called
+
+    monkeypatch.setattr("agent_core.daemon.cli.stop", fake_stop)
+    monkeypatch.setattr("agent_core.daemon.cli.install", fake_install)
+    monkeypatch.setattr("agent_core.daemon.cli.start", fake_start)
+
+    result = runner.invoke(daemon_app, ["refresh"])
+    assert result.exit_code != 0
+    assert "start" not in order
+    assert order == ["stop", "install"]
+
+
+def test_refresh_reuses_stamped_extra_when_no_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When --extra is omitted, refresh passes the stamped extra to install."""
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    # Write a stamp with extra='cu130'
+    from agent_core.daemon.install import InstallStamp, write_stamp
+
+    write_stamp(
+        tmp_path,
+        InstallStamp(
+            installed_at="2026-05-15T19:31:04Z",
+            installed_sha="abc1234",
+            python_version="3.12",
+            extra="cu130",
+            uv_lock_hash="sha256:abc",
+        ),
+    )
+
+    captured: dict = {}
+
+    def fake_install(extra: str | None = None, python_version: str = "3.12") -> None:
+        captured["extra"] = extra
+
+    monkeypatch.setattr("agent_core.daemon.cli.stop", lambda: None)
+    monkeypatch.setattr("agent_core.daemon.cli.install", fake_install)
+    monkeypatch.setattr("agent_core.daemon.cli.start", lambda: None)
+
+    result = runner.invoke(daemon_app, ["refresh"])
+    assert result.exit_code == 0
+    assert captured["extra"] == "cu130"

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -202,3 +202,31 @@ def test_install_reports_uv_not_found(
     result = runner.invoke(daemon_app, ["install"])
     assert result.exit_code == 1
     assert "uv not found" in result.stdout.lower()
+
+
+def test_install_reports_uv_exit_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """uv subprocess failure surfaces returncode + stderr cleanly."""
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+
+    def fake_run_install(*, home, workspace, extra, python_version):
+        import subprocess
+
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["uv", "sync", "--frozen"],
+            output="",
+            stderr="error: failed to resolve packages",
+        )
+
+    monkeypatch.setattr("agent_core.daemon.cli.run_install", fake_run_install)
+    monkeypatch.setattr(
+        "agent_core.daemon.cli.find_workspace_root",
+        lambda _start: tmp_path / "fake-workspace",
+    )
+
+    result = runner.invoke(daemon_app, ["install"])
+    assert result.exit_code == 1
+    assert "uv exited with code 1" in result.stdout
+    assert "failed to resolve" in result.stdout

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import time
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from typer.testing import CliRunner
@@ -115,3 +117,88 @@ def test_daemon_python_returns_daemon_venv_python_when_present(
     venv_python.write_text("# placeholder")
 
     assert _daemon_python() == str(venv_python)
+
+
+def test_install_refuses_when_daemon_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    pid_file = tmp_path / "daemon.pid"
+    pid_file.write_text(str(os.getpid()))  # current process is alive
+    result = runner.invoke(daemon_app, ["install"])
+    assert result.exit_code == 1
+    assert "currently running" in result.stdout.lower()
+    assert "refresh" in result.stdout.lower()
+
+
+def test_install_invokes_run_install_with_args(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    captured: dict = {}
+
+    fake_stamp = MagicMock(
+        installed_sha="abc1234",
+        extra="cu130",
+        python_version="3.12",
+        installed_at="2026-05-15T19:31:04Z",
+    )
+
+    def fake_run_install(*, home, workspace, extra, python_version):
+        captured["home"] = home
+        captured["workspace"] = workspace
+        captured["extra"] = extra
+        captured["python_version"] = python_version
+        return fake_stamp
+
+    monkeypatch.setattr("agent_core.daemon.cli.run_install", fake_run_install)
+    monkeypatch.setattr(
+        "agent_core.daemon.cli.find_workspace_root",
+        lambda _start: tmp_path / "fake-workspace",
+    )
+
+    result = runner.invoke(daemon_app, ["install", "--extra", "cu130"])
+    assert result.exit_code == 0, result.stdout
+    assert captured["home"] == tmp_path
+    assert captured["workspace"] == tmp_path / "fake-workspace"
+    assert captured["extra"] == "cu130"
+    assert captured["python_version"] == "3.12"
+    assert "abc1234" in result.stdout  # stamp sha echoed
+
+
+def test_install_reports_workspace_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+
+    def raise_not_found(_start):
+        from agent_core.daemon.install import WorkspaceNotFoundError
+
+        raise WorkspaceNotFoundError("can't find workspace")
+
+    monkeypatch.setattr("agent_core.daemon.cli.find_workspace_root", raise_not_found)
+
+    result = runner.invoke(daemon_app, ["install"])
+    assert result.exit_code == 1
+    assert "workspace" in result.stdout.lower()
+
+
+def test_install_reports_uv_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+
+    def fake_run_install(*, home, workspace, extra, python_version):
+        from agent_core.daemon.install import UvNotFoundError
+
+        raise UvNotFoundError("uv not found on PATH")
+
+    monkeypatch.setattr("agent_core.daemon.cli.run_install", fake_run_install)
+    monkeypatch.setattr(
+        "agent_core.daemon.cli.find_workspace_root",
+        lambda _start: tmp_path / "fake-workspace",
+    )
+
+    result = runner.invoke(daemon_app, ["install"])
+    assert result.exit_code == 1
+    assert "uv not found" in result.stdout.lower()

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -89,3 +89,32 @@ endpoints:
         time.sleep(0.1)
     assert is_alive(pid) is False
     assert not pid_file.exists()
+
+
+from agent_core.daemon.cli import _daemon_python
+
+
+def test_daemon_python_returns_sys_executable_when_venv_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    # No ~/.agent-core/.venv/ exists in tmp_path.
+    import sys
+
+    assert _daemon_python() == sys.executable
+
+
+def test_daemon_python_returns_daemon_venv_python_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    import sys
+
+    if sys.platform == "win32":
+        venv_python = tmp_path / ".venv" / "Scripts" / "python.exe"
+    else:
+        venv_python = tmp_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("# placeholder")
+
+    assert _daemon_python() == str(venv_python)

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -366,6 +366,15 @@ def test_status_shows_stamp_metadata(
         ),
     )
 
+    def _skip_workspace(_start):
+        from agent_core.daemon.install import WorkspaceNotFoundError
+
+        raise WorkspaceNotFoundError("hermetic test: skip drift check")
+
+    monkeypatch.setattr(
+        "agent_core.daemon.cli.find_workspace_root", _skip_workspace
+    )
+
     result = runner.invoke(daemon_app, ["status"])
     assert "abc1234" in result.stdout
     assert "2026-05-15" in result.stdout

--- a/packages/core/tests/test_daemon_install.py
+++ b/packages/core/tests/test_daemon_install.py
@@ -6,7 +6,14 @@ from pathlib import Path
 
 import pytest
 
-from agent_core.daemon.install import WorkspaceNotFoundError, find_workspace_root
+from agent_core.daemon.install import (
+    STAMP_FILENAME,
+    InstallStamp,
+    WorkspaceNotFoundError,
+    find_workspace_root,
+    read_stamp,
+    write_stamp,
+)
 
 
 def test_find_workspace_root_walks_up_to_pyproject(tmp_path: Path) -> None:
@@ -51,3 +58,33 @@ def test_find_workspace_root_skips_malformed_toml(tmp_path: Path) -> None:
         "[tool.uv.workspace]\nmembers = [\"inner\"]\n", encoding="utf-8"
     )
     assert find_workspace_root(inner) == tmp_path
+
+
+def test_write_then_read_stamp_round_trips(tmp_path: Path) -> None:
+    stamp = InstallStamp(
+        installed_at="2026-05-15T19:31:04Z",
+        installed_sha="42713d7",
+        python_version="3.12.5",
+        extra="cu130",
+        uv_lock_hash="sha256:abc",
+    )
+    write_stamp(tmp_path, stamp)
+
+    assert (tmp_path / STAMP_FILENAME).exists()
+    assert read_stamp(tmp_path) == stamp
+
+
+def test_read_stamp_returns_none_when_missing(tmp_path: Path) -> None:
+    assert read_stamp(tmp_path) is None
+
+
+def test_read_stamp_returns_none_when_corrupt(tmp_path: Path) -> None:
+    (tmp_path / STAMP_FILENAME).write_text("not json", encoding="utf-8")
+    assert read_stamp(tmp_path) is None
+
+
+def test_read_stamp_returns_none_when_missing_fields(tmp_path: Path) -> None:
+    (tmp_path / STAMP_FILENAME).write_text(
+        '{"installed_at": "2026-05-15T19:31:04Z"}', encoding="utf-8"
+    )
+    assert read_stamp(tmp_path) is None

--- a/packages/core/tests/test_daemon_install.py
+++ b/packages/core/tests/test_daemon_install.py
@@ -216,6 +216,25 @@ def test_run_install_raises_uv_not_found_on_oserror(
         run_install(home=home, workspace=workspace, extra=None, python_version="3.12")
 
 
+def test_run_install_raises_on_uv_venv_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """uv venv non-zero exit (e.g., requested Python version unavailable) raises."""
+    workspace = _make_workspace(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["uv", "venv"]:
+            return MagicMock(returncode=1, stderr="python 99.99 not found")
+        return MagicMock(returncode=0)
+
+    monkeypatch.setattr("agent_core.daemon.install.subprocess.run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        run_install(home=home, workspace=workspace, extra=None, python_version="99.99")
+
+
 def test_run_install_raises_on_uv_sync_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/core/tests/test_daemon_install.py
+++ b/packages/core/tests/test_daemon_install.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+import hashlib
+import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from agent_core.daemon.install import (
     STAMP_FILENAME,
     InstallStamp,
+    UvNotFoundError,
     WorkspaceNotFoundError,
     build_uv_sync_command,
     find_workspace_root,
     read_stamp,
+    run_install,
     write_stamp,
 )
 
@@ -111,3 +116,123 @@ def test_build_uv_sync_command_with_extra(tmp_path: Path) -> None:
         "cu130",
     ]
     assert env_overrides == {"UV_PROJECT_ENVIRONMENT": str(venv)}
+
+
+# ---------------------------------------------------------------------------
+# Task 5: run_install() tests
+# ---------------------------------------------------------------------------
+
+
+def _make_workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "pyproject.toml").write_text(
+        "[tool.uv.workspace]\nmembers = [\"packages/*\"]\n", encoding="utf-8"
+    )
+    (workspace / "uv.lock").write_text("# fake lock\n", encoding="utf-8")
+    return workspace
+
+
+def test_run_install_invokes_uv_venv_then_uv_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _make_workspace(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        result = MagicMock()
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr("agent_core.daemon.install.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "agent_core.daemon.install._git_head_sha", lambda _ws: "abc1234"
+    )
+
+    run_install(home=home, workspace=workspace, extra="cu130", python_version="3.12")
+
+    # First call: uv venv ... --python 3.12
+    assert calls[0][:2] == ["uv", "venv"]
+    assert "--python" in calls[0]
+    assert "3.12" in calls[0]
+    # Second call: uv sync --frozen --no-editable --no-dev --extra cu130
+    assert calls[1] == [
+        "uv",
+        "sync",
+        "--frozen",
+        "--no-editable",
+        "--no-dev",
+        "--extra",
+        "cu130",
+    ]
+
+
+def test_run_install_writes_stamp_with_lock_hash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _make_workspace(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    monkeypatch.setattr(
+        "agent_core.daemon.install.subprocess.run",
+        lambda cmd, **kwargs: MagicMock(returncode=0),
+    )
+    monkeypatch.setattr(
+        "agent_core.daemon.install._git_head_sha", lambda _ws: "abc1234"
+    )
+
+    run_install(home=home, workspace=workspace, extra=None, python_version="3.12")
+
+    stamp = read_stamp(home)
+    assert stamp is not None
+    assert stamp.installed_sha == "abc1234"
+    assert stamp.extra is None
+    # uv_lock_hash matches sha256 of the lock file content
+    expected_hash = (
+        "sha256:"
+        + hashlib.sha256((workspace / "uv.lock").read_bytes()).hexdigest()
+    )
+    assert stamp.uv_lock_hash == expected_hash
+
+
+def test_run_install_raises_uv_not_found_on_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _make_workspace(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "uv")
+
+    monkeypatch.setattr("agent_core.daemon.install.subprocess.run", fake_run)
+
+    with pytest.raises(UvNotFoundError, match="uv not found on PATH"):
+        run_install(home=home, workspace=workspace, extra=None, python_version="3.12")
+
+
+def test_run_install_raises_on_uv_sync_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _make_workspace(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    def fake_run(cmd, **kwargs):
+        # `uv venv` succeeds, `uv sync` fails.
+        if cmd[:2] == ["uv", "sync"]:
+            return MagicMock(returncode=1, stderr="resolution error")
+        return MagicMock(returncode=0)
+
+    monkeypatch.setattr("agent_core.daemon.install.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "agent_core.daemon.install._git_head_sha", lambda _ws: "abc1234"
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        run_install(home=home, workspace=workspace, extra=None, python_version="3.12")

--- a/packages/core/tests/test_daemon_install.py
+++ b/packages/core/tests/test_daemon_install.py
@@ -40,3 +40,14 @@ def test_find_workspace_root_ignores_non_workspace_pyproject(tmp_path: Path) -> 
 def test_find_workspace_root_raises_when_absent(tmp_path: Path) -> None:
     with pytest.raises(WorkspaceNotFoundError, match="workspace"):
         find_workspace_root(tmp_path)
+
+
+def test_find_workspace_root_skips_malformed_toml(tmp_path: Path) -> None:
+    """A pyproject.toml with invalid TOML syntax is skipped, not an error."""
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    (inner / "pyproject.toml").write_text("not = [ valid toml ???", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.uv.workspace]\nmembers = [\"inner\"]\n", encoding="utf-8"
+    )
+    assert find_workspace_root(inner) == tmp_path

--- a/packages/core/tests/test_daemon_install.py
+++ b/packages/core/tests/test_daemon_install.py
@@ -1,0 +1,42 @@
+"""Unit tests for `agent_core.daemon.install`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_core.daemon.install import WorkspaceNotFoundError, find_workspace_root
+
+
+def test_find_workspace_root_walks_up_to_pyproject(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "pyproject.toml").write_text(
+        "[tool.uv.workspace]\nmembers = [\"packages/*\"]\n",
+        encoding="utf-8",
+    )
+    deep = workspace / "packages" / "core" / "src" / "agent_core"
+    deep.mkdir(parents=True)
+
+    assert find_workspace_root(deep) == workspace
+
+
+def test_find_workspace_root_ignores_non_workspace_pyproject(tmp_path: Path) -> None:
+    """A pyproject.toml without [tool.uv.workspace] is not a workspace root."""
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    (inner / "pyproject.toml").write_text("[project]\nname = \"x\"\n", encoding="utf-8")
+
+    outer = tmp_path
+    (outer / "pyproject.toml").write_text(
+        "[tool.uv.workspace]\nmembers = [\"inner\"]\n",
+        encoding="utf-8",
+    )
+
+    assert find_workspace_root(inner) == outer
+
+
+def test_find_workspace_root_raises_when_absent(tmp_path: Path) -> None:
+    with pytest.raises(WorkspaceNotFoundError, match="workspace"):
+        find_workspace_root(tmp_path)

--- a/packages/core/tests/test_daemon_install.py
+++ b/packages/core/tests/test_daemon_install.py
@@ -10,6 +10,7 @@ from agent_core.daemon.install import (
     STAMP_FILENAME,
     InstallStamp,
     WorkspaceNotFoundError,
+    build_uv_sync_command,
     find_workspace_root,
     read_stamp,
     write_stamp,
@@ -88,3 +89,25 @@ def test_read_stamp_returns_none_when_missing_fields(tmp_path: Path) -> None:
         '{"installed_at": "2026-05-15T19:31:04Z"}', encoding="utf-8"
     )
     assert read_stamp(tmp_path) is None
+
+
+def test_build_uv_sync_command_basic(tmp_path: Path) -> None:
+    venv = tmp_path / ".venv"
+    cmd, env_overrides = build_uv_sync_command(venv=venv, extra=None)
+    assert cmd == ["uv", "sync", "--frozen", "--no-editable", "--no-dev"]
+    assert env_overrides == {"UV_PROJECT_ENVIRONMENT": str(venv)}
+
+
+def test_build_uv_sync_command_with_extra(tmp_path: Path) -> None:
+    venv = tmp_path / ".venv"
+    cmd, env_overrides = build_uv_sync_command(venv=venv, extra="cu130")
+    assert cmd == [
+        "uv",
+        "sync",
+        "--frozen",
+        "--no-editable",
+        "--no-dev",
+        "--extra",
+        "cu130",
+    ]
+    assert env_overrides == {"UV_PROJECT_ENVIRONMENT": str(venv)}

--- a/packages/core/tests/test_daemon_install_integration.py
+++ b/packages/core/tests/test_daemon_install_integration.py
@@ -15,7 +15,6 @@ import pytest
 
 from agent_core.daemon.install import read_stamp, run_install
 
-
 pytestmark = pytest.mark.slow
 
 

--- a/packages/core/tests/test_daemon_install_integration.py
+++ b/packages/core/tests/test_daemon_install_integration.py
@@ -1,0 +1,106 @@
+"""End-to-end install against a minimal tmp workspace. Real uv subprocess.
+
+Skipped by default (slow); run locally with:
+    pytest packages/core/tests/test_daemon_install_integration.py -v -m slow
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from agent_core.daemon.install import read_stamp, run_install
+
+
+pytestmark = pytest.mark.slow
+
+
+def _uv_available() -> bool:
+    return shutil.which("uv") is not None
+
+
+@pytest.mark.skipif(not _uv_available(), reason="uv not on PATH")
+def test_run_install_creates_working_venv_against_minimal_workspace(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    # Minimal workspace pyproject — no torch, no agent-core. Just `iniconfig`
+    # so uv has something real to install.
+    # hatchling needs an explicit packages declaration because the root project
+    # has no src/ directory matching "fake_ws_root" by default.
+    (workspace / "pyproject.toml").write_text(
+        """
+[project]
+name = "fake-ws-root"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = ["iniconfig"]
+
+[tool.uv.workspace]
+members = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/fake_ws_root"]
+""",
+        encoding="utf-8",
+    )
+    # Create a minimal package so hatchling can build a wheel.
+    pkg_dir = workspace / "src" / "fake_ws_root"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    # Generate a lockfile so --frozen has something to install against.
+    lock_result = subprocess.run(
+        ["uv", "lock"], cwd=workspace, capture_output=True, text=True, check=False
+    )
+    assert lock_result.returncode == 0, lock_result.stderr
+
+    home = tmp_path / "agent-core-home"
+    home.mkdir()
+
+    stamp = run_install(
+        home=home,
+        workspace=workspace,
+        extra=None,
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+    )
+
+    # Venv exists and has a Python interpreter.
+    if sys.platform == "win32":
+        py = home / ".venv" / "Scripts" / "python.exe"
+    else:
+        py = home / ".venv" / "bin" / "python"
+    assert py.exists(), f"expected interpreter at {py}"
+
+    # iniconfig was installed.
+    show = subprocess.run(
+        [str(py), "-c", "import iniconfig; print(iniconfig.__name__)"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert show.returncode == 0, show.stderr
+    assert show.stdout.strip() == "iniconfig"
+
+    # Stamp file exists and matches what run_install returned.
+    on_disk = read_stamp(home)
+    assert on_disk == stamp
+
+    # Re-running run_install is idempotent (uv sync no-op).
+    stamp2 = run_install(
+        home=home,
+        workspace=workspace,
+        extra=None,
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+    )
+    # Stamp's installed_at will differ (re-stamped); installed_sha/lock_hash
+    # should match the first call.
+    assert stamp2.uv_lock_hash == stamp.uv_lock_hash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ testpaths = [
     "packages/agent-core-voice/tests",
 ]
 asyncio_mode = "auto"
-addopts = "--import-mode=importlib"
+addopts = "--import-mode=importlib -m 'not slow'"
 markers = [
     "looptime: virtual asyncio clock compaction (looptime plugin; see test docs)",
     "slow: tests that hit network or take >5s; skipped by default in CI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,4 +89,5 @@ asyncio_mode = "auto"
 addopts = "--import-mode=importlib"
 markers = [
     "looptime: virtual asyncio clock compaction (looptime plugin; see test docs)",
+    "slow: tests that hit network or take >5s; skipped by default in CI",
 ]


### PR DESCRIPTION
## Summary

Closes #79.

The bus daemon now runs from its own venv at `~/.agent-core/.venv/`,
populated by a new `agent-core daemon install` subcommand. The supervisor
prefers that interpreter and falls back to `sys.executable` when the daemon
venv is absent — so merging this PR is a **no-op at runtime** until the
operator runs `daemon install`.

## What's new

- `agent-core daemon install [--extra <x>] [--python <v>]` — populates
  `~/.agent-core/.venv/` non-editable, frozen against `uv.lock`, excluding
  dev deps. Refuses while a daemon is running. Idempotent.
- `agent-core daemon refresh [--extra <x>]` — stop → install → start. Uses
  the stamped extra by default.
- `agent-core daemon status` — adds running-from interpreter, install
  metadata, and a lock-drift warning.
- `docs/setup/daemon.md` + README pointer.

## Acceptance — verified live on the maintainer's box (2026-05-15)

The ironclad regression test: reproduce the exact 2026-05-10 failure mode
and confirm the daemon survives.

```
# before
daemon is running (PID: 2804)
running from: C:\Users\jeffr\.agent-core\.venv\Scripts\python.exe

# the 2026-05-10 killer operation — unlink+relink every workspace package
uv sync --reinstall          # 2m17s, reinstalled all packages

# after
daemon is running (PID: 2804)   # <-- SAME PID. Did not flinch.
running from: C:\Users\jeffr\.agent-core\.venv\Scripts\python.exe
```

| # | Criterion | Status |
|---|---|---|
| 1 | Supervisor uses isolated venv, falls back when absent | Verified |
| 2 | `daemon install` populates venv, idempotent, stamps | Verified |
| 3 | `uv sync` zero effect on running daemon | **Verified via `uv sync --reinstall`** |
| 4 | Tests cover venv-present/missing/install/idempotent | 36 tests green |
| 5 | Docs updated | daemon.md + README |
| 6 | Pepper/testbot migrated to isolated venv | Verified (flipped atomically) |

Daily-flow `daemon refresh` smoke also passed end-to-end.

## Test plan

- [x] Unit suite: `pytest packages/core/tests/test_daemon_cli.py packages/core/tests/test_daemon_install.py` → 35 passed
- [x] Integration: `pytest packages/core/tests/test_daemon_install_integration.py -m slow` → 1 passed; deselected by default (no `-m slow`)
- [x] Full repo collection unaffected: 1122 tests collected, only the 1 new slow test deselected
- [x] `ruff check` clean on all touched files
- [x] Live manual verification incl. `uv sync --reinstall` regression proof

## Known follow-up (not a regression from this work)

#91 — a daemon bounce orphans live Claude Code agent MCP sessions. Pre-existing
bus/MCP gap, but `daemon refresh` makes it routine; documented in
`docs/setup/daemon.md` with an interim "restart live agent sessions after
refresh" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)