### PR TITLE
feat(busproxy): #91 daemon-bounce MCP session recovery via stdio proxy

### DIFF
--- a/docs/setup/daemon.md
+++ b/docs/setup/daemon.md
@@ -60,16 +60,15 @@ stays stopped and the error surfaces. Fix the underlying issue and re-run
 
 > **Note:** `daemon refresh` assumes a prior `daemon install` has already been run and recorded your `--extra` choice in the stamp file. If this is your first time setting up the daemon, run `daemon install --extra <x>` (e.g., `--extra cu130`) first — otherwise `refresh` will install with no extras (CPU-only torch).
 
-> **Live agent sessions must be restarted after a bounce.** `daemon refresh`
-> (and `install`/`start`/`stop`, and any crash) restarts the daemon process.
-> A new daemon process has no memory of prior MCP session IDs, so any
-> **already-running** Claude Code agent session (Pepper, testbot) is orphaned:
-> its tool calls fail with `Session not found`, and neither retrying nor
-> `/mcp reconnect` recovers it — only a full restart of that agent's Claude
-> Code session re-initializes the MCP connection. Agent work product is on
-> disk (vault/memory), independent of the bus, so nothing is lost — but plan
-> to restart any live agent session after a `daemon refresh`. Tracked in
-> [#91](https://github.com/jeffrichley/agent_core/issues/91).
+> **Live agent sessions survive a bounce (#91).** Agents connect to the
+> bus tool surface through the `agent-core-busproxy` stdio MCP server
+> (not directly over HTTP). Each tool call mints a fresh backend session,
+> so `daemon refresh`/`install`/`start`/`stop` (and crashes) no longer
+> strand a live Claude Code session: in-flight calls during the down
+> window return a structured `{"error":"bus_unavailable","transient":true,
+> "retry_after_seconds":5}` result that the agent retries, and the next
+> call after the daemon is back succeeds with no session restart. The
+> `agent-core-channel` wake relay already reconnects on its own.
 
 ## Why this exists
 
@@ -110,3 +109,33 @@ fresh.
 - `docs/superpowers/specs/2026-05-15-daemon-venv-isolation-design.md` — the design.
 - `agent_core.daemon.cli` — supervisor code.
 - `agent_core.daemon.install` — install orchestration.
+
+## Agent `.mcp.json` (resilient shape)
+
+Each agent's `<agent_root>/.mcp.json` must point the bus tool surface at
+the stdio busproxy — never the daemon HTTP URL directly:
+
+```json
+{
+  "mcpServers": {
+    "agent-core": {
+      "type": "stdio", "command": "uv",
+      "args": ["run", "--project", "<AGENT_CORE_REPO>",
+               "agent-core-busproxy", "--agent", "<AGENT>",
+               "--daemon-url", "http://127.0.0.1:8789"]
+    },
+    "agent-core-channel": {
+      "type": "stdio", "command": "uv",
+      "args": ["run", "--project", "<AGENT_CORE_REPO>",
+               "agent-core-channel", "--agent", "<AGENT>",
+               "--daemon-url", "http://127.0.0.1:8789"]
+    }
+  }
+}
+```
+
+Both surfaces are now stdio and reconnect independently. The old
+`{"type":"http","url":".../mcp/<agent>"}` form is the #91 failure mode —
+do not use it. Cut over per agent: a fresh/throwaway test agent first,
+validate across several real `daemon refresh` cycles, then Pepper last
+(rollback = restore the backed-up `.mcp.json`, a single file).

--- a/docs/setup/daemon.md
+++ b/docs/setup/daemon.md
@@ -105,7 +105,7 @@ fresh.
 ## Related
 
 - [#79](https://github.com/jeffrichley/agent_core/issues/79) — the issue that motivated this.
-- [#91](https://github.com/jeffrichley/agent_core/issues/91) — daemon bounce orphans live agent MCP sessions (restart agents after `refresh`).
+- [#91](https://github.com/jeffrichley/agent_core/issues/91) — daemon-bounce MCP session recovery (fixed: agents use the `agent-core-busproxy` stdio surface; a bounce no longer needs an agent session restart — see above).
 - `docs/superpowers/specs/2026-05-15-daemon-venv-isolation-design.md` — the design.
 - `agent_core.daemon.cli` — supervisor code.
 - `agent_core.daemon.install` — install orchestration.

--- a/docs/superpowers/plans/2026-05-16-daemon-mcp-session-recovery.md
+++ b/docs/superpowers/plans/2026-05-16-daemon-mcp-session-recovery.md
@@ -1,0 +1,997 @@
+# Daemon Bounce MCP Session Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the fragile direct-HTTP `agent-core` MCP surface with a self-contained stdio FastMCP proxy so a daemon bounce/refresh can no longer strand a live Claude Code agent session (issue #91).
+
+**Architecture:** A new `packages/agent-core-busproxy/` package runs a `FastMCPProxy` over **stdio**, backed by the daemon's per-agent HTTP endpoint (`http://127.0.0.1:8789/mcp/<agent>`) with a **fresh backend session per request**. Claude Code talks stdio to a process whose lifetime equals the Claude Code session; the backend session is reborn on every tool call, so a restarted daemon is never presented a stale `mcp-session-id`. A `TransientErrorMiddleware` converts backend-unreachable failures into a structured retryable tool result (fail-fast). The existing `agent-core-channel` wake relay is untouched.
+
+**Tech Stack:** Python 3.12+, uv workspace, FastMCP 3.2.2 (`fastmcp.server.providers.proxy.FastMCPProxy` / `ProxyClient`, `fastmcp.server.middleware.Middleware`, `fastmcp.tools.base.ToolResult`), Typer CLI, pytest (`asyncio_mode=auto`).
+
+**Reference spec:** `docs/superpowers/specs/2026-05-16-daemon-mcp-session-recovery-design.md`
+
+---
+
+## File Structure
+
+**New package — `packages/agent-core-busproxy/`:**
+
+- `pyproject.toml` — project metadata, `agent-core-busproxy` console script, hatchling build, deps.
+- `src/agent_core_busproxy/__init__.py` — empty package marker.
+- `src/agent_core_busproxy/transient.py` — `TransientErrorMiddleware`, `classify_backend_error`, `redact`, the transient-result builder + constants. One responsibility: turn backend-unreachable into a structured retryable tool result.
+- `src/agent_core_busproxy/proxy.py` — `build_busproxy(agent, daemon_url)` → a `FastMCPProxy` with a per-request client factory + the transient middleware attached. One responsibility: assemble the proxy.
+- `src/agent_core_busproxy/__main__.py` — Typer CLI (`--agent`, `--daemon-url`); runs the proxy over stdio. One responsibility: process entrypoint.
+- `tests/test_scaffold.py`, `tests/test_proxy_api_contract.py`, `tests/test_proxy_build.py`, `tests/test_transient.py`, `tests/test_down_window.py`, `tests/test_cli.py`, `tests/test_regression_daemon_bounce.py` — one test file per behavior.
+
+**Modified (existing):**
+
+- `pyproject.toml` (repo root) — add `agent-core-busproxy = { workspace = true }` under `[tool.uv.sources]`; add `"packages/agent-core-busproxy/tests"` to `[tool.pytest.ini_options].testpaths`.
+- `docs/setup/daemon.md` — replace the #91 stopgap warning with the resilient `.mcp.json` shape + behavior; add a cutover runbook.
+
+---
+
+## Task 1: Scaffold the `agent-core-busproxy` package
+
+**Files:**
+- Create: `packages/agent-core-busproxy/pyproject.toml`
+- Create: `packages/agent-core-busproxy/src/agent_core_busproxy/__init__.py`
+- Create: `packages/agent-core-busproxy/tests/test_scaffold.py`
+- Modify: `pyproject.toml` (repo root) — `[tool.uv.sources]` and `[tool.pytest.ini_options].testpaths`
+
+- [ ] **Step 1: Create the package `pyproject.toml`**
+
+Create `packages/agent-core-busproxy/pyproject.toml`:
+
+```toml
+[project]
+name = "agent-core-busproxy"
+version = "0.1.0"
+description = "Stdio MCP proxy — bridges Claude Code to the agent-core daemon bus tool surface with per-request backend sessions so a daemon bounce never strands the session."
+requires-python = ">=3.12"
+dependencies = [
+    "fastmcp>=3.2",
+    "mcp>=1.0",
+    "anyio>=4.0",
+    "httpx>=0.27",
+    "typer>=0.12",
+]
+
+[project.scripts]
+agent-core-busproxy = "agent_core_busproxy.__main__:app"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agent_core_busproxy"]
+```
+
+- [ ] **Step 2: Create the package marker**
+
+Create `packages/agent-core-busproxy/src/agent_core_busproxy/__init__.py`:
+
+```python
+"""agent-core-busproxy — stdio MCP proxy to the daemon bus tool surface."""
+```
+
+- [ ] **Step 3: Register the package in the workspace**
+
+In the repo-root `pyproject.toml`, under `[tool.uv.sources]`, add this line adjacent to the other `workspace = true` entries (e.g., right after the `agent-core-channel` line):
+
+```toml
+agent-core-busproxy = { workspace = true }
+```
+
+In the repo-root `pyproject.toml`, under `[tool.pytest.ini_options]`, add this entry to the `testpaths` array adjacent to the other `packages/agent-core-*/tests` entries:
+
+```toml
+    "packages/agent-core-busproxy/tests",
+```
+
+- [ ] **Step 4: Write the scaffold test**
+
+Create `packages/agent-core-busproxy/tests/test_scaffold.py`:
+
+```python
+"""Package scaffold smoke test."""
+
+from __future__ import annotations
+
+
+def test_package_imports() -> None:
+    import agent_core_busproxy
+
+    assert agent_core_busproxy.__doc__ is not None
+```
+
+- [ ] **Step 5: Sync the workspace and run the test**
+
+Run: `uv sync 2>&1 | tail -3 && uv run --package agent-core-busproxy pytest packages/agent-core-busproxy -q`
+Expected: `1 passed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agent-core-busproxy/pyproject.toml packages/agent-core-busproxy/src/agent_core_busproxy/__init__.py packages/agent-core-busproxy/tests/test_scaffold.py pyproject.toml
+git commit -m "feat(busproxy): scaffold agent-core-busproxy package (#91)"
+```
+
+---
+
+## Task 2: Pin the FastMCP proxy API with a characterization test
+
+The exact stdio-run call and the exact exception type raised when the backend URL is dead are FastMCP-version-specific. This task pins both against the installed `fastmcp` (3.2.2) with a real test, so later tasks use concrete names rather than guesses. This is API discovery that produces concrete code — not a placeholder.
+
+**Files:**
+- Create: `packages/agent-core-busproxy/tests/test_proxy_api_contract.py`
+
+- [ ] **Step 1: Write the characterization test**
+
+Create `packages/agent-core-busproxy/tests/test_proxy_api_contract.py`:
+
+```python
+"""Pin the installed FastMCP proxy API surface this package depends on.
+
+If FastMCP changes these, this test fails first and points at exactly
+what to update in proxy.py / transient.py.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+def test_fastmcpproxy_and_proxyclient_importable() -> None:
+    from fastmcp.server.providers.proxy import FastMCPProxy, ProxyClient
+
+    # FastMCPProxy takes a client_factory kwarg.
+    sig = inspect.signature(FastMCPProxy.__init__)
+    assert "client_factory" in sig.parameters
+
+    # ProxyClient accepts a URL string target and supports .new().
+    pc = ProxyClient("http://127.0.0.1:65535/mcp/nobody")
+    assert hasattr(pc, "new")
+
+
+def test_client_supports_init_timeout() -> None:
+    from fastmcp import Client
+
+    sig = inspect.signature(Client.__init__)
+    assert "init_timeout" in sig.parameters
+
+
+def test_middleware_has_on_call_tool() -> None:
+    from fastmcp.server.middleware import Middleware
+
+    assert hasattr(Middleware, "on_call_tool")
+
+
+def test_toolresult_accepts_structured_content() -> None:
+    from fastmcp.tools.base import ToolResult
+
+    r = ToolResult(structured_content={"error": "x", "transient": True})
+    assert r.structured_content == {"error": "x", "transient": True}
+
+
+@pytest.mark.asyncio
+async def test_client_surfaces_structured_content_attribute() -> None:
+    """Pin the CLIENT-side accessor: a tool returning ToolResult(
+    structured_content=...) is readable as result.structured_content.
+    Every later test asserts on this attribute."""
+    from fastmcp import Client, FastMCP
+    from fastmcp.tools.base import ToolResult
+
+    srv = FastMCP("pin")
+
+    @srv.tool()
+    async def t() -> ToolResult:
+        return ToolResult(structured_content={"transient": True})
+
+    async with Client(srv) as c:
+        res = await c.call_tool("t", {})
+
+    assert res.structured_content == {"transient": True}
+
+
+@pytest.mark.asyncio
+async def test_dead_backend_raises_on_tool_call() -> None:
+    """Calling a tool through a proxy whose backend is unreachable raises.
+
+    Records the concrete exception type so transient.py can catch it.
+    Port 65535 with nothing listening => connect failure.
+    """
+    from fastmcp import Client
+    from fastmcp.server.providers.proxy import FastMCPProxy, ProxyClient
+
+    base = ProxyClient("http://127.0.0.1:65535/mcp/nobody", init_timeout=2.0)
+    proxy = FastMCPProxy(client_factory=lambda: base.new(), name="probe")
+
+    with pytest.raises(BaseException) as excinfo:  # noqa: PT011 - characterizing
+        async with Client(proxy) as c:
+            await c.call_tool("list_endpoints", {})
+
+    # Concrete type pinned for transient.classify_backend_error.
+    # Assert it is NOT a clean MCP tool-result (i.e. the failure surfaces
+    # as an exception, which is what the middleware will intercept).
+    assert excinfo.value is not None
+    chain = []
+    e: BaseException | None = excinfo.value
+    while e is not None:
+        chain.append(type(e).__name__)
+        e = e.__cause__ or e.__context__
+    # Connection-class failure somewhere in the chain.
+    assert any(
+        n in chain
+        for n in (
+            "ConnectError",
+            "ConnectionError",
+            "ConnectTimeout",
+            "McpError",
+            "HTTPError",
+            "OSError",
+            "TimeoutError",
+        )
+    ), f"unexpected exception chain: {chain}"
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_proxy_api_contract.py -q`
+Expected: `6 passed`. If any assertion about the exception chain fails, read the printed `chain` and record the actual type names — those exact names are used in Task 4's `classify_backend_error`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent-core-busproxy/tests/test_proxy_api_contract.py
+git commit -m "test(busproxy): pin installed FastMCP proxy API contract (#91)"
+```
+
+---
+
+## Task 3: `proxy.py` — assemble the per-request proxy (tool-surface fidelity)
+
+**Files:**
+- Create: `packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py`
+- Create: `packages/agent-core-busproxy/tests/test_proxy_build.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-busproxy/tests/test_proxy_build.py`:
+
+```python
+"""build_busproxy assembles a proxy that mirrors the daemon tool surface."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client
+
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+from agent_core_busproxy.proxy import build_busproxy
+
+
+class _StubHandle:
+    async def ack(self, envelope_id: str) -> None: ...
+    async def publish(self, envelope, to=None) -> None: ...
+    async def nack(self, envelope_id, requeue=True) -> None: ...
+    def endpoints(self) -> list:
+        return []
+
+
+# The bus tool surface ClaudeCodeMCPEndpoint guarantees (see
+# claude_code_mcp.py _register_tools). Asserting these by name avoids
+# depending on any FastMCP-internal tool-enumeration API.
+_EXPECTED_BUS_TOOLS = {
+    "send",
+    "list_endpoints",
+    "describe_endpoint",
+    "list_pending",
+    "handle",
+    "ack",
+    "nack",
+    "consume",
+    "reply",
+    "peek",
+    "show_my_day",
+}
+
+
+@pytest.mark.asyncio
+async def test_proxy_mirrors_backend_tool_surface() -> None:
+    """tools/list through the proxy exposes the daemon endpoint's tools."""
+    backend = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    await backend.start(_StubHandle())  # type: ignore[arg-type]
+    try:
+        # Proxy pointed directly at the in-process backend server.
+        proxy = build_busproxy(agent="agent", daemon_url=None, _backend=backend._mcp)
+        async with Client(proxy) as c:
+            proxied = {t.name for t in await c.list_tools()}
+
+        missing = _EXPECTED_BUS_TOOLS - proxied
+        assert not missing, f"proxy missing bus tools: {missing}"
+    finally:
+        await backend.stop()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_proxy_build.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'agent_core_busproxy.proxy'`.
+
+- [ ] **Step 3: Implement `proxy.py`**
+
+Create `packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py`:
+
+```python
+"""Assemble the stdio bus proxy.
+
+The proxy forwards the daemon's per-agent MCP tool surface. Each tool
+call mints a FRESH backend session (ProxyClient.new()), so a restarted
+daemon is never presented a stale mcp-session-id — issue #91 is removed
+by construction, not by recovery logic.
+
+`init_timeout` keeps a down/bouncing daemon from hanging the call: the
+backend connect fails fast and the TransientErrorMiddleware (attached in
+Task 5) turns that into a structured retryable tool result.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp.server.providers.proxy import FastMCPProxy, ProxyClient
+
+# Fail-fast: a down daemon must not hang a tool call. Small connect/init
+# budget; the agent owns the retry decision (spec: fail-fast retryable).
+_BACKEND_INIT_TIMEOUT_SECONDS = 5.0
+# Per-call request budget once connected (a healthy daemon answers in ms;
+# this only bounds a half-open connection).
+_BACKEND_REQUEST_TIMEOUT_SECONDS = 60.0
+
+
+def build_busproxy(
+    *,
+    agent: str,
+    daemon_url: str | None,
+    _backend: Any | None = None,
+) -> FastMCPProxy:
+    """Return a FastMCPProxy over the daemon's per-agent endpoint.
+
+    Args:
+        agent: bus agent name (URL path segment).
+        daemon_url: e.g. ``http://127.0.0.1:8789``. Ignored when
+            ``_backend`` is supplied.
+        _backend: test seam — an in-process FastMCP server to proxy
+            instead of an HTTP URL. Production always passes a URL.
+    """
+    if _backend is not None:
+        base_client = ProxyClient(_backend)
+    else:
+        if not daemon_url:
+            raise ValueError("daemon_url is required when no _backend is given")
+        url = f"{daemon_url.rstrip('/')}/mcp/{agent}"
+        base_client = ProxyClient(
+            url,
+            init_timeout=_BACKEND_INIT_TIMEOUT_SECONDS,
+            timeout=_BACKEND_REQUEST_TIMEOUT_SECONDS,
+        )
+
+    def client_factory() -> Any:
+        # Fresh session per request — the #91 fix.
+        return base_client.new()
+
+    return FastMCPProxy(client_factory=client_factory, name=f"agent-core[{agent}]")
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_proxy_build.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py packages/agent-core-busproxy/tests/test_proxy_build.py
+git commit -m "feat(busproxy): build_busproxy with per-request backend sessions (#91)"
+```
+
+---
+
+## Task 4: `transient.py` — structured retryable error contract
+
+**Files:**
+- Create: `packages/agent-core-busproxy/src/agent_core_busproxy/transient.py`
+- Create: `packages/agent-core-busproxy/tests/test_transient.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-busproxy/tests/test_transient.py`:
+
+```python
+"""TransientErrorMiddleware: backend-down -> structured retryable result;
+genuine tool errors pass through verbatim."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastmcp.exceptions import ToolError
+
+from agent_core_busproxy.transient import (
+    TRANSIENT_ERROR_CODE,
+    TransientErrorMiddleware,
+    classify_backend_error,
+    redact,
+)
+
+
+def test_redact_strips_query_string() -> None:
+    # Same discipline as the #76 signed-CDN redaction.
+    assert redact("connect to https://cdn.example.com/x?sig=SECRET&t=9") == (
+        "connect to https://cdn.example.com/x?<redacted>"
+    )
+
+
+def test_classify_connection_error_is_transient() -> None:
+    assert classify_backend_error(httpx.ConnectError("refused")) is True
+    assert classify_backend_error(ConnectionError("refused")) is True
+    assert classify_backend_error(TimeoutError()) is True
+
+
+def test_classify_tool_error_is_not_transient() -> None:
+    assert classify_backend_error(ToolError("bad argument")) is False
+    assert classify_backend_error(ValueError("nope")) is False
+
+
+@pytest.mark.asyncio
+async def test_middleware_wraps_backend_down_as_structured_result() -> None:
+    mw = TransientErrorMiddleware()
+
+    async def call_next(_ctx):
+        raise httpx.ConnectError("Connection refused to http://h/x?token=ABC")
+
+    result = await mw.on_call_tool(object(), call_next)
+
+    assert result.structured_content["error"] == TRANSIENT_ERROR_CODE
+    assert result.structured_content["transient"] is True
+    assert isinstance(result.structured_content["retry_after_seconds"], int)
+    assert "token=ABC" not in result.structured_content["detail"]
+    assert "<redacted>" in result.structured_content["detail"]
+
+
+@pytest.mark.asyncio
+async def test_middleware_passes_genuine_tool_error_through() -> None:
+    mw = TransientErrorMiddleware()
+
+    async def call_next(_ctx):
+        raise ToolError("envelope_id not found")
+
+    with pytest.raises(ToolError, match="envelope_id not found"):
+        await mw.on_call_tool(object(), call_next)
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_transient.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'agent_core_busproxy.transient'`.
+
+- [ ] **Step 3: Implement `transient.py`**
+
+Create `packages/agent-core-busproxy/src/agent_core_busproxy/transient.py`:
+
+```python
+"""Translate backend-unreachable failures into a structured, retryable
+tool result. Genuine backend tool errors pass through verbatim so the
+agent never retry-loops on a real failure.
+
+Discriminator: a failure to *reach/handshake* the daemon (connect
+refused, connect/init timeout, transport drop, MCP protocol error from a
+missing session) is transient. An error the daemon itself raised while
+running the tool (ToolError / value errors surfaced as tool errors) is
+genuine and re-raised unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+import httpx
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import Middleware
+from fastmcp.tools.base import ToolResult
+from mcp.shared.exceptions import McpError
+
+log = logging.getLogger(__name__)
+
+TRANSIENT_ERROR_CODE = "bus_unavailable"
+_RETRY_AFTER_SECONDS = 5
+
+# Reuse the #76 redaction shape: drop the entire query string (signed CDN
+# tokens / session ids live there).
+_URL_QS_RE = re.compile(r"(https?://[^\s?]+)\?\S*")
+
+
+def redact(text: str) -> str:
+    """Strip query strings from any URLs in a human string."""
+    return _URL_QS_RE.sub(r"\1?<redacted>", text)
+
+
+# Genuine tool errors: the daemon connected and ran the tool, it failed.
+_GENUINE_TYPES: tuple[type[BaseException], ...] = (ToolError,)
+
+# Transient: could not reach / handshake the daemon.
+_TRANSIENT_TYPES: tuple[type[BaseException], ...] = (
+    httpx.HTTPError,
+    ConnectionError,
+    TimeoutError,
+    OSError,
+    McpError,
+)
+
+
+def classify_backend_error(exc: BaseException) -> bool:
+    """True => transient (daemon unreachable). False => genuine tool error."""
+    if isinstance(exc, _GENUINE_TYPES):
+        return False
+    if isinstance(exc, _TRANSIENT_TYPES):
+        return True
+    # Unknown: treat as genuine so real bugs are never masked as retryable.
+    return False
+
+
+def _transient_result(exc: BaseException) -> ToolResult:
+    detail = redact(f"{type(exc).__name__}: {exc}")
+    log.warning("busproxy: backend unavailable (transient): %s", detail)
+    return ToolResult(
+        structured_content={
+            "error": TRANSIENT_ERROR_CODE,
+            "transient": True,
+            "retry_after_seconds": _RETRY_AFTER_SECONDS,
+            "detail": detail,
+        }
+    )
+
+
+class TransientErrorMiddleware(Middleware):
+    """Intercept tool calls; map daemon-unreachable to a retryable result."""
+
+    async def on_call_tool(self, context: Any, call_next: Any) -> ToolResult:
+        try:
+            return await call_next(context)
+        except BaseException as exc:  # noqa: BLE001 - classify then re-raise
+            if classify_backend_error(exc):
+                return _transient_result(exc)
+            raise
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_transient.py -q`
+Expected: PASS (5 passed). If `test_classify_connection_error_is_transient` fails, the exception chain pinned in Task 2 Step 2 names the real type — add it to `_TRANSIENT_TYPES`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agent-core-busproxy/src/agent_core_busproxy/transient.py packages/agent-core-busproxy/tests/test_transient.py
+git commit -m "feat(busproxy): structured retryable transient-error contract (#91)"
+```
+
+---
+
+## Task 5: Wire the middleware into the proxy + down-window fail-fast test
+
+**Files:**
+- Modify: `packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py`
+- Create: `packages/agent-core-busproxy/tests/test_down_window.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-busproxy/tests/test_down_window.py`:
+
+```python
+"""Daemon-down window: a tool call returns the structured transient
+result PROMPTLY (fail-fast, no long hang)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastmcp import Client
+
+from agent_core_busproxy.proxy import build_busproxy
+from agent_core_busproxy.transient import TRANSIENT_ERROR_CODE
+
+
+@pytest.mark.asyncio
+async def test_dead_backend_returns_transient_result_fast() -> None:
+    # Nothing listening on 65535 => connect refused/timeout.
+    proxy = build_busproxy(agent="agent", daemon_url="http://127.0.0.1:65535")
+
+    async with Client(proxy) as c:
+        # Whole call must finish well under the 5s init budget * slack.
+        result = await asyncio.wait_for(
+            c.call_tool("list_endpoints", {}), timeout=15.0
+        )
+
+    assert result.structured_content["error"] == TRANSIENT_ERROR_CODE
+    assert result.structured_content["transient"] is True
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_down_window.py -q`
+Expected: FAIL — without the middleware the dead backend raises instead of returning the structured result (the assertion on `structured_content` fails, or the call raises).
+
+- [ ] **Step 3: Attach the middleware in `build_busproxy`**
+
+In `packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py`, add the import near the top with the other imports:
+
+```python
+from agent_core_busproxy.transient import TransientErrorMiddleware
+```
+
+Then change the final `return` of `build_busproxy` from:
+
+```python
+    return FastMCPProxy(client_factory=client_factory, name=f"agent-core[{agent}]")
+```
+
+to:
+
+```python
+    proxy = FastMCPProxy(client_factory=client_factory, name=f"agent-core[{agent}]")
+    proxy.add_middleware(TransientErrorMiddleware())
+    return proxy
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_down_window.py packages/agent-core-busproxy/tests/test_proxy_build.py -q`
+Expected: PASS (both — the middleware must not break the fidelity test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py packages/agent-core-busproxy/tests/test_down_window.py
+git commit -m "feat(busproxy): attach transient middleware; fail-fast down-window (#91)"
+```
+
+---
+
+## Task 6: `__main__.py` — stdio CLI entrypoint
+
+**Files:**
+- Create: `packages/agent-core-busproxy/src/agent_core_busproxy/__main__.py`
+- Create: `packages/agent-core-busproxy/tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-busproxy/tests/test_cli.py`:
+
+```python
+"""Smoke tests for the busproxy Typer CLI."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from agent_core_busproxy.__main__ import app
+
+
+def test_cli_help_runs() -> None:
+    result = CliRunner().invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "--agent" in result.output
+    assert "--daemon-url" in result.output
+
+
+def test_cli_requires_agent() -> None:
+    result = CliRunner().invoke(app, [])
+    assert result.exit_code != 0
+    assert (
+        "Missing option" in result.output
+        or "required" in result.output.lower()
+    )
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_cli.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'agent_core_busproxy.__main__'`.
+
+- [ ] **Step 3: Implement `__main__.py`**
+
+Create `packages/agent-core-busproxy/src/agent_core_busproxy/__main__.py`:
+
+```python
+"""Typer CLI for agent-core-busproxy.
+
+Runs a FastMCP proxy over stdio, backed by the daemon's per-agent HTTP
+endpoint. Spawned by Claude Code as a stdio MCP server; its lifetime is
+the Claude Code session, decoupled from the daemon's lifetime.
+"""
+
+from __future__ import annotations
+
+import anyio
+import typer
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def main(
+    agent: str = typer.Option(..., "--agent", help="Agent name on the bus."),
+    daemon_url: str = typer.Option(
+        "http://127.0.0.1:8789",
+        "--daemon-url",
+        help="agent-core daemon URL (default: http://127.0.0.1:8789).",
+    ),
+) -> None:
+    """Run the agent-core stdio bus proxy."""
+    from agent_core_busproxy.proxy import build_busproxy
+
+    proxy = build_busproxy(agent=agent, daemon_url=daemon_url)
+
+    async def _run() -> None:
+        await proxy.run_async(transport="stdio")
+
+    anyio.run(_run)
+
+
+if __name__ == "__main__":
+    app()
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_cli.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Verify the console script resolves**
+
+Run: `uv run agent-core-busproxy --help 2>&1 | tail -5`
+Expected: usage text containing `--agent` and `--daemon-url`. (If `run_async` rejects `transport="stdio"`, the Task 2 contract test's FastMCP version differs — read `FastMCP.run_async` signature in the installed source and use the documented stdio invocation; the default of `run_async()` is stdio.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agent-core-busproxy/src/agent_core_busproxy/__main__.py packages/agent-core-busproxy/tests/test_cli.py
+git commit -m "feat(busproxy): stdio Typer CLI entrypoint (#91)"
+```
+
+---
+
+## Task 7: #91 regression — survive a real daemon bounce
+
+This is the load-bearing proof. Stand up a real `ClaudeCodeMCPEndpoint` FastMCP server on an ephemeral TCP port (HTTP, exactly like the daemon), connect one long-lived busproxy `Client` to it, call a tool, **stop and restart** the backend server, then call again — it must succeed with no client-side re-handshake. Deterministic; no real sleeps (poll readiness with a short bounded loop).
+
+**Files:**
+- Create: `packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py`
+
+- [ ] **Step 1: Write the regression test**
+
+Create `packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py`:
+
+```python
+"""#91 regression: a daemon restart must not strand a live session.
+
+A long-lived busproxy Client stays connected across a full backend
+stop+start. Because every tool call mints a fresh backend session, the
+post-restart call succeeds without any client re-initialize.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+
+import pytest
+import uvicorn
+from fastmcp import Client
+
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+from agent_core_busproxy.proxy import build_busproxy
+
+
+class _StubHandle:
+    async def ack(self, envelope_id: str) -> None: ...
+    async def publish(self, envelope, to=None) -> None: ...
+    async def nack(self, envelope_id, requeue=True) -> None: ...
+    def endpoints(self) -> list:
+        return [type("E", (), {"name": "discord", "description": "d"})()]
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@contextlib.asynccontextmanager
+async def _run_backend(port: int):
+    """Serve a real ClaudeCodeMCPEndpoint over HTTP on `port`."""
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    await ep.start(_StubHandle())  # type: ignore[arg-type]
+    app = ep.asgi_app()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    # Bounded readiness poll (no fixed sleep).
+    for _ in range(100):
+        if server.started:
+            break
+        await asyncio.sleep(0.05)
+    try:
+        yield ep
+    finally:
+        server.should_exit = True
+        await task
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_session_survives_backend_bounce() -> None:
+    port = _free_port()
+    proxy = build_busproxy(
+        agent="agent", daemon_url=f"http://127.0.0.1:{port}"
+    )
+
+    async with Client(proxy) as client:  # one long-lived client
+        async with _run_backend(port):
+            r1 = await client.call_tool("list_endpoints", {})
+            assert any(e["name"] == "discord" for e in r1.data)
+
+        # Backend is now DOWN. A call here is the daemon-down window.
+        mid = await client.call_tool("list_endpoints", {})
+        assert mid.structured_content["transient"] is True
+
+        # Bring a brand-new backend process up on the same port.
+        async with _run_backend(port):
+            r2 = await client.call_tool("list_endpoints", {})
+            # Succeeds with NO client re-handshake — #91 fixed.
+            assert any(e["name"] == "discord" for e in r2.data)
+```
+
+- [ ] **Step 2: Ensure `uvicorn` is available to the test**
+
+`uvicorn` is already a transitive dep of the daemon HTTP host. Confirm it imports in the busproxy env:
+
+Run: `uv run --package agent-core-busproxy python -c "import uvicorn; print(uvicorn.__version__)"`
+Expected: a version prints. If `ModuleNotFoundError`, add `"uvicorn>=0.30"` to `packages/agent-core-busproxy/pyproject.toml` `dependencies`, re-run `uv sync`, and re-run this step.
+
+- [ ] **Step 3: Run the regression**
+
+Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py -q`
+Expected: PASS. This passing is the definition of #91 being fixed. If it hangs, the per-request session is not actually fresh — re-check `client_factory` calls `base_client.new()` per call (Task 3).
+
+- [ ] **Step 4: Run the whole package suite**
+
+Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy -q`
+Expected: all green.
+
+- [ ] **Step 5: Wake path untouched (regression)**
+
+This change adds a new package and does not modify `agent-core-channel`.
+Prove the wake relay still passes unchanged.
+
+Run: `uv run --package agent-core-channel pytest packages/agent-core-channel -q`
+Expected: all green (same count as before this branch — 93 passed at base).
+If anything fails, the change leaked outside its package — stop and fix.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py packages/agent-core-busproxy/pyproject.toml
+git commit -m "test(busproxy): #91 regression — session survives daemon bounce"
+```
+
+---
+
+## Task 8: Docs — replace the #91 stopgap, document the resilient `.mcp.json`
+
+**Files:**
+- Modify: `docs/setup/daemon.md` (the warning block added on the #79 branch)
+
+- [ ] **Step 1: Replace the stopgap warning**
+
+In `docs/setup/daemon.md`, find the block that begins:
+
+> **Live agent sessions must be restarted after a bounce.**
+
+Replace that entire block-quote with:
+
+```markdown
+> **Live agent sessions survive a bounce (#91).** Agents connect to the
+> bus tool surface through the `agent-core-busproxy` stdio MCP server
+> (not directly over HTTP). Each tool call mints a fresh backend session,
+> so `daemon refresh`/`install`/`start`/`stop` (and crashes) no longer
+> strand a live Claude Code session: in-flight calls during the down
+> window return a structured `{"error":"bus_unavailable","transient":true,
+> "retry_after_seconds":5}` result that the agent retries, and the next
+> call after the daemon is back succeeds with no session restart. The
+> `agent-core-channel` wake relay already reconnects on its own.
+```
+
+- [ ] **Step 2: Add the resilient `.mcp.json` shape**
+
+Append to `docs/setup/daemon.md` a new section:
+
+````markdown
+## Agent `.mcp.json` (resilient shape)
+
+Each agent's `<agent_root>/.mcp.json` must point the bus tool surface at
+the stdio busproxy — never the daemon HTTP URL directly:
+
+```json
+{
+  "mcpServers": {
+    "agent-core": {
+      "type": "stdio", "command": "uv",
+      "args": ["run", "--project", "<AGENT_CORE_REPO>",
+               "agent-core-busproxy", "--agent", "<AGENT>",
+               "--daemon-url", "http://127.0.0.1:8789"]
+    },
+    "agent-core-channel": {
+      "type": "stdio", "command": "uv",
+      "args": ["run", "--project", "<AGENT_CORE_REPO>",
+               "agent-core-channel", "--agent", "<AGENT>",
+               "--daemon-url", "http://127.0.0.1:8789"]
+    }
+  }
+}
+```
+
+Both surfaces are now stdio and reconnect independently. The old
+`{"type":"http","url":".../mcp/<agent>"}` form is the #91 failure mode —
+do not use it. Cut over per agent: a fresh/throwaway test agent first,
+validate across several real `daemon refresh` cycles, then Pepper last
+(rollback = restore the backed-up `.mcp.json`, a single file).
+````
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/setup/daemon.md
+git commit -m "docs(daemon): replace #91 stopgap with resilient busproxy .mcp.json (#91)"
+```
+
+---
+
+## Task 9: Manual acceptance + Claude Code respawn verification (operator-run — no commit)
+
+Final acceptance before close-out. Same shape as #79's manual step / #76 T7. The operator runs this; nothing is committed. Test agent first, Pepper last (per the standing hands-off rule).
+
+- [ ] **Step 1:** On a **fresh/throwaway test agent**, set `<agent_root>/.mcp.json` to the resilient shape from Task 8 Step 2 (back up the old file first). Start the agent's Claude Code session.
+- [ ] **Step 2:** Confirm the agent can call a bus tool (e.g. ask it to `list_endpoints` / `consume`) — baseline works through the busproxy.
+- [ ] **Step 3:** While that session stays open, run `uv run agent-core daemon refresh` (real bounce). Per #79's cache hazard, verify the daemon actually runs current code (check the installed file, not just the stamp).
+- [ ] **Step 4:** Without restarting the agent session, have the agent call a bus tool again. Expected: it succeeds (possibly after one `{transient:true}` retry during the down window) — **no session restart**. Repeat the refresh→call cycle 3× to cover slow refreshes.
+- [ ] **Step 5:** Confirm wake still works: send the test agent a message, confirm it wakes (the `agent-core-channel` path) and can read/reply via the busproxy.
+- [ ] **Step 6 (residual-SPOF verification, spec §Error handling item 3b):** Kill the busproxy *child process itself* (find it via the OS process list; it is a `uv run … agent-core-busproxy` child of the Claude Code session). Observe whether Claude Code re-spawns the stdio MCP server on the next tool call. Record the finding in `docs/setup/daemon.md` under the resilient-`.mcp.json` section: if Claude Code auto-respawns, state so; if not, document the operator action (restart the session) and note this is the seam the future always-on/reboot work must automate.
+- [ ] **Step 7:** Only after Steps 1–6 pass on the test agent: cut Pepper's `.mcp.json` over to the resilient shape (back up first), restart her session once, and re-run Steps 3–5 against her. Rollback if anything regresses (restore the backup, restart).
+- [ ] **Step 8:** Capture the test-agent transcript (a refresh-survived tool call + the down-window `{transient:true}` retry) as PR/issue acceptance evidence, then close #91.
+
+---
+
+## After all tasks: finish the branch
+
+Use **superpowers:finishing-a-development-branch**. Do not push/open/merge or cut Pepper's `.mcp.json` over without Jeff's explicit go-ahead — same gate as #79/#76. Task 9 is operator-run and gates close-out; #91 closes only after the test-agent validation passes.
+
+## Notes for the implementer
+
+- **DRY/YAGNI:** no shared/persistent backend session, no in-proxy retry/queue — per-request + fail-fast is the whole design (spec decisions 1–2).
+- **No real sleeps in tests:** all retry/backoff lives in the agent, not the proxy. Readiness is a bounded poll. (This avoids the looptime no-yield hang that bit #76 Task 5.)
+- **Self-contained package:** `agent-core-busproxy` never reaches into sibling-project venvs; it depends only on published deps + (in tests) the in-repo `agent-core` endpoint for a real backend.
+- **Redaction:** `detail` strips URL query strings (signed tokens/session ids) — same discipline as #76.
+- **Bus services are their own package:** mirrors `agent-core-channel`'s shape exactly.
+- **Wake×tool interleave — deliberate scoping:** the spec's testing list mentions an automated wake/tool interleave test. The two surfaces are independent OS processes with **no shared state** (busproxy = per-request sessions; channel relay = its own `/notify` SSE), so an automated interleave adds little over the per-surface tests (Tasks 5/7) + the channel suite staying green (Task 7 Step 5). The genuine end-to-end interleave is validated by the operator in Task 9 Step 5 (real wake + real busproxy tool call after a real refresh). This is a conscious YAGNI call, recorded here so it is not a silent gap.
+```

--- a/docs/superpowers/plans/2026-05-16-daemon-mcp-session-recovery.md
+++ b/docs/superpowers/plans/2026-05-16-daemon-mcp-session-recovery.md
@@ -10,6 +10,17 @@
 
 **Reference spec:** `docs/superpowers/specs/2026-05-16-daemon-mcp-session-recovery-design.md`
 
+> **Amendment 2026-05-16 (Task 2 spike finding — Tasks 3–5 revised below):**
+> Installed FastMCP 3.2.2 caches the backend tool list and *swallows* a
+> backend-down `list_*` into an empty registry → a tool call then raises
+> `ToolError("Unknown tool: …")`, **not** a transport error. `FastMCPProxy`
+> does not expose `cache_ttl`. Resolution (chosen): build the proxy as
+> `FastMCP` + `add_provider(ProxyProvider(client_factory, cache_ttl=<long>))`
+> (cache hardening), and make the middleware disambiguate a `ToolError` via a
+> fast daemon **liveness probe** (down → transient; up → genuine passthrough).
+> See the spec's "Amendment 2026-05-16" section. Tasks 3, 4, 5 below are the
+> revised versions; Tasks 1, 2, 6–9 are unchanged.
+
 ---
 
 ## File Structure
@@ -333,6 +344,16 @@ call mints a FRESH backend session (ProxyClient.new()), so a restarted
 daemon is never presented a stale mcp-session-id — issue #91 is removed
 by construction, not by recovery logic.
 
+Cache hardening (spec Amendment 2026-05-16): FastMCP's ProxyProvider
+caches the backend tool list and swallows a backend-down list into an
+EMPTY registry. We build the proxy via the documented lower-level
+pattern — FastMCP + add_provider(ProxyProvider(client_factory,
+cache_ttl=<long>)) — with a 24h cache_ttl so the tool palette survives
+any realistic daemon bounce. (FastMCPProxy hardcodes ProxyProvider with
+no cache_ttl passthrough, so it cannot be used here.) No active
+keepalive: a keepalive cannot help the cold-start-while-down edge, and a
+long TTL covers expiry (YAGNI).
+
 `init_timeout` keeps a down/bouncing daemon from hanging the call: the
 backend connect fails fast and the TransientErrorMiddleware (attached in
 Task 5) turns that into a structured retryable tool result.
@@ -342,7 +363,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastmcp.server.providers.proxy import FastMCPProxy, ProxyClient
+from fastmcp import FastMCP
+from fastmcp.server.providers.proxy import ProxyClient, ProxyProvider
 
 # Fail-fast: a down daemon must not hang a tool call. Small connect/init
 # budget; the agent owns the retry decision (spec: fail-fast retryable).
@@ -350,6 +372,9 @@ _BACKEND_INIT_TIMEOUT_SECONDS = 5.0
 # Per-call request budget once connected (a healthy daemon answers in ms;
 # this only bounds a half-open connection).
 _BACKEND_REQUEST_TIMEOUT_SECONDS = 60.0
+# Tool-list cache lifetime. Long enough that the palette survives any
+# realistic daemon bounce/refresh within a session (spec Amendment).
+_TOOL_CACHE_TTL_SECONDS = 86400.0
 
 
 def build_busproxy(
@@ -357,8 +382,8 @@ def build_busproxy(
     agent: str,
     daemon_url: str | None,
     _backend: Any | None = None,
-) -> FastMCPProxy:
-    """Return a FastMCPProxy over the daemon's per-agent endpoint.
+) -> FastMCP:
+    """Return a FastMCP proxy over the daemon's per-agent endpoint.
 
     Args:
         agent: bus agent name (URL path segment).
@@ -383,7 +408,11 @@ def build_busproxy(
         # Fresh session per request — the #91 fix.
         return base_client.new()
 
-    return FastMCPProxy(client_factory=client_factory, name=f"agent-core[{agent}]")
+    proxy = FastMCP(name=f"agent-core[{agent}]")
+    proxy.add_provider(
+        ProxyProvider(client_factory, cache_ttl=_TOOL_CACHE_TTL_SECONDS)
+    )
+    return proxy
 ```
 
 - [ ] **Step 4: Run it to verify it passes**
@@ -412,9 +441,18 @@ Create `packages/agent-core-busproxy/tests/test_transient.py`:
 
 ```python
 """TransientErrorMiddleware: backend-down -> structured retryable result;
-genuine tool errors pass through verbatim."""
+genuine tool errors pass through verbatim.
+
+Per spec Amendment 2026-05-16: a backend-down failure can surface either
+as a transport error (warm cache, per-request connect fails) OR as a
+ToolError("Unknown tool: ...") (empty registry because the list fetch
+was swallowed). The latter is AMBIGUOUS with a genuine unknown-tool /
+tool exception, so it is disambiguated with a fast daemon liveness probe.
+"""
 
 from __future__ import annotations
+
+import socket
 
 import httpx
 import pytest
@@ -422,8 +460,10 @@ from fastmcp.exceptions import ToolError
 
 from agent_core_busproxy.transient import (
     TRANSIENT_ERROR_CODE,
+    Disposition,
     TransientErrorMiddleware,
     classify_backend_error,
+    daemon_reachable,
     redact,
 )
 
@@ -435,20 +475,39 @@ def test_redact_strips_query_string() -> None:
     )
 
 
-def test_classify_connection_error_is_transient() -> None:
-    assert classify_backend_error(httpx.ConnectError("refused")) is True
-    assert classify_backend_error(ConnectionError("refused")) is True
-    assert classify_backend_error(TimeoutError()) is True
+def test_classify_transport_error_is_transient() -> None:
+    assert classify_backend_error(httpx.ConnectError("refused")) is Disposition.TRANSIENT
+    assert classify_backend_error(ConnectionError("refused")) is Disposition.TRANSIENT
+    assert classify_backend_error(TimeoutError()) is Disposition.TRANSIENT
 
 
-def test_classify_tool_error_is_not_transient() -> None:
-    assert classify_backend_error(ToolError("bad argument")) is False
-    assert classify_backend_error(ValueError("nope")) is False
+def test_classify_tool_error_is_ambiguous() -> None:
+    # Could be 'down -> empty registry' OR a real unknown-tool error.
+    assert classify_backend_error(ToolError("Unknown tool: x")) is Disposition.AMBIGUOUS
+
+
+def test_classify_unknown_is_genuine() -> None:
+    # Never mask an unrecognized error as retryable.
+    assert classify_backend_error(ValueError("nope")) is Disposition.GENUINE
 
 
 @pytest.mark.asyncio
-async def test_middleware_wraps_backend_down_as_structured_result() -> None:
-    mw = TransientErrorMiddleware()
+async def test_daemon_reachable_true_and_false() -> None:
+    srv = socket.socket()
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    host, port = srv.getsockname()
+    try:
+        assert await daemon_reachable(f"http://{host}:{port}") is True
+    finally:
+        srv.close()
+    # Nothing listening on 65535 => not reachable.
+    assert await daemon_reachable("http://127.0.0.1:65535") is False
+
+
+@pytest.mark.asyncio
+async def test_transport_error_becomes_transient_result() -> None:
+    mw = TransientErrorMiddleware(daemon_url="http://127.0.0.1:65535")
 
     async def call_next(_ctx):
         raise httpx.ConnectError("Connection refused to http://h/x?token=ABC")
@@ -463,8 +522,40 @@ async def test_middleware_wraps_backend_down_as_structured_result() -> None:
 
 
 @pytest.mark.asyncio
-async def test_middleware_passes_genuine_tool_error_through() -> None:
-    mw = TransientErrorMiddleware()
+async def test_toolerror_with_daemon_down_becomes_transient() -> None:
+    # 65535 unbound => probe says down => AMBIGUOUS resolves to transient.
+    mw = TransientErrorMiddleware(daemon_url="http://127.0.0.1:65535")
+
+    async def call_next(_ctx):
+        raise ToolError("Unknown tool: 'consume'")
+
+    result = await mw.on_call_tool(object(), call_next)
+    assert result.structured_content["transient"] is True
+
+
+@pytest.mark.asyncio
+async def test_toolerror_with_daemon_up_passes_through() -> None:
+    # A real listening socket => probe says reachable => genuine passthrough.
+    srv = socket.socket()
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    host, port = srv.getsockname()
+    try:
+        mw = TransientErrorMiddleware(daemon_url=f"http://{host}:{port}")
+
+        async def call_next(_ctx):
+            raise ToolError("envelope_id not found")
+
+        with pytest.raises(ToolError, match="envelope_id not found"):
+            await mw.on_call_tool(object(), call_next)
+    finally:
+        srv.close()
+
+
+@pytest.mark.asyncio
+async def test_no_daemon_url_treats_ambiguous_as_genuine() -> None:
+    # In-process/test path (no URL): cannot probe => do not mask as transient.
+    mw = TransientErrorMiddleware(daemon_url=None)
 
     async def call_next(_ctx):
         raise ToolError("envelope_id not found")
@@ -487,18 +578,28 @@ Create `packages/agent-core-busproxy/src/agent_core_busproxy/transient.py`:
 tool result. Genuine backend tool errors pass through verbatim so the
 agent never retry-loops on a real failure.
 
-Discriminator: a failure to *reach/handshake* the daemon (connect
-refused, connect/init timeout, transport drop, MCP protocol error from a
-missing session) is transient. An error the daemon itself raised while
-running the tool (ToolError / value errors surfaced as tool errors) is
-genuine and re-raised unchanged.
+Two backend-down shapes (spec Amendment 2026-05-16):
+  1. Transport error — warm tool cache, per-request connect to the dead
+     daemon fails. Unambiguously transient.
+  2. ToolError("Unknown tool: ...") — the tool-list fetch failed and
+     FastMCP's ProxyProvider/AggregateProvider swallowed it into an empty
+     registry. AMBIGUOUS: identical shape to a genuine unknown-tool / tool
+     exception from a HEALTHY daemon. Disambiguated with a fast TCP
+     liveness probe to the daemon: unreachable => transient; reachable =>
+     genuine, re-raised unchanged.
+
+Unknown exception types are treated as genuine — a real bug is never
+masked as retryable.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
+from enum import Enum
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from fastmcp.exceptions import ToolError
@@ -510,6 +611,7 @@ log = logging.getLogger(__name__)
 
 TRANSIENT_ERROR_CODE = "bus_unavailable"
 _RETRY_AFTER_SECONDS = 5
+_PROBE_TIMEOUT_SECONDS = 2.0
 
 # Reuse the #76 redaction shape: drop the entire query string (signed CDN
 # tokens / session ids live there).
@@ -521,10 +623,16 @@ def redact(text: str) -> str:
     return _URL_QS_RE.sub(r"\1?<redacted>", text)
 
 
-# Genuine tool errors: the daemon connected and ran the tool, it failed.
-_GENUINE_TYPES: tuple[type[BaseException], ...] = (ToolError,)
+class Disposition(Enum):
+    """How a backend exception should be handled."""
 
-# Transient: could not reach / handshake the daemon.
+    TRANSIENT = "transient"  # definitely daemon unreachable
+    GENUINE = "genuine"  # definitely a real error — re-raise
+    AMBIGUOUS = "ambiguous"  # could be either — probe the daemon to decide
+
+
+# Transport-class: could not reach / handshake the daemon. Definitely
+# transient. (ToolError is NOT in here — it is ambiguous, handled below.)
 _TRANSIENT_TYPES: tuple[type[BaseException], ...] = (
     httpx.HTTPError,
     ConnectionError,
@@ -534,14 +642,38 @@ _TRANSIENT_TYPES: tuple[type[BaseException], ...] = (
 )
 
 
-def classify_backend_error(exc: BaseException) -> bool:
-    """True => transient (daemon unreachable). False => genuine tool error."""
-    if isinstance(exc, _GENUINE_TYPES):
-        return False
+def classify_backend_error(exc: BaseException) -> Disposition:
+    """Triage a backend exception (see module docstring)."""
     if isinstance(exc, _TRANSIENT_TYPES):
-        return True
-    # Unknown: treat as genuine so real bugs are never masked as retryable.
-    return False
+        return Disposition.TRANSIENT
+    if isinstance(exc, ToolError):
+        return Disposition.AMBIGUOUS
+    return Disposition.GENUINE
+
+
+async def daemon_reachable(daemon_url: str) -> bool:
+    """Fast TCP liveness probe — can we open a socket to the daemon?
+
+    A bounced/down daemon has nothing listening on its port, so a refused
+    or timed-out connect means 'down'. Bounded by _PROBE_TIMEOUT_SECONDS
+    so it cannot itself hang a tool call.
+    """
+    parsed = urlparse(daemon_url)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 80
+    try:
+        fut = asyncio.open_connection(host, port)
+        _reader, writer = await asyncio.wait_for(
+            fut, timeout=_PROBE_TIMEOUT_SECONDS
+        )
+    except (OSError, asyncio.TimeoutError):
+        return False
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except Exception:  # noqa: BLE001 - close best-effort
+        pass
+    return True
 
 
 def _transient_result(exc: BaseException) -> ToolResult:
@@ -558,13 +690,27 @@ def _transient_result(exc: BaseException) -> ToolResult:
 
 
 class TransientErrorMiddleware(Middleware):
-    """Intercept tool calls; map daemon-unreachable to a retryable result."""
+    """Map daemon-unreachable to a retryable result; pass real errors through.
+
+    ``daemon_url`` is the liveness-probe target. ``None`` (the in-process
+    test path) disables probing — an AMBIGUOUS error is then treated as
+    genuine so a real error is never masked when we cannot verify.
+    """
+
+    def __init__(self, daemon_url: str | None = None) -> None:
+        self._daemon_url = daemon_url
 
     async def on_call_tool(self, context: Any, call_next: Any) -> ToolResult:
         try:
             return await call_next(context)
-        except BaseException as exc:  # noqa: BLE001 - classify then re-raise
-            if classify_backend_error(exc):
+        except BaseException as exc:  # noqa: BLE001 - triage then re-raise
+            disposition = classify_backend_error(exc)
+            if disposition is Disposition.TRANSIENT:
+                return _transient_result(exc)
+            if disposition is Disposition.AMBIGUOUS and (
+                self._daemon_url is not None
+                and not await daemon_reachable(self._daemon_url)
+            ):
                 return _transient_result(exc)
             raise
 ```
@@ -572,7 +718,7 @@ class TransientErrorMiddleware(Middleware):
 - [ ] **Step 4: Run it to verify it passes**
 
 Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_transient.py -q`
-Expected: PASS (5 passed). If `test_classify_connection_error_is_transient` fails, the exception chain pinned in Task 2 Step 2 names the real type — add it to `_TRANSIENT_TYPES`.
+Expected: PASS (9 passed). If a transport-class assertion fails, the exception chain pinned in Task 2 names the real type — add it to `_TRANSIENT_TYPES`. The probe tests bind an ephemeral localhost socket; if a sandbox forbids `listen()`, note it and fall back to asserting only the `65535`-unreachable direction.
 
 - [ ] **Step 5: Commit**
 
@@ -626,7 +772,7 @@ async def test_dead_backend_returns_transient_result_fast() -> None:
 - [ ] **Step 2: Run it to verify it fails**
 
 Run: `uv run --package agent-core-busproxy pytest packages/agent-core-busproxy/tests/test_down_window.py -q`
-Expected: FAIL — without the middleware the dead backend raises instead of returning the structured result (the assertion on `structured_content` fails, or the call raises).
+Expected: FAIL — without the middleware the dead backend surfaces as a raised `ToolError("Unknown tool: …")` (empty registry — spec Amendment), so the call raises instead of returning the structured transient result.
 
 - [ ] **Step 3: Attach the middleware in `build_busproxy`**
 
@@ -636,17 +782,26 @@ In `packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py`, add the impo
 from agent_core_busproxy.transient import TransientErrorMiddleware
 ```
 
-Then change the final `return` of `build_busproxy` from:
+Then change the final three lines of `build_busproxy` from:
 
 ```python
-    return FastMCPProxy(client_factory=client_factory, name=f"agent-core[{agent}]")
+    proxy = FastMCP(name=f"agent-core[{agent}]")
+    proxy.add_provider(
+        ProxyProvider(client_factory, cache_ttl=_TOOL_CACHE_TTL_SECONDS)
+    )
+    return proxy
 ```
 
 to:
 
 ```python
-    proxy = FastMCPProxy(client_factory=client_factory, name=f"agent-core[{agent}]")
-    proxy.add_middleware(TransientErrorMiddleware())
+    proxy = FastMCP(name=f"agent-core[{agent}]")
+    proxy.add_provider(
+        ProxyProvider(client_factory, cache_ttl=_TOOL_CACHE_TTL_SECONDS)
+    )
+    # daemon_url is the middleware's liveness-probe target. None on the
+    # in-process test path => probing disabled (ambiguous => genuine).
+    proxy.add_middleware(TransientErrorMiddleware(daemon_url=daemon_url))
     return proxy
 ```
 
@@ -771,6 +926,16 @@ git commit -m "feat(busproxy): stdio Typer CLI entrypoint (#91)"
 ## Task 7: #91 regression — survive a real daemon bounce
 
 This is the load-bearing proof. Stand up a real `ClaudeCodeMCPEndpoint` FastMCP server on an ephemeral TCP port (HTTP, exactly like the daemon), connect one long-lived busproxy `Client` to it, call a tool, **stop and restart** the backend server, then call again — it must succeed with no client-side re-handshake. Deterministic; no real sleeps (poll readiness with a short bounded loop).
+
+> **Expected internal path (post-Amendment):** `r1` (backend up) populates
+> the 24h tool-list cache. The `mid` call (backend down) resolves the tool
+> from the warm cache, opens a fresh per-request session, the connect
+> fails → a **transport-class** error → middleware's TRANSIENT branch (no
+> probe needed) → `{transient:true}`. `r2` (backend back) opens a fresh
+> session and succeeds. If `mid` instead surfaces as a `ToolError`, the
+> middleware's liveness probe still resolves it to transient — either way
+> the assertion holds. Do not "fix" the test if the internal path differs;
+> only the observable assertions matter.
 
 **Files:**
 - Create: `packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py`

--- a/docs/superpowers/plans/2026-05-16-daemon-mcp-session-recovery.md
+++ b/docs/superpowers/plans/2026-05-16-daemon-mcp-session-recovery.md
@@ -936,6 +936,20 @@ This is the load-bearing proof. Stand up a real `ClaudeCodeMCPEndpoint` FastMCP 
 > middleware's liveness probe still resolves it to transient — either way
 > the assertion holds. Do not "fix" the test if the internal path differs;
 > only the observable assertions matter.
+>
+> **Harness fidelity (corrected 2026-05-16 during impl):** the backend is
+> served through the **real `agent_core.bus.http_host.HTTPHost`**, not a
+> hand-rolled `uvicorn.Config(ep.asgi_app())`. The daemon mounts each
+> endpoint under its `.mount` path (`/mcp/<agent>`) via Starlette `Mount`
+> + a trailing-slash shim, and runs FastMCP's session-manager lifespan.
+> `build_busproxy` connects to `…/mcp/agent` (production-correct), so a
+> bare-root mount 404s every request ("Session terminated" → empty
+> registry → `Unknown tool`) and the hand-rolled server skipped the
+> session-manager lifespan. Using `HTTPHost` reproduces the production
+> HTTP shape exactly. The client is opened **while the first backend is
+> up** and kept open across the stop+start (one long-lived `Client` — the
+> #91 property), via explicit enter/exit so its lifetime crosscuts the
+> backend's.
 
 **Files:**
 - Create: `packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py`
@@ -947,21 +961,24 @@ Create `packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py`:
 ```python
 """#91 regression: a daemon restart must not strand a live session.
 
-A long-lived busproxy Client stays connected across a full backend
-stop+start. Because every tool call mints a fresh backend session, the
-post-restart call succeeds without any client re-initialize.
+A single long-lived busproxy Client stays connected across a full
+backend stop+start. Because every tool call mints a fresh backend
+session, the post-restart call succeeds without any client re-init.
+
+The backend is served through the production HTTPHost so the per-agent
+mount path (/mcp/agent), trailing-slash routing, and FastMCP session-
+manager lifespan exactly match the real daemon.
 """
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import socket
 
 import pytest
-import uvicorn
 from fastmcp import Client
 
+from agent_core.bus.http_host import HTTPHost
 from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
 from agent_core_busproxy.proxy import build_busproxy
 
@@ -984,55 +1001,65 @@ def _free_port() -> int:
 
 @contextlib.asynccontextmanager
 async def _run_backend(port: int):
-    """Serve a real ClaudeCodeMCPEndpoint over HTTP on `port`."""
+    """Serve a real ClaudeCodeMCPEndpoint via the production HTTPHost.
+
+    HTTPHost mounts the endpoint at its `.mount` path (/mcp/agent) with
+    the trailing-slash shim and runs FastMCP's session-manager lifespan
+    — the exact HTTP shape the real daemon presents, so the proxy's
+    production URL path is exercised faithfully.
+    """
     ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
     await ep.start(_StubHandle())  # type: ignore[arg-type]
-    app = ep.asgi_app()
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
-    server = uvicorn.Server(config)
-    task = asyncio.create_task(server.serve())
-    # Bounded readiness poll (no fixed sleep).
-    for _ in range(100):
-        if server.started:
-            break
-        await asyncio.sleep(0.05)
+    host = HTTPHost(bind_host="127.0.0.1", bind_port=port)
+    host.mount(ep)
+    await host.start()
     try:
         yield ep
     finally:
-        server.should_exit = True
-        await task
+        await host.stop()
         await ep.stop()
 
 
 @pytest.mark.asyncio
 async def test_session_survives_backend_bounce() -> None:
     port = _free_port()
-    proxy = build_busproxy(
-        agent="agent", daemon_url=f"http://127.0.0.1:{port}"
-    )
+    proxy = build_busproxy(agent="agent", daemon_url=f"http://127.0.0.1:{port}")
 
-    async with Client(proxy) as client:  # one long-lived client
-        async with _run_backend(port):
+    # The client must be created while a backend is UP and then OUTLIVE a
+    # full backend stop+start — that crosscut is the whole #91 property,
+    # so the backend context is entered/exited explicitly rather than
+    # nested inside the client's `async with`.
+    backend = _run_backend(port)
+    await backend.__aenter__()  # backend #1 UP
+    entered_first = True
+    try:
+        async with Client(proxy) as client:  # one long-lived client
             r1 = await client.call_tool("list_endpoints", {})
             assert any(e["name"] == "discord" for e in r1.data)
 
-        # Backend is now DOWN. A call here is the daemon-down window.
-        mid = await client.call_tool("list_endpoints", {})
-        assert mid.structured_content["transient"] is True
+            await backend.__aexit__(None, None, None)  # backend DOWN
+            entered_first = False
 
-        # Bring a brand-new backend process up on the same port.
-        async with _run_backend(port):
-            r2 = await client.call_tool("list_endpoints", {})
-            # Succeeds with NO client re-handshake — #91 fixed.
-            assert any(e["name"] == "discord" for e in r2.data)
+            # Daemon-down window: same client, no re-handshake.
+            mid = await client.call_tool("list_endpoints", {})
+            assert mid.structured_content["transient"] is True
+
+            # Brand-new backend on the same port; SAME client.
+            async with _run_backend(port):
+                r2 = await client.call_tool("list_endpoints", {})
+                # Succeeds with NO client re-handshake — #91 fixed.
+                assert any(e["name"] == "discord" for e in r2.data)
+    finally:
+        if entered_first:
+            await backend.__aexit__(None, None, None)
 ```
 
-- [ ] **Step 2: Ensure `uvicorn` is available to the test**
+- [ ] **Step 2: Confirm `HTTPHost` is importable in the workspace env**
 
-`uvicorn` is already a transitive dep of the daemon HTTP host. Confirm it imports in the busproxy env:
+The test imports `agent_core.bus.http_host.HTTPHost` and `agent_core.endpoints.claude_code_mcp.ClaudeCodeMCPEndpoint` — both come from the in-repo `agent-core` package, available in the shared uv workspace venv at test time (the busproxy package does NOT declare `agent-core`/`uvicorn` as its own deps and must NOT — they are test-only, satisfied by the workspace venv, like `agent-core-channel`'s tests do).
 
-Run: `uv run --package agent-core-busproxy python -c "import uvicorn; print(uvicorn.__version__)"`
-Expected: a version prints. If `ModuleNotFoundError`, add `"uvicorn>=0.30"` to `packages/agent-core-busproxy/pyproject.toml` `dependencies`, re-run `uv sync`, and re-run this step.
+Run: `uv run --package agent-core-busproxy python -c "from agent_core.bus.http_host import HTTPHost; print('ok', HTTPHost.__name__)"`
+Expected: `ok HTTPHost`. (No pyproject change — do NOT add agent-core/uvicorn to busproxy deps.)
 
 - [ ] **Step 3: Run the regression**
 
@@ -1056,9 +1083,14 @@ If anything fails, the change leaked outside its package — stop and fix.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py packages/agent-core-busproxy/pyproject.toml
+git add packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py uv.lock
 git commit -m "test(busproxy): #91 regression — session survives daemon bounce"
 ```
+
+(`uv.lock` carries the legitimate workspace lock entry for the new
+`agent-core-busproxy` package — accumulated from Task 1's registration,
+not secrets/unrelated churn. Stage it explicitly; do NOT `git add -A`.
+Do NOT add `uvicorn`/`agent-core` to the busproxy `pyproject.toml`.)
 
 ---
 

--- a/docs/superpowers/specs/2026-05-16-daemon-mcp-session-recovery-design.md
+++ b/docs/superpowers/specs/2026-05-16-daemon-mcp-session-recovery-design.md
@@ -249,6 +249,48 @@ and respawn behaviour explicitly verified in the plan.
   the substrate any auto-relaunched agent depends on.
 - **#76** — reuses the URL/token redaction discipline for `detail`.
 
+## Amendment 2026-05-16 (discovered during implementation, Task 2 spike)
+
+The Task 2 characterization test against installed FastMCP 3.2.2 invalidated
+one premise in *Library facts* / *Error handling*: a down daemon does **not**
+reliably surface as a connection error.
+
+- `FastMCPProxy` wraps a `ProxyProvider` that **caches the backend component
+  list** (default TTL 300s) and, via `AggregateProvider`, **swallows** a
+  failed backend `list_*` (logs, returns empty) instead of raising. A tool
+  call against an empty registry raises `ToolError("Unknown tool: …")`, not a
+  transport error. `FastMCPProxy.__init__` hardcodes `ProxyProvider(
+  client_factory)` with no `cache_ttl` passthrough.
+- **Severity:** the routine #91 case (tool list discovered while healthy →
+  `daemon refresh` bounce → call) is unaffected — the tool resolves from the
+  warm cache and the per-request session hits the daemon directly, yielding a
+  real transport error in the down window (classified transient) and success
+  once back. The gap is the edges: cold start while the daemon is down, an
+  outage longer than the cache TTL, or `tools/list` landing in the down
+  window — these degrade to `ToolError("Unknown tool")`.
+
+**Resolution (chosen 2026-05-16 — "smarter classifier + cache hardening"):**
+
+1. **Cache hardening.** Build the proxy with the documented lower-level
+   pattern — `FastMCP(name=…)` + `add_provider(ProxyProvider(client_factory,
+   cache_ttl=<long>))` — instead of `FastMCPProxy(...)`, with a long
+   `cache_ttl` (24h) so the tool palette survives any realistic bounce. No
+   active keepalive (YAGNI: a keepalive cannot help cold-start-while-down,
+   and a long TTL covers expiry).
+2. **Smarter classifier.** `TransientErrorMiddleware` keeps the
+   transport-error → transient rule, and additionally disambiguates a
+   `ToolError` / empty-registry failure with a fast daemon **liveness probe**
+   (async TCP connect to the daemon host:port, ~2s budget): unreachable →
+   structured `{transient:true}`; reachable → genuine, re-raise unchanged
+   (a real unknown-tool / tool exception is never masked as retryable).
+
+This stays within the approved architecture (still a FastMCP proxy, per-
+request sessions, fail-fast retryable, wake path untouched). Residual: the
+cold-start-while-daemon-down edge still returns transient and recovers once
+the daemon is back and a tool list succeeds — this is the same surface as the
+spec's already-acknowledged residual SPOF (Task 9 respawn/relist
+verification).
+
 ## Provenance
 
 #91 surfaced 2026-05-15 by Pepper from inside the affected session during the

--- a/docs/superpowers/specs/2026-05-16-daemon-mcp-session-recovery-design.md
+++ b/docs/superpowers/specs/2026-05-16-daemon-mcp-session-recovery-design.md
@@ -1,0 +1,255 @@
+# Daemon Bounce MCP Session Recovery — Design
+
+**Issue:** [#91](https://github.com/jeffrichley/agent_core/issues/91) — Daemon
+bounce orphans the live Claude Code MCP client session; no recovery without a
+full session restart.
+
+**Status:** Approved design (2026-05-16). Next: implementation plan.
+
+---
+
+## Problem
+
+A daemon restart (`daemon stop`/`start`, the new `daemon refresh`/`install`
+from #79, or a crash) permanently strands any already-connected, long-lived
+Claude Code agent session. Every subsequent MCP tool call fails with
+`Session not found`. The session cannot self-recover — not by retry, not by
+`/mcp reconnect`. The only fix today is a full restart of that Claude Code
+session.
+
+With #79 making `daemon refresh` the **daily** code-pickup flow, this failure
+goes from occasional to routine. It is also a hard prerequisite for the
+always-on / reboot-resilience goal: any auto-relaunched agent must survive a
+daemon bounce.
+
+## Root cause
+
+MCP over streamable-HTTP is session-based. On connect the client runs an
+`initialize` handshake and the daemon issues an `mcp-session-id`; the client
+caches it and presents it on every later call. A restarted daemon is a new
+process with no memory of prior session IDs (sessions are in-process state in
+`ClaudeCodeMCPEndpoint`, not persisted). The still-running client keeps
+presenting the stale ID; the new process rejects every call with
+`Session not found`. Claude Code's MCP client does not re-`initialize` on
+`Session not found`, and `/mcp reconnect` does not force a fresh handshake.
+
+The fragility is isolated to **one of the agent's two MCP surfaces**:
+
+| `.mcp.json` entry | Transport | Role | Behaviour on daemon bounce |
+|---|---|---|---|
+| `agent-core` | streamable-HTTP, direct to daemon | bus tool surface (`send`/`consume`/`reply`/`list_pending`/…) | **stranded** — stale `mcp-session-id` (this *is* #91) |
+| `agent-core-channel` | stdio child process | push-wake relay (`/notify/<agent>` SSE → inline render) | **already resilient** — `sse_client.py` reconnects forever with backoff |
+
+The wake path already survives bounces (confirmed in the 2026-05-15 incident).
+Only the direct-HTTP tool surface is broken.
+
+## Decisions
+
+Settled during brainstorming:
+
+1. **Recovery bar: fully transparent.** After a daemon bounce/refresh the live
+   session keeps working with zero human action and no session restart.
+2. **Down-window behaviour: fail-fast, retryable.** When the daemon is
+   unreachable mid-refresh, a tool call returns a structured transient error
+   immediately; the agent owns the retry decision. No in-proxy hang/queue.
+3. **Surface count: A1 — two stdio entries.** Replace the fragile direct-HTTP
+   `agent-core` entry with a stdio proxy; leave `agent-core-channel` as-is.
+   Both surfaces become stdio and resilient — the *asymmetry* that is #91 is
+   eliminated. Folding both into a single MCP server (A2) was rejected: it
+   couples wake-rendering with tool-proxying and departs from FastMCP's native
+   proxy shape for only a cosmetic "one entry" gain (two servers is not
+   cognitively harder for the agent — tools are tools regardless of backing
+   server).
+4. **Rollout: test agent first, Pepper last** — per the standing
+   "Pepper hands-off until proven" rule.
+
+## Library facts (verified via context7, FastMCP `/prefecthq/fastmcp`)
+
+- `fastmcp.server.create_proxy(backend, name)` forwards all requests to an MCP
+  backend (URL / FastMCP instance / script / MCPConfig) and can be run over
+  **stdio** (`proxy.run()` defaults to stdio) — the documented
+  "bridge HTTP backend to local stdio for Claude Desktop" pattern, which is
+  exactly our scenario.
+- Default mode mints a **fresh backend session per request** (session
+  isolation). This is the load-bearing property: there is no long-lived
+  `mcp-session-id` to go stale, so a daemon bounce cannot strand the proxy.
+- `tools/list` / `tools/call` are forwarded natively (the "dynamic
+  passthrough" is built in, not hand-rolled); standard MCP feature
+  notifications (sampling/logging/progress/…) are forwarded.
+- The docs do **not** promise forwarding of *arbitrary custom* server→client
+  notification methods. Our wake (`notifications/claude/channel`) is custom
+  and rides a persistent SSE stream — so wake stays on the existing
+  `agent-core-channel` `/notify` path and is **not** routed through the proxy.
+- Explicit session control is available via
+  `FastMCPProxy(client_factory=…)` returning `ProxyClient(backend)` — this is
+  the seam for per-request sessions + error translation.
+
+## Architecture
+
+```
+Claude Code (agent session)
+  ├── MCP server "agent-core"          ── stdio ──>  agent-core-busproxy (NEW)
+  │                                                     │  per-request
+  │                                                     │  fresh session
+  │                                                     ▼
+  │                                          daemon  http://127.0.0.1:8789/mcp/<agent>
+  │                                                     ▲
+  └── MCP server "agent-core-channel"  ── stdio ──>  channel relay (UNCHANGED)
+                                                        │  SSE, reconnects forever
+                                                        ▼
+                                          daemon  /notify/<agent>
+```
+
+- **Tool surface → stdio FastMCP proxy.** `.mcp.json` `agent-core` changes
+  from `{"type":"http","url":".../mcp/<agent>"}` to a stdio command running
+  the busproxy against `http://127.0.0.1:8789/mcp/<agent>` with per-request
+  backend sessions. Claude Code ⇄ stdio busproxy (lifetime = the Claude Code
+  session; never dies on a bounce) ⇄ fresh HTTP session to whatever daemon is
+  currently up.
+- **Wake surface → unchanged.** `agent-core-channel` keeps its `/notify`
+  subscription via `sse_client.py` (already reconnects across bounces).
+
+#91 is eliminated **by construction**, not by recovery logic: no stale
+session id ever exists.
+
+## Components
+
+1. **`agent-core-busproxy` — new, self-contained package**
+   (`packages/agent-core-busproxy/`, mirroring `agent-core-channel`'s shape;
+   per the "bus services are their own package, never reach into sibling
+   venvs" rule). A thin stdio MCP server = `FastMCP` proxy over
+   `http://127.0.0.1:8789/mcp/<agent>`. CLI:
+   `agent-core-busproxy --agent <name> --daemon-url http://127.0.0.1:8789`
+   (same arg shape as the channel relay).
+
+2. **`client_factory` seam.** `FastMCPProxy(client_factory=…)` mints a fresh
+   `ProxyClient` per request (FastMCP's recommended isolation mode). Single
+   place where daemon-down is caught and translated.
+
+3. **Transient-error contract.** On backend connect/handshake/transport
+   failure the proxy returns a structured tool result:
+   `{"error": "bus_unavailable", "transient": true,
+   "retry_after_seconds": <n>, "detail": "<redacted reason>"}`.
+   A genuine backend tool exception forwards through **verbatim** and is
+   **not** relabeled transient. `detail` is redacted (no signed URLs/tokens —
+   same discipline as the #76 redaction work).
+
+4. **`.mcp.json` template + per-agent cutover.** The canonical per-agent
+   template swaps the `agent-core` `{"type":"http",…}` block for the stdio
+   busproxy command; `agent-core-channel` untouched. Applied per agent
+   (test agent first, Pepper last).
+
+**Explicitly out of scope (YAGNI):** no shared/persistent backend session
+(per-request is the safe default; revisit only if localhost handshake latency
+ever bites); no in-proxy retry/queue (fail-fast — the agent owns retry).
+
+## Data flow
+
+- **Steady state (no call in flight):** there is *no* persistent MCP session
+  for the agent — and that is correct. The daemon's
+  `ClaudeCodeMCPEndpoint.deliver()` already handles "no session connected":
+  it queues the envelope and raises `EndpointUnavailable` (bus redelivers),
+  while `_notify_mail_arrived` fans out to the broker → `/notify/<agent>`.
+  "No live MCP session" becomes the *normal* resting state, not a failure.
+- **Wake:** envelope → daemon queues + publishes to `/notify/<agent>` →
+  unchanged channel relay injects the wake. (Unchanged path.)
+- **Tool call:** Claude Code → stdio → busproxy → `client_factory` mints a
+  fresh `ProxyClient` → new `initialize` + session against the currently
+  running daemon → `tools/call` forwarded → result → backend session closes.
+  Next call repeats with a brand-new session.
+- **Across `daemon refresh`:** if a call lands while the daemon is down, the
+  per-request connect fails → busproxy returns the transient error → agent
+  retries → by retry the new daemon is up → fresh session succeeds. The stdio
+  pipe never broke; the channel relay reconnected its SSE on its own.
+
+**Key invariant:** the busproxy holds no cross-call state. Every tool call is
+independent and self-contained — which is exactly why a backend restart
+cannot strand it.
+
+## Error handling & self-healing
+
+1. **Backend errors never crash the proxy.** Every forwarded call wraps
+   backend connect/handshake/transport failures and returns the structured
+   transient result. A daemon-down or mid-refresh state produces a *tool
+   error*, never a process exit. This invariant is what makes the structural
+   self-healing hold.
+2. **Genuine tool errors pass through verbatim** — not relabeled transient,
+   so the agent never retry-loops on a real failure.
+3. **Residual single point of failure — the stdio child's own liveness.**
+   The busproxy (and the channel relay) are children Claude Code spawns. A
+   daemon *bounce* is fully self-healing by construction. A *crash of the
+   busproxy process itself* (a proxy bug/OOM, not a daemon fault) depends on
+   Claude Code re-spawning stdio MCP servers. Hardening:
+   (a) the proxy is deliberately thin with a broad top-level guard so a
+   daemon fault cannot propagate to a process crash;
+   (b) **plan-stage verification task:** confirm Claude Code's stdio-server
+   respawn behaviour; if it does not auto-respawn, document/automate it. This
+   is also the seam the future always-on/reboot work plugs into.
+4. **No silent degradation.** Transient errors are logged with a redacted
+   reason so a *persistently* down daemon is diagnosable rather than an
+   infinite quiet retry.
+
+**Honest summary:** the daemon-bounce case (the actual #91) is zero-touch
+self-healing by construction. The only residual that still needs a human (or
+future automation) is a crash of the stdio child itself — surface minimized
+and respawn behaviour explicitly verified in the plan.
+
+## Testing strategy
+
+1. **Transient-error contract (unit).** Backend connect/handshake failure →
+   asserts structured `{transient:true,…}` result, reason redacted. Genuine
+   backend tool exception → asserts verbatim passthrough, **not** relabeled
+   transient. Fake backend mirrors real FastMCP refusal semantics strictly
+   (test-fakes-mirror-real rule) so green tests cannot mask a real-lib gap.
+2. **#91 regression (the proof).** One long-lived busproxy process: call a
+   tool (succeeds) → stop & restart the backend daemon → call again →
+   succeeds with no client-side re-handshake. Deterministic (in-process or
+   ephemeral-port backend, **no real sleeps** — all backoff stays in the
+   agent, not the proxy, avoiding the looptime no-yield pitfall from #76 T5).
+   This test failing == #91 not fixed.
+3. **Down-window (fail-fast).** Backend unreachable → call returns the
+   transient error promptly (asserts no long hang) → backend back → next call
+   succeeds.
+4. **Tool-surface fidelity.** `tools/list` through the proxy == daemon's real
+   surface; `notifications/tools/list_changed` (briefs plugin fires it)
+   propagates so the agent re-enumerates.
+5. **Wake untouched (regression).** `agent-core-channel`'s existing suite
+   stays green; an interleave test confirms wake (`/notify`) + tool calls
+   coexist with per-request sessions and the daemon's no-session
+   `EndpointUnavailable` path.
+6. **Manual acceptance.** Real test agent, real `daemon refresh`, zero-touch
+   tool survival — runbook step the operator runs (same shape as #76 T7 /
+   #79's manual step).
+
+## Rollout & cutover
+
+1. **Build phase (zero agents touched).** Ship `packages/agent-core-busproxy/`
+   + test suite. No `.mcp.json` changes yet — pure addition, no blast radius.
+2. **Test-agent validation gate.** A fresh throwaway agent gets the new
+   shape. Bar: multiple real `daemon refresh` / `stop`+`start` cycles,
+   asserting zero-touch tool survival *and* wake delivery across each, over a
+   realistic span — not a single happy-path bounce.
+3. **Pepper cutover (only after the gate passes).** Swap Pepper's `.mcp.json`
+   `agent-core` block to the stdio busproxy command; `agent-core-channel`
+   untouched. Rollback = copy back the backed-up `.mcp.json` (single file,
+   one `Copy-Item` — same rollback pattern as the 2026-05-06 pepper-flip).
+4. **Make it the default.** Update the canonical per-agent template /
+   agent-init so every new agent is born resilient.
+5. **Docs + close-out.** Replace the #91 stopgap warning in
+   `docs/setup/daemon.md` ("live agent sessions must be restarted after a
+   bounce") with the new behaviour; close #91. Unblocks the always-on/reboot
+   work — the busproxy is the substrate it plugs into.
+
+## Relationships
+
+- **#79** — `daemon refresh` (daily flow) is what made #91 routine; this
+  design removes that sharp edge. The #79 stopgap doc warning is replaced in
+  step 5.
+- **Always-on / reboot resilience** — this is a prerequisite; the busproxy is
+  the substrate any auto-relaunched agent depends on.
+- **#76** — reuses the URL/token redaction discipline for `detail`.
+
+## Provenance
+
+#91 surfaced 2026-05-15 by Pepper from inside the affected session during the
+#79 migration; root-cause analysis and repro hers.

--- a/docs/superpowers/specs/2026-05-16-daemon-mcp-session-recovery-design.md
+++ b/docs/superpowers/specs/2026-05-16-daemon-mcp-session-recovery-design.md
@@ -291,6 +291,37 @@ the daemon is back and a tool list succeeds — this is the same surface as the
 spec's already-acknowledged residual SPOF (Task 9 respawn/relist
 verification).
 
+## Amendment 2 2026-05-16 (discovered during implementation, Task 7 regression)
+
+The Task 7 regression (real `HTTPHost`-served backend) exposed a second
+FastMCP-proxy behavior the design missed: a `ProxyProvider` mirrors each
+backend tool **including its `output_schema`**, and the FastMCP server then
+**re-validates every tool result against that schema**. When
+`TransientErrorMiddleware` returns the `{transient:true}` payload in the
+daemon-down window, it does not match the proxied tool's schema (e.g.
+`list_endpoints`) → FastMCP rejects it with `Output validation error` and
+the agent gets an opaque error instead of the structured retryable signal.
+
+- **Severity:** #91's core (one long-lived client survives a real daemon
+  stop+start) is sound — verified: the warm-cache `r1` call succeeds
+  end-to-end against an `HTTPHost`-served `ClaudeCodeMCPEndpoint`. Only the
+  down-window *signal shape* was broken.
+
+**Resolution (chosen 2026-05-16 — "strip output_schema on proxied tools"):**
+a small `ProxyProvider` subclass overrides `_list_tools`/`_get_tool` to
+`model_copy(update={"output_schema": None})` every proxied tool, so FastMCP
+performs no output validation on proxied results. This is semantically
+correct for a transparent passthrough proxy — the backend already owns and
+validated its outputs; the proxy must not re-impose a schema it cannot
+satisfy for synthetic transient results. Lets the transient payload AND
+normal passthrough results through. Stays within the approved architecture
+(still a FastMCP proxy + ProxyProvider; only output-schema re-validation is
+disabled). Also: the Task 7 harness was corrected to serve the backend via
+the real `agent_core.bus.http_host.HTTPHost` (production mount path
+`/mcp/<agent>` + session-manager lifespan), since a hand-rolled
+`uvicorn.Config(ep.asgi_app())` mounted at root did not reproduce the
+daemon's HTTP shape.
+
 ## Provenance
 
 #91 surfaced 2026-05-15 by Pepper from inside the affected session during the

--- a/packages/agent-core-busproxy/pyproject.toml
+++ b/packages/agent-core-busproxy/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "agent-core-busproxy"
+version = "0.1.0"
+description = "Stdio MCP proxy — bridges Claude Code to the agent-core daemon bus tool surface with per-request backend sessions so a daemon bounce never strands the session."
+requires-python = ">=3.12"
+dependencies = [
+    "fastmcp>=3.2",
+    "mcp>=1.0",
+    "anyio>=4.0",
+    "httpx>=0.27",
+    "typer>=0.12",
+]
+
+[project.scripts]
+agent-core-busproxy = "agent_core_busproxy.__main__:app"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agent_core_busproxy"]

--- a/packages/agent-core-busproxy/src/agent_core_busproxy/__init__.py
+++ b/packages/agent-core-busproxy/src/agent_core_busproxy/__init__.py
@@ -1,0 +1,1 @@
+"""agent-core-busproxy — stdio MCP proxy to the daemon bus tool surface."""

--- a/packages/agent-core-busproxy/src/agent_core_busproxy/__main__.py
+++ b/packages/agent-core-busproxy/src/agent_core_busproxy/__main__.py
@@ -1,0 +1,37 @@
+"""Typer CLI for agent-core-busproxy.
+
+Runs a FastMCP proxy over stdio, backed by the daemon's per-agent HTTP
+endpoint. Spawned by Claude Code as a stdio MCP server; its lifetime is
+the Claude Code session, decoupled from the daemon's lifetime.
+"""
+
+from __future__ import annotations
+
+import anyio
+import typer
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def main(
+    agent: str = typer.Option(..., "--agent", help="Agent name on the bus."),
+    daemon_url: str = typer.Option(
+        "http://127.0.0.1:8789",
+        "--daemon-url",
+        help="agent-core daemon URL (default: http://127.0.0.1:8789).",
+    ),
+) -> None:
+    """Run the agent-core stdio bus proxy."""
+    from agent_core_busproxy.proxy import build_busproxy
+
+    proxy = build_busproxy(agent=agent, daemon_url=daemon_url)
+
+    async def _run() -> None:
+        await proxy.run_async(transport="stdio")
+
+    anyio.run(_run)
+
+
+if __name__ == "__main__":
+    app()

--- a/packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py
+++ b/packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py
@@ -1,0 +1,76 @@
+"""Assemble the stdio bus proxy.
+
+The proxy forwards the daemon's per-agent MCP tool surface. Each tool
+call mints a FRESH backend session (ProxyClient.new()), so a restarted
+daemon is never presented a stale mcp-session-id — issue #91 is removed
+by construction, not by recovery logic.
+
+Cache hardening (spec Amendment 2026-05-16): FastMCP's ProxyProvider
+caches the backend tool list and swallows a backend-down list into an
+EMPTY registry. We build the proxy via the documented lower-level
+pattern — FastMCP + add_provider(ProxyProvider(client_factory,
+cache_ttl=<long>)) — with a 24h cache_ttl so the tool palette survives
+any realistic daemon bounce. (FastMCPProxy hardcodes ProxyProvider with
+no cache_ttl passthrough, so it cannot be used here.) No active
+keepalive: a keepalive cannot help the cold-start-while-down edge, and a
+long TTL covers expiry (YAGNI).
+
+`init_timeout` keeps a down/bouncing daemon from hanging the call: the
+backend connect fails fast and the TransientErrorMiddleware (attached in
+Task 5) turns that into a structured retryable tool result.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.server.providers.proxy import ProxyClient, ProxyProvider
+
+# Fail-fast: a down daemon must not hang a tool call. Small connect/init
+# budget; the agent owns the retry decision (spec: fail-fast retryable).
+_BACKEND_INIT_TIMEOUT_SECONDS = 5.0
+# Per-call request budget once connected (a healthy daemon answers in ms;
+# this only bounds a half-open connection).
+_BACKEND_REQUEST_TIMEOUT_SECONDS = 60.0
+# Tool-list cache lifetime. Long enough that the palette survives any
+# realistic daemon bounce/refresh within a session (spec Amendment).
+_TOOL_CACHE_TTL_SECONDS = 86400.0
+
+
+def build_busproxy(
+    *,
+    agent: str,
+    daemon_url: str | None,
+    _backend: Any | None = None,
+) -> FastMCP:
+    """Return a FastMCP proxy over the daemon's per-agent endpoint.
+
+    Args:
+        agent: bus agent name (URL path segment).
+        daemon_url: e.g. ``http://127.0.0.1:8789``. Ignored when
+            ``_backend`` is supplied.
+        _backend: test seam — an in-process FastMCP server to proxy
+            instead of an HTTP URL. Production always passes a URL.
+    """
+    if _backend is not None:
+        base_client = ProxyClient(_backend)
+    else:
+        if not daemon_url:
+            raise ValueError("daemon_url is required when no _backend is given")
+        url = f"{daemon_url.rstrip('/')}/mcp/{agent}"
+        base_client = ProxyClient(
+            url,
+            init_timeout=_BACKEND_INIT_TIMEOUT_SECONDS,
+            timeout=_BACKEND_REQUEST_TIMEOUT_SECONDS,
+        )
+
+    def client_factory() -> Any:
+        # Fresh session per request — the #91 fix.
+        return base_client.new()
+
+    proxy = FastMCP(name=f"agent-core[{agent}]")
+    proxy.add_provider(
+        ProxyProvider(client_factory, cache_ttl=_TOOL_CACHE_TTL_SECONDS)
+    )
+    return proxy

--- a/packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py
+++ b/packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py
@@ -18,6 +18,15 @@ long TTL covers expiry (YAGNI).
 `init_timeout` keeps a down/bouncing daemon from hanging the call: the
 backend connect fails fast and the TransientErrorMiddleware (attached in
 Task 5) turns that into a structured retryable tool result.
+
+Output-schema stripping (spec Amendment 2): a FastMCP ProxyProvider
+mirrors each backend tool's output_schema and the server then
+re-validates every result against it. That would reject the
+TransientErrorMiddleware's {transient:true} payload (it cannot match an
+arbitrary tool's schema) and mangle it into an opaque output-validation
+error. A transparent passthrough proxy must not re-validate the
+backend's own outputs anyway, so _NoOutputSchemaProxyProvider drops the
+output_schema on every proxied tool.
 """
 
 from __future__ import annotations
@@ -28,6 +37,28 @@ from fastmcp import FastMCP
 from fastmcp.server.providers.proxy import ProxyClient, ProxyProvider
 
 from agent_core_busproxy.transient import TransientErrorMiddleware
+
+
+class _NoOutputSchemaProxyProvider(ProxyProvider):
+    """ProxyProvider that drops backend tool output schemas.
+
+    See module docstring (spec Amendment 2). Overrides both the list and
+    single-tool resolution paths so FastMCP performs no output validation
+    on proxied results — letting the transient payload AND normal
+    passthrough results through unchanged.
+    """
+
+    @staticmethod
+    def _strip(tool: Any) -> Any:
+        if tool is None:
+            return None
+        return tool.model_copy(update={"output_schema": None})
+
+    async def _list_tools(self) -> Any:
+        return [self._strip(t) for t in await super()._list_tools()]
+
+    async def _get_tool(self, name: str, version: Any = None) -> Any:
+        return self._strip(await super()._get_tool(name, version))
 
 # Fail-fast: a down daemon must not hang a tool call. Small connect/init
 # budget; the agent owns the retry decision (spec: fail-fast retryable).
@@ -75,7 +106,9 @@ def build_busproxy(
 
     proxy = FastMCP(name=f"agent-core[{agent}]")
     proxy.add_provider(
-        ProxyProvider(client_factory, cache_ttl=_TOOL_CACHE_TTL_SECONDS)
+        _NoOutputSchemaProxyProvider(
+            client_factory, cache_ttl=_TOOL_CACHE_TTL_SECONDS
+        )
     )
     # daemon_url is the middleware's liveness-probe target. None on the
     # in-process test path => probing disabled (ambiguous => genuine).

--- a/packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py
+++ b/packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py
@@ -27,6 +27,8 @@ from typing import Any
 from fastmcp import FastMCP
 from fastmcp.server.providers.proxy import ProxyClient, ProxyProvider
 
+from agent_core_busproxy.transient import TransientErrorMiddleware
+
 # Fail-fast: a down daemon must not hang a tool call. Small connect/init
 # budget; the agent owns the retry decision (spec: fail-fast retryable).
 _BACKEND_INIT_TIMEOUT_SECONDS = 5.0
@@ -65,6 +67,8 @@ def build_busproxy(
             timeout=_BACKEND_REQUEST_TIMEOUT_SECONDS,
         )
 
+    # -> Any: ProxyClient.new() returns an httpx-backed client (URL path)
+    # or an in-process FastMCP client (_backend path) — undifferentiated.
     def client_factory() -> Any:
         # Fresh session per request — the #91 fix.
         return base_client.new()
@@ -73,4 +77,7 @@ def build_busproxy(
     proxy.add_provider(
         ProxyProvider(client_factory, cache_ttl=_TOOL_CACHE_TTL_SECONDS)
     )
+    # daemon_url is the middleware's liveness-probe target. None on the
+    # in-process test path => probing disabled (ambiguous => genuine).
+    proxy.add_middleware(TransientErrorMiddleware(daemon_url=daemon_url))
     return proxy

--- a/packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py
+++ b/packages/agent-core-busproxy/src/agent_core_busproxy/proxy.py
@@ -50,6 +50,7 @@ class _NoOutputSchemaProxyProvider(ProxyProvider):
 
     @staticmethod
     def _strip(tool: Any) -> Any:
+        # Any: avoid annotating with fastmcp's non-public Tool internals.
         if tool is None:
             return None
         return tool.model_copy(update={"output_schema": None})

--- a/packages/agent-core-busproxy/src/agent_core_busproxy/transient.py
+++ b/packages/agent-core-busproxy/src/agent_core_busproxy/transient.py
@@ -1,0 +1,139 @@
+"""Translate backend-unreachable failures into a structured, retryable
+tool result. Genuine backend tool errors pass through verbatim so the
+agent never retry-loops on a real failure.
+
+Two backend-down shapes (spec Amendment 2026-05-16):
+  1. Transport error — warm tool cache, per-request connect to the dead
+     daemon fails. Unambiguously transient.
+  2. ToolError("Unknown tool: ...") — the tool-list fetch failed and
+     FastMCP's ProxyProvider/AggregateProvider swallowed it into an empty
+     registry. AMBIGUOUS: identical shape to a genuine unknown-tool / tool
+     exception from a HEALTHY daemon. Disambiguated with a fast TCP
+     liveness probe to the daemon: unreachable => transient; reachable =>
+     genuine, re-raised unchanged.
+
+Unknown exception types are treated as genuine — a real bug is never
+masked as retryable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from enum import Enum
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import Middleware
+from fastmcp.tools.base import ToolResult
+from mcp.shared.exceptions import McpError
+
+log = logging.getLogger(__name__)
+
+TRANSIENT_ERROR_CODE = "bus_unavailable"
+_RETRY_AFTER_SECONDS = 5
+_PROBE_TIMEOUT_SECONDS = 2.0
+
+# Reuse the #76 redaction shape: drop the entire query string (signed CDN
+# tokens / session ids live there).
+_URL_QS_RE = re.compile(r"(https?://[^\s?]+)\?\S*")
+
+
+def redact(text: str) -> str:
+    """Strip query strings from any URLs in a human string."""
+    return _URL_QS_RE.sub(r"\1?<redacted>", text)
+
+
+class Disposition(Enum):
+    """How a backend exception should be handled."""
+
+    TRANSIENT = "transient"  # definitely daemon unreachable
+    GENUINE = "genuine"  # definitely a real error — re-raise
+    AMBIGUOUS = "ambiguous"  # could be either — probe the daemon to decide
+
+
+# Transport-class: could not reach / handshake the daemon. Definitely
+# transient. (ToolError is NOT in here — it is ambiguous, handled below.)
+_TRANSIENT_TYPES: tuple[type[BaseException], ...] = (
+    httpx.HTTPError,
+    ConnectionError,
+    TimeoutError,
+    OSError,
+    McpError,
+)
+
+
+def classify_backend_error(exc: BaseException) -> Disposition:
+    """Triage a backend exception (see module docstring)."""
+    if isinstance(exc, _TRANSIENT_TYPES):
+        return Disposition.TRANSIENT
+    if isinstance(exc, ToolError):
+        return Disposition.AMBIGUOUS
+    return Disposition.GENUINE
+
+
+async def daemon_reachable(daemon_url: str) -> bool:
+    """Fast TCP liveness probe — can we open a socket to the daemon?
+
+    A bounced/down daemon has nothing listening on its port, so a refused
+    or timed-out connect means 'down'. Bounded by _PROBE_TIMEOUT_SECONDS
+    so it cannot itself hang a tool call.
+    """
+    parsed = urlparse(daemon_url)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 80
+    try:
+        fut = asyncio.open_connection(host, port)
+        _reader, writer = await asyncio.wait_for(
+            fut, timeout=_PROBE_TIMEOUT_SECONDS
+        )
+    except (OSError, asyncio.TimeoutError):
+        return False
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except Exception:  # noqa: BLE001 - close best-effort
+        pass
+    return True
+
+
+def _transient_result(exc: BaseException) -> ToolResult:
+    detail = redact(f"{type(exc).__name__}: {exc}")
+    log.warning("busproxy: backend unavailable (transient): %s", detail)
+    return ToolResult(
+        structured_content={
+            "error": TRANSIENT_ERROR_CODE,
+            "transient": True,
+            "retry_after_seconds": _RETRY_AFTER_SECONDS,
+            "detail": detail,
+        }
+    )
+
+
+class TransientErrorMiddleware(Middleware):
+    """Map daemon-unreachable to a retryable result; pass real errors through.
+
+    ``daemon_url`` is the liveness-probe target. ``None`` (the in-process
+    test path) disables probing — an AMBIGUOUS error is then treated as
+    genuine so a real error is never masked when we cannot verify.
+    """
+
+    def __init__(self, daemon_url: str | None = None) -> None:
+        self._daemon_url = daemon_url
+
+    async def on_call_tool(self, context: Any, call_next: Any) -> ToolResult:
+        try:
+            return await call_next(context)
+        except BaseException as exc:  # noqa: BLE001 - triage then re-raise
+            disposition = classify_backend_error(exc)
+            if disposition is Disposition.TRANSIENT:
+                return _transient_result(exc)
+            if disposition is Disposition.AMBIGUOUS and (
+                self._daemon_url is not None
+                and not await daemon_reachable(self._daemon_url)
+            ):
+                return _transient_result(exc)
+            raise

--- a/packages/agent-core-busproxy/src/agent_core_busproxy/transient.py
+++ b/packages/agent-core-busproxy/src/agent_core_busproxy/transient.py
@@ -99,12 +99,12 @@ async def daemon_reachable(daemon_url: str) -> bool:
         _reader, writer = await asyncio.wait_for(
             fut, timeout=_PROBE_TIMEOUT_SECONDS
         )
-    except (OSError, asyncio.TimeoutError):
+    except (TimeoutError, OSError):
         return False
     writer.close()
     try:
         await writer.wait_closed()
-    except Exception:  # noqa: BLE001 - close best-effort
+    except Exception:  # close best-effort
         pass
     return True
 
@@ -136,7 +136,7 @@ class TransientErrorMiddleware(Middleware):
     async def on_call_tool(self, context: Any, call_next: Any) -> ToolResult:
         try:
             return await call_next(context)
-        except BaseException as exc:  # noqa: BLE001 - triage then re-raise
+        except BaseException as exc:  # triage then re-raise (never swallow)
             disposition = classify_backend_error(exc)
             if disposition is Disposition.TRANSIENT:
                 return _transient_result(exc)

--- a/packages/agent-core-busproxy/src/agent_core_busproxy/transient.py
+++ b/packages/agent-core-busproxy/src/agent_core_busproxy/transient.py
@@ -12,11 +12,11 @@ Two backend-down shapes (spec Amendment 2026-05-16):
      liveness probe to the daemon: unreachable => transient; reachable =>
      genuine, re-raised unchanged.
 
-     NOTE: fastmcp 3.2.4 raises fastmcp.exceptions.NotFoundError (not
-     ToolError) from server.call_tool() when the resolved tool list is
-     empty (source: fastmcp/server/server.py line 1157). ToolError is
-     also classified AMBIGUOUS for forward-compatibility with versions
-     that may change this behaviour.
+     NOTE: fastmcp raises `NotFoundError` server-side from
+     `FastMCP.call_tool` when the resolved tool list is empty (backend-down
+     → swallowed list → empty registry). ToolError is also classified
+     AMBIGUOUS for forward-compatibility with versions that may change this
+     behaviour.
 
 Unknown exception types are treated as genuine — a real bug is never
 masked as retryable.
@@ -76,10 +76,9 @@ def classify_backend_error(exc: BaseException) -> Disposition:
     """Triage a backend exception (see module docstring)."""
     if isinstance(exc, _TRANSIENT_TYPES):
         return Disposition.TRANSIENT
-    # NotFoundError: fastmcp 3.2.4 raises this (not ToolError) when the
-    # resolved tool list is empty due to a dead backend swallowing the
-    # tool-list fetch (source: fastmcp/server/server.py line 1157).
-    # ToolError: kept for forward-compatibility.
+    # NotFoundError: fastmcp raises this (not ToolError) from FastMCP.call_tool
+    # when the resolved tool list is empty (backend-down → swallowed list →
+    # empty registry). ToolError: kept for forward-compatibility.
     if isinstance(exc, (NotFoundError, ToolError)):
         return Disposition.AMBIGUOUS
     return Disposition.GENUINE

--- a/packages/agent-core-busproxy/src/agent_core_busproxy/transient.py
+++ b/packages/agent-core-busproxy/src/agent_core_busproxy/transient.py
@@ -5,12 +5,18 @@ agent never retry-loops on a real failure.
 Two backend-down shapes (spec Amendment 2026-05-16):
   1. Transport error — warm tool cache, per-request connect to the dead
      daemon fails. Unambiguously transient.
-  2. ToolError("Unknown tool: ...") — the tool-list fetch failed and
+  2. NotFoundError("Unknown tool: ...") — the tool-list fetch failed and
      FastMCP's ProxyProvider/AggregateProvider swallowed it into an empty
      registry. AMBIGUOUS: identical shape to a genuine unknown-tool / tool
      exception from a HEALTHY daemon. Disambiguated with a fast TCP
      liveness probe to the daemon: unreachable => transient; reachable =>
      genuine, re-raised unchanged.
+
+     NOTE: fastmcp 3.2.4 raises fastmcp.exceptions.NotFoundError (not
+     ToolError) from server.call_tool() when the resolved tool list is
+     empty (source: fastmcp/server/server.py line 1157). ToolError is
+     also classified AMBIGUOUS for forward-compatibility with versions
+     that may change this behaviour.
 
 Unknown exception types are treated as genuine — a real bug is never
 masked as retryable.
@@ -26,7 +32,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import httpx
-from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import NotFoundError, ToolError
 from fastmcp.server.middleware import Middleware
 from fastmcp.tools.base import ToolResult
 from mcp.shared.exceptions import McpError
@@ -56,7 +62,7 @@ class Disposition(Enum):
 
 
 # Transport-class: could not reach / handshake the daemon. Definitely
-# transient. (ToolError is NOT in here — it is ambiguous, handled below.)
+# transient. (NotFoundError/ToolError are NOT in here — ambiguous, handled below.)
 _TRANSIENT_TYPES: tuple[type[BaseException], ...] = (
     httpx.HTTPError,
     ConnectionError,
@@ -70,7 +76,11 @@ def classify_backend_error(exc: BaseException) -> Disposition:
     """Triage a backend exception (see module docstring)."""
     if isinstance(exc, _TRANSIENT_TYPES):
         return Disposition.TRANSIENT
-    if isinstance(exc, ToolError):
+    # NotFoundError: fastmcp 3.2.4 raises this (not ToolError) when the
+    # resolved tool list is empty due to a dead backend swallowing the
+    # tool-list fetch (source: fastmcp/server/server.py line 1157).
+    # ToolError: kept for forward-compatibility.
+    if isinstance(exc, (NotFoundError, ToolError)):
         return Disposition.AMBIGUOUS
     return Disposition.GENUINE
 

--- a/packages/agent-core-busproxy/tests/_backend_server.py
+++ b/packages/agent-core-busproxy/tests/_backend_server.py
@@ -30,8 +30,8 @@ async def _main(port: int) -> None:
     host = HTTPHost(bind_host="127.0.0.1", bind_port=port)
     host.mount(ep)
     await host.start()
-    # Signal readiness to the parent (flushed line on stdout).
-    print("READY", flush=True)
+    # Readiness is observed by the parent via a TCP port-probe (this
+    # process's stdout is discarded), so nothing to emit here.
     # Serve until the parent kills this process (faithful daemon death).
     await asyncio.Event().wait()
 

--- a/packages/agent-core-busproxy/tests/_backend_server.py
+++ b/packages/agent-core-busproxy/tests/_backend_server.py
@@ -1,0 +1,40 @@
+"""Disposable test backend for the #91 subprocess regression.
+
+Run as: ``python _backend_server.py <port>``. Serves ONE throwaway
+``ClaudeCodeMCPEndpoint`` via the production ``HTTPHost`` on
+``127.0.0.1:<port>`` until the process is killed. This is NOT shipped
+(lives under tests/) and never touches the real daemon — the regression
+always passes an OS-assigned free port and kills only this child.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from agent_core.bus.http_host import HTTPHost
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+
+
+class _StubHandle:
+    async def ack(self, envelope_id: str) -> None: ...
+    async def publish(self, envelope, to=None) -> None: ...
+    async def nack(self, envelope_id, requeue=True) -> None: ...
+    def endpoints(self) -> list:
+        return [type("E", (), {"name": "discord", "description": "d"})()]
+
+
+async def _main(port: int) -> None:
+    ep = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    await ep.start(_StubHandle())  # type: ignore[arg-type]
+    host = HTTPHost(bind_host="127.0.0.1", bind_port=port)
+    host.mount(ep)
+    await host.start()
+    # Signal readiness to the parent (flushed line on stdout).
+    print("READY", flush=True)
+    # Serve until the parent kills this process (faithful daemon death).
+    await asyncio.Event().wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main(int(sys.argv[1])))

--- a/packages/agent-core-busproxy/tests/test_cli.py
+++ b/packages/agent-core-busproxy/tests/test_cli.py
@@ -1,0 +1,23 @@
+"""Smoke tests for the busproxy Typer CLI."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from agent_core_busproxy.__main__ import app
+
+
+def test_cli_help_runs() -> None:
+    result = CliRunner().invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "--agent" in result.output
+    assert "--daemon-url" in result.output
+
+
+def test_cli_requires_agent() -> None:
+    result = CliRunner().invoke(app, [])
+    assert result.exit_code != 0
+    assert (
+        "Missing option" in result.output
+        or "required" in result.output.lower()
+    )

--- a/packages/agent-core-busproxy/tests/test_cli.py
+++ b/packages/agent-core-busproxy/tests/test_cli.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typer.testing import CliRunner
-
 from agent_core_busproxy.__main__ import app
+from typer.testing import CliRunner
 
 
 def test_cli_help_runs() -> None:

--- a/packages/agent-core-busproxy/tests/test_down_window.py
+++ b/packages/agent-core-busproxy/tests/test_down_window.py
@@ -6,10 +6,9 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from fastmcp import Client
-
 from agent_core_busproxy.proxy import build_busproxy
 from agent_core_busproxy.transient import TRANSIENT_ERROR_CODE
+from fastmcp import Client
 
 
 @pytest.mark.asyncio

--- a/packages/agent-core-busproxy/tests/test_down_window.py
+++ b/packages/agent-core-busproxy/tests/test_down_window.py
@@ -1,0 +1,27 @@
+"""Daemon-down window: a tool call returns the structured transient
+result PROMPTLY (fail-fast, no long hang)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastmcp import Client
+
+from agent_core_busproxy.proxy import build_busproxy
+from agent_core_busproxy.transient import TRANSIENT_ERROR_CODE
+
+
+@pytest.mark.asyncio
+async def test_dead_backend_returns_transient_result_fast() -> None:
+    # Nothing listening on 65535 => connect refused/timeout.
+    proxy = build_busproxy(agent="agent", daemon_url="http://127.0.0.1:65535")
+
+    async with Client(proxy) as c:
+        # Whole call must finish well under the 5s init budget * slack.
+        result = await asyncio.wait_for(
+            c.call_tool("list_endpoints", {}), timeout=15.0
+        )
+
+    assert result.structured_content["error"] == TRANSIENT_ERROR_CODE
+    assert result.structured_content["transient"] is True

--- a/packages/agent-core-busproxy/tests/test_proxy_api_contract.py
+++ b/packages/agent-core-busproxy/tests/test_proxy_api_contract.py
@@ -1,0 +1,120 @@
+"""Pin the installed FastMCP proxy API surface this package depends on.
+
+If FastMCP changes these, this test fails first and points at exactly
+what to update in proxy.py / transient.py.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+def test_fastmcpproxy_and_proxyclient_importable() -> None:
+    from fastmcp.server.providers.proxy import FastMCPProxy, ProxyClient
+
+    # FastMCPProxy takes a client_factory kwarg.
+    sig = inspect.signature(FastMCPProxy.__init__)
+    assert "client_factory" in sig.parameters
+
+    # ProxyClient accepts a URL string target and supports .new().
+    pc = ProxyClient("http://127.0.0.1:65535/mcp/nobody")
+    assert hasattr(pc, "new")
+
+
+def test_client_supports_init_timeout() -> None:
+    from fastmcp import Client
+
+    sig = inspect.signature(Client.__init__)
+    assert "init_timeout" in sig.parameters
+
+
+def test_middleware_has_on_call_tool() -> None:
+    from fastmcp.server.middleware import Middleware
+
+    assert hasattr(Middleware, "on_call_tool")
+
+
+def test_toolresult_accepts_structured_content() -> None:
+    from fastmcp.tools.base import ToolResult
+
+    r = ToolResult(structured_content={"error": "x", "transient": True})
+    assert r.structured_content == {"error": "x", "transient": True}
+
+
+@pytest.mark.asyncio
+async def test_client_surfaces_structured_content_attribute() -> None:
+    """Pin the CLIENT-side accessor: a tool returning ToolResult(
+    structured_content=...) is readable as result.structured_content.
+    Every later test asserts on this attribute.
+
+    NOTE: The inner tool function deliberately omits a return-type annotation.
+    Using ``-> ToolResult`` with ``from __future__ import annotations`` (PEP 563)
+    causes pydantic to evaluate it as a forward-reference against the *module*
+    globalns, where the name ``ToolResult`` is absent (the import lives only in
+    the test-function locals).  Omitting the annotation is equivalent for the
+    purpose of this characterization test.
+    """
+    from fastmcp import Client, FastMCP
+    from fastmcp.tools.base import ToolResult
+
+    srv = FastMCP("pin")
+
+    @srv.tool()
+    async def t():  # no return annotation — see docstring
+        return ToolResult(structured_content={"transient": True})
+
+    async with Client(srv) as c:
+        res = await c.call_tool("t", {})
+
+    assert res.structured_content == {"transient": True}
+
+
+@pytest.mark.asyncio
+async def test_dead_backend_raises_on_tool_call() -> None:
+    """Calling a tool through a proxy whose backend is unreachable raises.
+
+    Records the concrete exception type so transient.py can catch it.
+    Port 65535 with nothing listening => connect failure.
+    """
+    from fastmcp import Client
+    from fastmcp.server.providers.proxy import FastMCPProxy, ProxyClient
+
+    base = ProxyClient("http://127.0.0.1:65535/mcp/nobody", init_timeout=2.0)
+    proxy = FastMCPProxy(client_factory=lambda: base.new(), name="probe")
+
+    with pytest.raises(BaseException) as excinfo:  # noqa: PT011 - characterizing
+        async with Client(proxy) as c:
+            await c.call_tool("list_endpoints", {})
+
+    # Concrete type pinned for transient.classify_backend_error.
+    # Assert it is NOT a clean MCP tool-result (i.e. the failure surfaces
+    # as an exception, which is what the middleware will intercept).
+    assert excinfo.value is not None
+    chain = []
+    e: BaseException | None = excinfo.value
+    while e is not None:
+        chain.append(type(e).__name__)
+        e = e.__cause__ or e.__context__
+    # Connection-class failure somewhere in the chain.
+    #
+    # OBSERVED BEHAVIOUR (fastmcp 3.2.2): AggregateProvider._collect_list_results
+    # absorbs the actual connect error during list_tools() (logs a WARNING) and
+    # returns an empty tool list.  A subsequent call_tool() therefore fails with
+    # ToolError("Unknown tool: '...'") — never a raw connection exception.
+    # transient.classify_backend_error must therefore match "ToolError" (in
+    # addition to raw transport errors that could surface in other code-paths).
+    assert any(
+        n in chain
+        for n in (
+            "ToolError",
+            "ConnectError",
+            "ConnectionError",
+            "ConnectTimeout",
+            "McpError",
+            "HTTPError",
+            "OSError",
+            "TimeoutError",
+        )
+    ), f"unexpected exception chain: {chain}"

--- a/packages/agent-core-busproxy/tests/test_proxy_api_contract.py
+++ b/packages/agent-core-busproxy/tests/test_proxy_api_contract.py
@@ -84,7 +84,7 @@ async def test_dead_backend_raises_on_tool_call() -> None:
     base = ProxyClient("http://127.0.0.1:65535/mcp/nobody", init_timeout=2.0)
     proxy = FastMCPProxy(client_factory=lambda: base.new(), name="probe")
 
-    with pytest.raises(BaseException) as excinfo:  # noqa: PT011 - characterizing
+    with pytest.raises(BaseException) as excinfo:  # broad: characterizing
         async with Client(proxy) as c:
             await c.call_tool("list_endpoints", {})
 

--- a/packages/agent-core-busproxy/tests/test_proxy_build.py
+++ b/packages/agent-core-busproxy/tests/test_proxy_build.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import pytest
+from agent_core_busproxy.proxy import build_busproxy
 from fastmcp import Client
 
 from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
-from agent_core_busproxy.proxy import build_busproxy
 
 
 class _StubHandle:

--- a/packages/agent-core-busproxy/tests/test_proxy_build.py
+++ b/packages/agent-core-busproxy/tests/test_proxy_build.py
@@ -1,0 +1,52 @@
+"""build_busproxy assembles a proxy that mirrors the daemon tool surface."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client
+
+from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
+from agent_core_busproxy.proxy import build_busproxy
+
+
+class _StubHandle:
+    async def ack(self, envelope_id: str) -> None: ...
+    async def publish(self, envelope, to=None) -> None: ...
+    async def nack(self, envelope_id, requeue=True) -> None: ...
+    def endpoints(self) -> list:
+        return []
+
+
+# The bus tool surface ClaudeCodeMCPEndpoint guarantees (see
+# claude_code_mcp.py _register_tools). Asserting these by name avoids
+# depending on any FastMCP-internal tool-enumeration API.
+_EXPECTED_BUS_TOOLS = {
+    "send",
+    "list_endpoints",
+    "describe_endpoint",
+    "list_pending",
+    "handle",
+    "ack",
+    "nack",
+    "consume",
+    "reply",
+    "peek",
+    "show_my_day",
+}
+
+
+@pytest.mark.asyncio
+async def test_proxy_mirrors_backend_tool_surface() -> None:
+    """tools/list through the proxy exposes the daemon endpoint's tools."""
+    backend = ClaudeCodeMCPEndpoint(name="agent", mount="/mcp/agent")
+    await backend.start(_StubHandle())  # type: ignore[arg-type]
+    try:
+        # Proxy pointed directly at the in-process backend server.
+        proxy = build_busproxy(agent="agent", daemon_url=None, _backend=backend._mcp)
+        async with Client(proxy) as c:
+            proxied = {t.name for t in await c.list_tools()}
+
+        missing = _EXPECTED_BUS_TOOLS - proxied
+        assert not missing, f"proxy missing bus tools: {missing}"
+    finally:
+        await backend.stop()

--- a/packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py
+++ b/packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py
@@ -1,0 +1,121 @@
+"""#91 regression: a daemon restart must not strand a live session.
+
+A single long-lived busproxy Client stays connected across a full
+daemon bounce. Because every tool call mints a fresh backend session,
+the post-restart call recovers without any client re-initialize.
+
+The backend runs as a real SEPARATE PROCESS on an OS-assigned free port
+(never the real daemon's port) so killing it and starting a fresh one is
+a faithful daemon bounce (process dies → new process binds the port),
+free of in-process event-loop/lifespan races. The test only ever kills
+its own child process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+
+from agent_core_busproxy.proxy import build_busproxy
+
+_BACKEND = Path(__file__).parent / "_backend_server.py"
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+async def _port_open(port: int) -> bool:
+    try:
+        fut = asyncio.open_connection("127.0.0.1", port)
+        _r, w = await asyncio.wait_for(fut, timeout=1.0)
+    except (OSError, asyncio.TimeoutError):
+        return False
+    w.close()
+    return True
+
+
+async def _spawn_backend(port: int) -> subprocess.Popen:
+    """Start the disposable backend subprocess and wait until it listens."""
+    proc = subprocess.Popen(
+        [sys.executable, str(_BACKEND), str(port)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    for _ in range(100):  # ~10s bounded readiness
+        if proc.poll() is not None:
+            raise RuntimeError(f"backend exited early (rc={proc.returncode})")
+        if await _port_open(port):
+            return proc
+        await asyncio.sleep(0.1)
+    proc.kill()
+    raise RuntimeError("backend did not become ready within 10s")
+
+
+def _kill(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_session_survives_backend_bounce() -> None:
+    port = _free_port()
+    proxy = build_busproxy(agent="agent", daemon_url=f"http://127.0.0.1:{port}")
+
+    backend = await _spawn_backend(port)  # daemon #1 (own child, own port)
+    second: subprocess.Popen | None = None
+    try:
+        async with Client(proxy) as client:  # one long-lived client
+            r1 = await client.call_tool("list_endpoints", {})
+            assert any(e["name"] == "discord" for e in r1.data)
+
+            _kill(backend)  # real daemon bounce: process dies
+            backend = None  # type: ignore[assignment]
+
+            # Daemon-down window: SAME client, no re-handshake → transient.
+            mid = await client.call_tool("list_endpoints", {})
+            assert mid.structured_content["transient"] is True
+
+            # Fresh daemon process on the SAME port (OS released it on the
+            # kill above — no in-process race). The spec contract is
+            # fail-fast + the agent RETRIES on {transient}, so model that:
+            # poll the same client until it recovers, bounded. #91 is the
+            # property that the session *eventually recovers* across the
+            # bounce with no re-handshake.
+            second = await _spawn_backend(port)
+            recovered = False
+            for _ in range(40):  # ~20s bounded retry budget
+                try:
+                    res = await client.call_tool("list_endpoints", {})
+                except Exception:
+                    await asyncio.sleep(0.5)
+                    continue
+                sc = res.structured_content
+                if isinstance(sc, dict) and sc.get("transient"):
+                    await asyncio.sleep(0.5)
+                    continue
+                assert any(e["name"] == "discord" for e in res.data)
+                recovered = True
+                break
+            assert recovered, "session did not recover after daemon restart"
+    finally:
+        if backend is not None:
+            _kill(backend)
+        if second is not None:
+            _kill(second)

--- a/packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py
+++ b/packages/agent-core-busproxy/tests/test_regression_daemon_bounce.py
@@ -20,9 +20,8 @@ import sys
 from pathlib import Path
 
 import pytest
-from fastmcp import Client
-
 from agent_core_busproxy.proxy import build_busproxy
+from fastmcp import Client
 
 _BACKEND = Path(__file__).parent / "_backend_server.py"
 
@@ -39,7 +38,7 @@ async def _port_open(port: int) -> bool:
     try:
         fut = asyncio.open_connection("127.0.0.1", port)
         _r, w = await asyncio.wait_for(fut, timeout=1.0)
-    except (OSError, asyncio.TimeoutError):
+    except (TimeoutError, OSError):
         return False
     w.close()
     return True

--- a/packages/agent-core-busproxy/tests/test_scaffold.py
+++ b/packages/agent-core-busproxy/tests/test_scaffold.py
@@ -1,0 +1,9 @@
+"""Package scaffold smoke test."""
+
+from __future__ import annotations
+
+
+def test_package_imports() -> None:
+    import agent_core_busproxy
+
+    assert agent_core_busproxy.__doc__ is not None

--- a/packages/agent-core-busproxy/tests/test_transient.py
+++ b/packages/agent-core-busproxy/tests/test_transient.py
@@ -14,7 +14,7 @@ import socket
 
 import httpx
 import pytest
-from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import NotFoundError, ToolError
 
 from agent_core_busproxy.transient import (
     TRANSIENT_ERROR_CODE,
@@ -120,3 +120,46 @@ async def test_no_daemon_url_treats_ambiguous_as_genuine() -> None:
 
     with pytest.raises(ToolError, match="envelope_id not found"):
         await mw.on_call_tool(object(), call_next)
+
+
+def test_classify_not_found_error_is_ambiguous() -> None:
+    # fastmcp 3.2.4 raises NotFoundError (NOT ToolError) server-side for an
+    # empty-registry unknown tool — the #91 backend-down path the proxy's
+    # middleware actually sees. Must be AMBIGUOUS so the liveness probe can
+    # disambiguate down-daemon vs a genuinely missing tool.
+    assert (
+        classify_backend_error(NotFoundError("Unknown tool: 'x'"))
+        is Disposition.AMBIGUOUS
+    )
+
+
+@pytest.mark.asyncio
+async def test_not_found_error_with_daemon_down_becomes_transient() -> None:
+    mw = TransientErrorMiddleware(daemon_url="http://127.0.0.1:65535")
+
+    async def call_next(_ctx):
+        raise NotFoundError("Unknown tool: 'consume'")
+
+    result = await mw.on_call_tool(object(), call_next)
+    assert result.structured_content["transient"] is True
+
+
+@pytest.mark.asyncio
+async def test_not_found_error_with_daemon_up_passes_through() -> None:
+    # The no-masking guarantee for the exact exception that motivated the
+    # Task 5 deviation: a genuinely-missing tool on a HEALTHY daemon must
+    # re-raise, never be masked as a retryable transient result.
+    srv = socket.socket()
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    host, port = srv.getsockname()
+    try:
+        mw = TransientErrorMiddleware(daemon_url=f"http://{host}:{port}")
+
+        async def call_next(_ctx):
+            raise NotFoundError("Unknown tool: 'genuinely_missing'")
+
+        with pytest.raises(NotFoundError, match="genuinely_missing"):
+            await mw.on_call_tool(object(), call_next)
+    finally:
+        srv.close()

--- a/packages/agent-core-busproxy/tests/test_transient.py
+++ b/packages/agent-core-busproxy/tests/test_transient.py
@@ -1,0 +1,122 @@
+"""TransientErrorMiddleware: backend-down -> structured retryable result;
+genuine tool errors pass through verbatim.
+
+Per spec Amendment 2026-05-16: a backend-down failure can surface either
+as a transport error (warm cache, per-request connect fails) OR as a
+ToolError("Unknown tool: ...") (empty registry because the list fetch
+was swallowed). The latter is AMBIGUOUS with a genuine unknown-tool /
+tool exception, so it is disambiguated with a fast daemon liveness probe.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import httpx
+import pytest
+from fastmcp.exceptions import ToolError
+
+from agent_core_busproxy.transient import (
+    TRANSIENT_ERROR_CODE,
+    Disposition,
+    TransientErrorMiddleware,
+    classify_backend_error,
+    daemon_reachable,
+    redact,
+)
+
+
+def test_redact_strips_query_string() -> None:
+    # Same discipline as the #76 signed-CDN redaction.
+    assert redact("connect to https://cdn.example.com/x?sig=SECRET&t=9") == (
+        "connect to https://cdn.example.com/x?<redacted>"
+    )
+
+
+def test_classify_transport_error_is_transient() -> None:
+    assert classify_backend_error(httpx.ConnectError("refused")) is Disposition.TRANSIENT
+    assert classify_backend_error(ConnectionError("refused")) is Disposition.TRANSIENT
+    assert classify_backend_error(TimeoutError()) is Disposition.TRANSIENT
+
+
+def test_classify_tool_error_is_ambiguous() -> None:
+    # Could be 'down -> empty registry' OR a real unknown-tool error.
+    assert classify_backend_error(ToolError("Unknown tool: x")) is Disposition.AMBIGUOUS
+
+
+def test_classify_unknown_is_genuine() -> None:
+    # Never mask an unrecognized error as retryable.
+    assert classify_backend_error(ValueError("nope")) is Disposition.GENUINE
+
+
+@pytest.mark.asyncio
+async def test_daemon_reachable_true_and_false() -> None:
+    srv = socket.socket()
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    host, port = srv.getsockname()
+    try:
+        assert await daemon_reachable(f"http://{host}:{port}") is True
+    finally:
+        srv.close()
+    # Nothing listening on 65535 => not reachable.
+    assert await daemon_reachable("http://127.0.0.1:65535") is False
+
+
+@pytest.mark.asyncio
+async def test_transport_error_becomes_transient_result() -> None:
+    mw = TransientErrorMiddleware(daemon_url="http://127.0.0.1:65535")
+
+    async def call_next(_ctx):
+        raise httpx.ConnectError("Connection refused to http://h/x?token=ABC")
+
+    result = await mw.on_call_tool(object(), call_next)
+
+    assert result.structured_content["error"] == TRANSIENT_ERROR_CODE
+    assert result.structured_content["transient"] is True
+    assert isinstance(result.structured_content["retry_after_seconds"], int)
+    assert "token=ABC" not in result.structured_content["detail"]
+    assert "<redacted>" in result.structured_content["detail"]
+
+
+@pytest.mark.asyncio
+async def test_toolerror_with_daemon_down_becomes_transient() -> None:
+    # 65535 unbound => probe says down => AMBIGUOUS resolves to transient.
+    mw = TransientErrorMiddleware(daemon_url="http://127.0.0.1:65535")
+
+    async def call_next(_ctx):
+        raise ToolError("Unknown tool: 'consume'")
+
+    result = await mw.on_call_tool(object(), call_next)
+    assert result.structured_content["transient"] is True
+
+
+@pytest.mark.asyncio
+async def test_toolerror_with_daemon_up_passes_through() -> None:
+    # A real listening socket => probe says reachable => genuine passthrough.
+    srv = socket.socket()
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    host, port = srv.getsockname()
+    try:
+        mw = TransientErrorMiddleware(daemon_url=f"http://{host}:{port}")
+
+        async def call_next(_ctx):
+            raise ToolError("envelope_id not found")
+
+        with pytest.raises(ToolError, match="envelope_id not found"):
+            await mw.on_call_tool(object(), call_next)
+    finally:
+        srv.close()
+
+
+@pytest.mark.asyncio
+async def test_no_daemon_url_treats_ambiguous_as_genuine() -> None:
+    # In-process/test path (no URL): cannot probe => do not mask as transient.
+    mw = TransientErrorMiddleware(daemon_url=None)
+
+    async def call_next(_ctx):
+        raise ToolError("envelope_id not found")
+
+    with pytest.raises(ToolError, match="envelope_id not found"):
+        await mw.on_call_tool(object(), call_next)

--- a/packages/agent-core-busproxy/tests/test_transient.py
+++ b/packages/agent-core-busproxy/tests/test_transient.py
@@ -14,8 +14,6 @@ import socket
 
 import httpx
 import pytest
-from fastmcp.exceptions import NotFoundError, ToolError
-
 from agent_core_busproxy.transient import (
     TRANSIENT_ERROR_CODE,
     Disposition,
@@ -24,6 +22,7 @@ from agent_core_busproxy.transient import (
     daemon_reachable,
     redact,
 )
+from fastmcp.exceptions import NotFoundError, ToolError
 
 
 def test_redact_strips_query_string() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ agent-core-briefs = { workspace = true }
 agent-core-webcam = { workspace = true }
 agent-core-hatchery = { workspace = true }
 agent-core-voice = { workspace = true }
+agent-core-busproxy = { workspace = true }
 
 [dependency-groups]
 # Dev tools only; real package deps live in member pyprojects.
@@ -84,6 +85,7 @@ testpaths = [
     "packages/agent-core-channel/tests",
     "packages/agent-core-webcam/tests",
     "packages/agent-core-voice/tests",
+    "packages/agent-core-busproxy/tests",
 ]
 asyncio_mode = "auto"
 addopts = "--import-mode=importlib -m 'not slow'"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32' and extra != 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130'",
@@ -52,6 +52,7 @@ conflicts = [[
 members = [
     "agent-core",
     "agent-core-briefs",
+    "agent-core-busproxy",
     "agent-core-channel",
     "agent-core-credentials",
     "agent-core-discord",
@@ -161,6 +162,27 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "simpleeval", specifier = ">=1.0" },
+    { name = "typer", specifier = ">=0.12" },
+]
+
+[[package]]
+name = "agent-core-busproxy"
+version = "0.1.0"
+source = { editable = "packages/agent-core-busproxy" }
+dependencies = [
+    { name = "anyio" },
+    { name = "fastmcp" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=4.0" },
+    { name = "fastmcp", specifier = ">=3.2" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "mcp", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.12" },
 ]
 
@@ -1440,7 +1462,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
     { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
     { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
     { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
     { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
     { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
@@ -1448,7 +1472,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
     { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
     { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
     { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
     { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
     { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
@@ -1456,7 +1482,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
     { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
     { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
     { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
     { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
     { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
     { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
@@ -1464,7 +1492,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
     { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
     { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
     { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
     { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
     { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
     { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },


### PR DESCRIPTION
## Summary

Fixes the #91 failure mode where a daemon bounce (`daemon refresh`/restart/crash) permanently stranded any live Claude Code agent session (`Session not found`, no self-recovery).

- **New self-contained `packages/agent-core-busproxy/`** — a stdio FastMCP proxy. Claude Code talks stdio to a long-lived proxy (lifetime = the session); the proxy mints a **fresh backend session per tool call**, so a restarted daemon is never presented a stale session id. #91 is removed *by construction*, not by recovery logic.
- **`TransientErrorMiddleware`** turns daemon-unreachable into a structured `{"error":"bus_unavailable","transient":true,"retry_after_seconds":5}` retryable result (fail-fast; the agent owns retry). A genuine error from a *healthy* daemon is **never** masked as transient (exhaustively traced, incl. `CancelledError`/`KeyboardInterrupt`).
- **Wake path untouched** — `agent-core-channel` (the `/notify` SSE relay) already reconnects on its own; zero changes there (channel suite 93/93, proving no leak).

## Spec amendments (discovered during TDD, recorded in the design doc)

1. **Cache hardening + `NotFoundError`** — FastMCP's `ProxyProvider` caches the tool list and swallows a backend-down list into an empty registry (surfacing as `NotFoundError`, not a transport error). Resolution: 24h `cache_ttl` + a fast TCP **liveness probe** to disambiguate `ToolError`/`NotFoundError` (daemon down → transient; up → genuine, re-raised).
2. **Strip `output_schema` on proxied tools** — a FastMCP proxy re-validates results against each backend tool's output schema, which mangled the `{transient:true}` payload into an opaque error. A transparent passthrough proxy must not re-validate the backend's own outputs; `_NoOutputSchemaProxyProvider` drops it.

## Test plan

- [x] Automated: `agent-core-busproxy` suite **24 passed** incl. the #91 regression — one long-lived client survives a real **subprocess** daemon kill+respawn on an OS-assigned free port (never 8789), asserting the down-window transient AND eventual recovery, no orphaned children.
- [x] `agent-core-channel` **93 passed** (wake path untouched). `ruff check packages/agent-core-busproxy` clean.
- [ ] **Operator-run rollout (gates close-out — test agent first, Pepper last):** on a fresh test agent, set `.mcp.json` to the resilient stdio shape (see `docs/setup/daemon.md`), run `agent-core daemon refresh` mid-session, confirm the agent recovers with no session restart across ~3 refresh cycles; confirm wake still works; record the stdio-child respawn behavior; only then cut Pepper over (rollback = restore the backed-up `.mcp.json`).

> Intentionally does **not** auto-close #91 — per the rollout plan, #91 closes only after the test-agent validation passes.

Design: `docs/superpowers/specs/2026-05-16-daemon-mcp-session-recovery-design.md` (+ Amendments). Plan: `docs/superpowers/plans/2026-05-16-daemon-mcp-session-recovery.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)