### PR TITLE
Phase 1: CI gate (workflow + pre-push hook + main ruleset)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Pre-push quality gate: run the same fast gate CI runs.
+# Emergency bypass (use sparingly): git push --no-verify
+exec just check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
-    env:
-      # Typer/Rich bakes help width from COLUMNS at import; GitHub sets
-      # COLUMNS=110, wrapping help. TERMINAL_WIDTH is read by Typer as
-      # MAX_WIDTH at import and wins, keeping option names un-wrapped.
-      TERMINAL_WIDTH: "200"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
           enable-cache: true
           python-version: "3.12"
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
+      # The slow tests shell out to `uv venv --python 3.12`; ensure a managed CPython exists
+      - run: uv python install 3.12
       # --package agent-core intentionally excludes agent-core-voice/qwen-tts (no Torch in CI)
       - run: uv sync --locked --package agent-core
       # Scoped to packages/core/tests — the only location of slow-marked tests today

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,7 @@ jobs:
           enable-cache: true
           python-version: "3.12"
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
+      # --package agent-core intentionally excludes agent-core-voice/qwen-tts (no Torch in CI)
       - run: uv sync --locked --package agent-core
+      # Scoped to packages/core/tests — the only location of slow-marked tests today
       - run: uv run --no-sync pytest packages/core/tests -m slow -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,19 @@ jobs:
       - run: uv sync --locked --all-packages
       - run: just check
       - run: uv cache prune --ci
+
+  integration:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
+      - run: uv sync --locked --package agent-core
+      - run: uv run --no-sync pytest packages/core/tests -m slow -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
+      - run: uv sync --locked --all-packages
+      - run: just check
+      - run: uv cache prune --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
 
 jobs:
   check:
@@ -17,6 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+    env:
+      # Typer/Rich bakes help width from COLUMNS at import; GitHub sets
+      # COLUMNS=110, wrapping help. TERMINAL_WIDTH is read by Typer as
+      # MAX_WIDTH at import and wins, keeping option names un-wrapped.
+      TERMINAL_WIDTH: "200"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/docs/setup/ci.md
+++ b/docs/setup/ci.md
@@ -1,0 +1,50 @@
+# CI & the pre-push gate
+
+## One-time per clone or worktree
+
+On a fresh clone or new worktree, in this order:
+
+```
+uv sync          # or: just sync  — populates the env
+just install-hooks
+```
+
+`just install-hooks` runs `uv run --no-sync python -m agent_core.githooks`,
+which points `core.hooksPath` at the version-controlled `.githooks/`. It
+uses `--no-sync`, so the uv environment must already exist — run `uv sync`
+(or `just sync`) FIRST, otherwise `agent_core` is not importable and the
+recipe fails.
+
+Git will not auto-run committed hook code on a fresh clone, so this
+one-time bootstrap is required. Humans and agents run the identical
+recipe.
+
+After install, `git push` runs `just check` first. Emergency bypass (use
+sparingly): `git push --no-verify`.
+
+## What CI runs (`.github/workflows/ci.yml`)
+
+- **check** — `ubuntu-latest` + `windows-latest`, `fail-fast: false`,
+  `timeout-minutes: 20`: `uv sync --locked --all-packages` then
+  `just check` then `uv cache prune --ci`.
+- **integration** — `windows-latest`, `timeout-minutes: 20`: a narrow
+  Torch-free sync `uv sync --locked --package agent-core`, then the
+  self-contained slow suite `uv run --no-sync pytest packages/core/tests
+  -m slow -v` (the Phase 0 stale-cache regression). The narrow sync is
+  intentional — `--all-packages` here would pull multi-GB Torch the
+  hosted runner cannot use; do not "widen" it.
+
+Triggers: every PR, every push to `main`, and manual `workflow_dispatch`.
+All third-party actions are pinned by commit SHA. `concurrency` cancels
+superseded runs for PRs only — `push: main` runs always finish so every
+commit on `main` has a recorded check.
+
+## One-time GitHub setup (owner account; manual)
+
+- Branch ruleset on `main` (exact `gh api` call in the Phase 1 plan):
+  requires `check (ubuntu-latest)`, `check (windows-latest)`, and
+  `integration` green and the branch up to date; owner on the bypass
+  list; no required reviews / signed commits / linear history.
+- Settings → Notifications → Actions → **"Send notifications for failed
+  workflows only."** Failures email; successes are silent. Failures stay
+  rare because the pre-push hook catches breakage locally.

--- a/docs/setup/daemon.md
+++ b/docs/setup/daemon.md
@@ -134,6 +134,7 @@ fresh.
 
 ## Related
 
+- `docs/setup/ci.md` — the CI gate and the one-time `just install-hooks` bootstrap.
 - [#79](https://github.com/jeffrichley/agent_core/issues/79) — the issue that motivated the venv isolation.
 - [#93](https://github.com/jeffrichley/agent_core/issues/93) — Defect A (stale daemon install); fixed by the per-member `tool.uv.cache-keys` git entry.
 - `docs/superpowers/specs/2026-05-18-agent-core-maturity-design.md` — the maturity spec (Phase 0 = this fix).

--- a/docs/superpowers/plans/2026-05-18-phase1-ci-gate.md
+++ b/docs/superpowers/plans/2026-05-18-phase1-ci-gate.md
@@ -1,0 +1,651 @@
+# Phase 1 — CI Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a greenfield CI gate (GitHub Actions + version-controlled pre-push hook + `main` branch ruleset) so `main` is never red and CI failures stay rare-but-loud.
+
+**Architecture:** A `just install-hooks` recipe wraps a unit-tested pure function (`agent_core.githooks.install_git_hooks`) that points the clone's `core.hooksPath` at a version-controlled `.githooks/pre-push` which runs `just check`. A `.github/workflows/ci.yml` runs a fast `check` matrix (`ubuntu`+`windows`) and a Windows-only `integration` job that runs the self-contained slow suite (`pytest packages/core/tests -m slow`) with a Torch-free sync. A `main` branch ruleset (created via `gh api`) requires all three contexts green. All third-party actions are SHA-pinned.
+
+**Tech Stack:** GitHub Actions, `uv`, `just`, `git` hooks, Typer/Python (core package), `gh` CLI.
+
+**Spec:** `docs/superpowers/specs/2026-05-18-phase1-ci-gate-design.md` (refines §Phase 1 of `2026-05-18-agent-core-maturity-design.md`).
+
+**Branch:** all work on `feat/phase1-ci-gate` off `main`. Do NOT implement on `main`.
+
+**Resolved action pins (authoritative, fetched 2026-05-18 via `gh api`):**
+- `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` # v6.0.2
+- `astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b` # v8.1.0
+- `extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3` # v4
+
+**Repo facts the implementer needs:**
+- `owner/repo` = `jeffrichley/agent_core`; default branch `main`.
+- `justfile` already defines `check: lint typecheck contracts test`; `pyproject.toml` `addopts = "--import-mode=importlib -m 'not slow'"`. A CLI `-m slow` overrides the addopts `-m 'not slow'` (later `-m` wins) — this is how the slow suite is selected.
+- The ONLY `slow`-marked module is `packages/core/tests/test_daemon_install_integration.py` (`pytestmark = pytest.mark.slow`); it is self-contained (builds its own temp workspace, calls real `uv`/`git`). No supervised daemon, no `agent_core.yaml`, no port. Scoping pytest to `packages/core/tests` avoids collecting Torch-heavy `packages/agent-core-voice/tests`.
+- `torch`/`torchaudio` are **extra-only** (`agent-core-voice` `[project.optional-dependencies] cpu`/`cu130`); never base deps. The vendored `qwen-tts` (`vendor/Qwen3-TTS`, `editable=false`) may pull Torch as its own base dep — hence the integration job must sync narrowly (Task 5).
+- `set windows-shell := ["cmd.exe", "/c"]` in the justfile: recipe lines run under `cmd.exe` on Windows, so recipe commands must be cmd-safe (`uv run ... python -m ...` is).
+- The core CLI is Typer (`packages/core/src/agent_core/cli.py`), pattern: pure logic module + thin wrapper (e.g. `daemon/install.py` vs `daemon/cli.py`). `agent_core.githooks` follows the same split.
+
+---
+
+### Task 1: `install_git_hooks` pure function + unit tests
+
+**Files:**
+- Create: `packages/core/src/agent_core/githooks.py`
+- Test: `packages/core/tests/test_githooks.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/core/tests/test_githooks.py`:
+
+```python
+"""Unit tests for agent_core.githooks.install_git_hooks (temp git repos only)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent_core.githooks import HOOKS_DIR_NAME, HookInstallError, install_git_hooks
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    return repo
+
+
+def _make_hooks(repo: Path) -> Path:
+    hooks = repo / HOOKS_DIR_NAME
+    hooks.mkdir()
+    (hooks / "pre-push").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    return hooks
+
+
+def test_install_sets_hookspath_to_githooks(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    hooks = _make_hooks(repo)
+
+    returned = install_git_hooks(repo)
+
+    assert returned == hooks.resolve()
+    assert _git(repo, "config", "--get", "core.hooksPath") == HOOKS_DIR_NAME
+
+
+def test_install_is_idempotent(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _make_hooks(repo)
+
+    install_git_hooks(repo)
+    install_git_hooks(repo)  # second run must not raise
+
+    assert _git(repo, "config", "--get", "core.hooksPath") == HOOKS_DIR_NAME
+
+
+def test_install_raises_when_pre_push_missing(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / HOOKS_DIR_NAME).mkdir()  # dir exists but pre-push absent
+
+    with pytest.raises(HookInstallError, match="pre-push"):
+        install_git_hooks(repo)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run --no-sync pytest packages/core/tests/test_githooks.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'agent_core.githooks'`.
+
+- [ ] **Step 3: Implement the module**
+
+Create `packages/core/src/agent_core/githooks.py`:
+
+```python
+"""Install this clone's version-controlled git hooks (.githooks/).
+
+`just install-hooks` wraps `main()`. Logic lives here (not in the recipe)
+so it is directly unit-testable, mirroring daemon/install.py vs
+daemon/cli.py.
+
+A relative `core.hooksPath` of ".githooks" is resolved by git relative
+to the working-tree root at hook-trigger time, so it is correct for the
+main checkout and every linked worktree (each has its own committed
+.githooks/ directory).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+HOOKS_DIR_NAME = ".githooks"
+REQUIRED_HOOKS = ("pre-push",)
+
+
+class HookInstallError(Exception):
+    """Raised when the versioned hooks directory is missing or incomplete."""
+
+
+def install_git_hooks(repo_root: Path) -> Path:
+    """Point `repo_root`'s git at `<repo_root>/.githooks`. Idempotent.
+
+    Returns the resolved hooks directory. Raises HookInstallError if
+    `.githooks/pre-push` is absent, so a broken checkout fails loudly
+    instead of silently disabling the gate.
+    """
+    repo_root = repo_root.resolve()
+    hooks_dir = repo_root / HOOKS_DIR_NAME
+    for hook in REQUIRED_HOOKS:
+        if not (hooks_dir / hook).is_file():
+            raise HookInstallError(
+                f"missing {HOOKS_DIR_NAME}/{hook} under {repo_root} — "
+                "run this from the agent_core repo root"
+            )
+    subprocess.run(
+        ["git", "-C", str(repo_root), "config", "core.hooksPath", HOOKS_DIR_NAME],
+        check=True,
+    )
+    return hooks_dir
+
+
+def main() -> int:
+    try:
+        hooks_dir = install_git_hooks(Path.cwd())
+    except HookInstallError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(f"error: git config failed (exit {exc.returncode})", file=sys.stderr)
+        return 1
+    print(f"git hooks installed: core.hooksPath -> {HOOKS_DIR_NAME} ({hooks_dir})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run --no-sync pytest packages/core/tests/test_githooks.py -v`
+Expected: PASS — 3 passed.
+
+- [ ] **Step 5: Run the fast gate**
+
+Run: `just check`
+Expected: PASS (ruff, mypy, import-linter, fast pytest all green). `mypy` covers `packages/core/src` — the new module must be clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/agent_core/githooks.py packages/core/tests/test_githooks.py
+git commit -m "feat(githooks): install_git_hooks pure function + unit tests"
+```
+
+---
+
+### Task 2: `.githooks/pre-push` hook script
+
+**Files:**
+- Create: `.githooks/pre-push`
+- Test: `packages/core/tests/test_githooks.py` (append one test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/core/tests/test_githooks.py`:
+
+```python
+def test_committed_pre_push_runs_just_check_and_is_executable() -> None:
+    """The real .githooks/pre-push must exist, invoke `just check`, and be
+    tracked with git's executable mode (100755) so it runs on a fresh clone.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    hook = repo_root / ".githooks" / "pre-push"
+    assert hook.is_file(), f"{hook} missing"
+
+    body = hook.read_text(encoding="utf-8")
+    assert "just check" in body
+
+    mode = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "--stage", ".githooks/pre-push"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.split()
+    assert mode and mode[0] == "100755", f"pre-push git mode is {mode[:1]}, want 100755"
+```
+
+(`parents[3]` from `packages/core/tests/test_githooks.py` → repo root.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run --no-sync pytest packages/core/tests/test_githooks.py::test_committed_pre_push_runs_just_check_and_is_executable -v`
+Expected: FAIL — assertion `.githooks/pre-push missing`.
+
+- [ ] **Step 3: Create the hook**
+
+Create `.githooks/pre-push` with exactly:
+
+```sh
+#!/bin/sh
+# Pre-push quality gate: run the same fast gate CI runs.
+# Emergency bypass (use sparingly): git push --no-verify
+exec just check
+```
+
+- [ ] **Step 4: Mark it executable in git's index**
+
+```bash
+git add .githooks/pre-push
+git update-index --chmod=+x .githooks/pre-push
+git ls-files --stage .githooks/pre-push
+```
+Expected: output begins `100755`.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `uv run --no-sync pytest packages/core/tests/test_githooks.py -v`
+Expected: PASS — 4 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .githooks/pre-push packages/core/tests/test_githooks.py
+git commit -m "feat(githooks): version-controlled pre-push hook runs just check"
+```
+
+---
+
+### Task 3: `just install-hooks` recipe + self-install
+
+**Files:**
+- Modify: `justfile` (append a recipe)
+
+- [ ] **Step 1: Add the recipe**
+
+Append to `justfile` (after the `sync:` recipe at EOF):
+
+```just
+# Install this clone's git hooks (.githooks/) — run once per clone/worktree
+install-hooks:
+    uv run --no-sync python -m agent_core.githooks
+```
+
+- [ ] **Step 2: Verify the recipe lists**
+
+Run: `just --list`
+Expected: `install-hooks` appears in the recipe list.
+
+- [ ] **Step 3: Run it against this repo (idempotent, intended end-state)**
+
+Run: `just install-hooks`
+Expected: prints `git hooks installed: core.hooksPath -> .githooks (...)`, exit 0.
+
+- [ ] **Step 4: Verify git now uses the versioned hook**
+
+Run: `git config --get core.hooksPath`
+Expected: `.githooks`
+
+- [ ] **Step 5: Smoke-test the hook fires (non-destructive)**
+
+Run: `git hook run pre-push </dev/null` (Git ≥ 2.36; on Windows Git-Bash same command)
+Expected: it executes `just check` (the full fast gate runs). If `git hook run` is unavailable, instead run `sh .githooks/pre-push` and confirm `just check` runs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add justfile
+git commit -m "feat(githooks): just install-hooks recipe"
+```
+
+---
+
+### Task 4: CI workflow — `check` job
+
+**Files:**
+- Create: `.github/workflows/ci.yml` (this task writes the `name`/`on`/`concurrency`/`check` parts; Task 5 appends `integration`)
+
+- [ ] **Step 1: Create the workflow with the `check` job**
+
+Create `.github/workflows/ci.yml`:
+
+```yaml
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
+      - run: uv sync --locked --all-packages
+      - run: just check
+      - run: uv cache prune --ci
+```
+
+- [ ] **Step 2: Validate YAML parses**
+
+Run: `uv run --no-sync python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Lint the workflow with actionlint (if available; non-blocking)**
+
+Run: `actionlint .github/workflows/ci.yml` (skip with a note if `actionlint` is not installed — the authoritative validation is the PR run in Task 8).
+Expected: no errors, or "actionlint not installed — deferred to PR run".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "feat(ci): check matrix job (ubuntu+windows, SHA-pinned actions)"
+```
+
+---
+
+### Task 5: CI workflow — `integration` job (Torch-free, empirically pinned)
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (append the `integration` job)
+
+**Context for the implementer:** the `integration` job must run `pytest packages/core/tests -m slow` on `windows-latest` with `uv`+`git` available and **no Torch installed**. The exact `uv sync` invocation that yields (a) `agent_core` + `pytest` + `pytest-asyncio` + `looptime` importable for collection of `packages/core/tests`, and (b) no `torch` in the env, must be determined empirically. **Use the context7 MCP server** for authoritative `uv` `sync` semantics (`--package`, `--group`, `--no-install-package`, virtual-workspace behavior) rather than relying on training data.
+
+- [ ] **Step 1: Determine the minimal Torch-free sync (empirical)**
+
+On a Windows shell at the repo root, try in order and pick the first that satisfies BOTH gates below:
+
+Candidate A: `uv sync --locked --package agent-core --group dev`
+Candidate B: `uv sync --locked --no-install-package agent-core-voice --no-install-package qwen-tts`
+Candidate C (fallback, accepts the cost): `uv sync --locked --all-packages` (Torch-free only if the lock has no base Torch; verify gate 2 still holds)
+
+Gate 1 (collection works):
+`uv run --no-sync pytest packages/core/tests -m slow -v` → the two tests in `test_daemon_install_integration.py` run (not collection-errored).
+
+Gate 2 (no Torch):
+`uv run --no-sync python -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('torch') is None else 1)"` → exit 0.
+
+Record the winning command as `<SYNC_CMD>` for Step 2.
+
+- [ ] **Step 2: Append the `integration` job**
+
+Append under `jobs:` in `.github/workflows/ci.yml` (replace `<SYNC_CMD>` with the Step 1 winner; example shown uses Candidate A):
+
+```yaml
+  integration:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
+      - run: uv sync --locked --package agent-core --group dev
+      - run: uv run --no-sync pytest packages/core/tests -m slow -v
+```
+
+- [ ] **Step 3: Validate YAML parses**
+
+Run: `uv run --no-sync python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+Expected: no output, exit 0. Confirm both jobs (`check`, `integration`) present:
+`uv run --no-sync python -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); print(sorted(d['jobs']))"` → `['check', 'integration']`.
+
+- [ ] **Step 4: Run the slow suite locally with the chosen sync (proof)**
+
+Run `<SYNC_CMD>` then `uv run --no-sync pytest packages/core/tests -m slow -v`
+Expected: PASS — `test_run_install_creates_working_venv_against_minimal_workspace` and both `test_defect_a_source_only_change_is_picked_up` params pass; no Torch pulled (re-confirm Gate 2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "feat(ci): windows integration job runs the self-contained slow suite (no Torch)"
+```
+
+---
+
+### Task 6: Docs — contributor bootstrap + spec reconciliation
+
+**Files:**
+- Create: `docs/setup/ci.md`
+- Modify: `docs/setup/daemon.md` (add one cross-reference line)
+- Modify: `docs/superpowers/specs/2026-05-18-phase1-ci-gate-design.md` (reconcile with implemented reality)
+
+- [ ] **Step 1: Write `docs/setup/ci.md`**
+
+Create `docs/setup/ci.md`:
+
+```markdown
+# CI & the pre-push gate
+
+## One-time per clone or worktree
+
+```
+just install-hooks
+```
+
+This points `core.hooksPath` at the version-controlled `.githooks/`, so
+`git push` runs `just check` first. Git will not auto-run committed hook
+code on a fresh clone — running `just install-hooks` once is required
+(humans and agents both run this exact recipe).
+
+Emergency bypass (use sparingly): `git push --no-verify`.
+
+## What CI runs (`.github/workflows/ci.yml`)
+
+- **check** — `ubuntu-latest` + `windows-latest`, `fail-fast: false`:
+  `uv sync --locked --all-packages` then `just check`.
+- **integration** — `windows-latest`: the self-contained slow suite
+  `pytest packages/core/tests -m slow` (includes the Phase 0 stale-cache
+  regression), synced Torch-free.
+
+Triggers: every PR, every push to `main`, and manual `workflow_dispatch`.
+All third-party actions are pinned by commit SHA.
+
+## One-time GitHub setup (owner account; manual)
+
+- Branch ruleset on `main` (see the Phase 1 plan for the exact `gh api`
+  call): requires `check (ubuntu-latest)`, `check (windows-latest)`, and
+  `integration` green and the branch up to date; owner on the bypass
+  list; no required reviews / signed commits / linear history.
+- Settings → Notifications → Actions → **"Send notifications for failed
+  workflows only."** Failures email; successes are silent. Failures stay
+  rare because the pre-push hook catches breakage locally.
+```
+
+- [ ] **Step 2: Cross-reference from `docs/setup/daemon.md`**
+
+Add this line to the "## Related" section of `docs/setup/daemon.md` (create the line; keep existing content):
+
+```markdown
+- `docs/setup/ci.md` — the CI gate and the one-time `just install-hooks` bootstrap.
+```
+
+- [ ] **Step 3: Reconcile the Phase 1 spec with what shipped**
+
+In `docs/superpowers/specs/2026-05-18-phase1-ci-gate-design.md`:
+- In §3 "Job `integration`", replace the ephemeral-daemon choreography
+  description with: the slow suite is self-contained, so the job is
+  `windows-latest` + Torch-free sync + `pytest packages/core/tests -m slow`;
+  no `agent_core.yaml`, port, or `daemon status` polling.
+- In §7 flagged item 1, mark it **resolved/moot for CI** (the slow suite
+  never starts the supervised daemon, so the daemon-without-`cu130`
+  question does not gate CI).
+- In §6, change the "executable" assertion wording to: assert the
+  committed `.githooks/pre-push` is tracked with git mode `100755`
+  (cross-platform-meaningful) plus the temp-repo `core.hooksPath` test.
+
+- [ ] **Step 4: Run the fast gate (docs shouldn't break it, but confirm)**
+
+Run: `just check`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/setup/ci.md docs/setup/daemon.md docs/superpowers/specs/2026-05-18-phase1-ci-gate-design.md
+git commit -m "docs(ci): contributor bootstrap + reconcile Phase 1 spec with implementation"
+```
+
+---
+
+### Task 7: `main` branch ruleset + notification posture
+
+**Files:** none (imperative GitHub state + recorded commands). **No code.**
+
+> **GATED — shared-state mutation.** Creating the ruleset changes the
+> live GitHub repo. The executor MUST get explicit user confirmation
+> immediately before running Step 2. The notification-posture step is
+> documentation only (the implementer does NOT change account settings).
+
+- [ ] **Step 1: Confirm there is no existing ruleset to clobber**
+
+Run: `gh api repos/jeffrichley/agent_core/rulesets`
+Expected: `[]` (greenfield, as recorded in the spec). If non-empty, STOP and surface to the user.
+
+- [ ] **Step 2: Create the ruleset (after explicit user confirmation)**
+
+Write the payload to a temp file and POST it:
+
+```bash
+cat > /tmp/phase1-ruleset.json <<'JSON'
+{
+  "name": "phase1-main-gate",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["refs/heads/main"], "exclude": [] } },
+  "bypass_actors": [
+    { "actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "always" }
+  ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "check (ubuntu-latest)" },
+          { "context": "check (windows-latest)" },
+          { "context": "integration" }
+        ]
+      }
+    }
+  ]
+}
+JSON
+gh api --method POST repos/jeffrichley/agent_core/rulesets \
+  --input /tmp/phase1-ruleset.json
+```
+
+Notes:
+- `actor_id: 5` = the built-in **admin** repository role; `bypass_mode:
+  always` preserves emergency direct push for the owner.
+- `strict_required_status_checks_policy: true` = branch must be up to
+  date before merge.
+- No `required_signatures`, `pull_request`, or `required_linear_history`
+  rules — deliberately omitted per the spec.
+
+- [ ] **Step 3: Verify the ruleset**
+
+Run: `gh api repos/jeffrichley/agent_core/rulesets`
+Expected: one ruleset `phase1-main-gate`, `enforcement: active`. Then:
+`gh api repos/jeffrichley/agent_core/rulesets/<id>` and confirm the three
+required contexts and the admin bypass actor are present.
+
+- [ ] **Step 4: Record the manual notification step (no action taken)**
+
+Confirm `docs/setup/ci.md` (Task 6) documents the "failed workflows only"
+posture. The implementer does not change the owner's account settings;
+this is the user's one-time manual action.
+
+- [ ] **Step 5: No commit** (this task creates no files; the doc was committed in Task 6).
+
+---
+
+### Task 8: Final verification — the PR is its own acceptance test
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch and open the PR**
+
+```bash
+git push -u origin feat/phase1-ci-gate
+gh pr create --title "Phase 1: CI gate (workflow + pre-push hook + main ruleset)" \
+  --body "Implements docs/superpowers/specs/2026-05-18-phase1-ci-gate-design.md. See plan docs/superpowers/plans/2026-05-18-phase1-ci-gate.md."
+```
+
+> The push itself exercises the new `pre-push` hook (`just check` runs).
+> If it blocks the push, the gate works — fix the failure, do not
+> `--no-verify` unless genuinely an emergency.
+
+- [ ] **Step 2: Watch the CI run**
+
+Run: `gh pr checks --watch`
+Expected: `check (ubuntu-latest)`, `check (windows-latest)`, and
+`integration` all succeed. This is the authoritative validation of the
+workflow YAML and the integration sync (Task 5) — no mocking CI.
+
+- [ ] **Step 3: Confirm the ruleset blocks a red merge**
+
+In the PR, confirm GitHub shows the three required checks as required and
+"Merge" is gated until green (visual confirmation in `gh pr view --web`
+or the merge box). Do not merge here — merging is handled by
+`superpowers:finishing-a-development-branch` after final review.
+
+- [ ] **Step 4: Report status**
+
+Report: branch pushed, PR number, all three CI contexts green, ruleset
+active and gating. Hand off to the final whole-branch review and
+`superpowers:finishing-a-development-branch`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3 CI workflow `check` → Task 4. `integration` (revised: no choreography) → Task 5. Triggers/concurrency/SHA-pins → Task 4. ✔
+- §4 pre-push hook + `just install-hooks` + distribution doc → Tasks 1–3, 6. ✔
+- §5 branch ruleset (exact `gh api`) + notification posture (manual, recorded) → Task 7 + Task 6. ✔
+- §6 testing: install-hooks unit test (temp repo) → Task 1; committed-hook mode/`just check` test → Task 2; "PR is its own acceptance" → Task 8. ✔
+- §7 flagged item 1 → resolved/moot, reconciled in Task 6 Step 3. Flagged item 2 (`--all-packages` kept for `check`) → Task 4 uses `--all-packages` as decided. ✔
+- §9 out-of-scope (no pre-commit framework, no macOS, no GPU) → respected; nothing added. ✔
+- §10 one-time setup → `just install-hooks` (Task 3/6), ruleset (Task 7), notification posture (Task 6 doc). ✔
+
+**Placeholder scan:** `<SYNC_CMD>` in Task 5 is an explicitly empirical value with two concrete acceptance gates and a context7 directive (not a vague placeholder); a worked example (Candidate A) is shown. `<id>` in Task 7 Step 3 is the ruleset id returned by Step 2's POST. Action SHAs are real (resolved via `gh api`). No "TBD/TODO/handle appropriately".
+
+**Type consistency:** `install_git_hooks(repo_root: Path) -> Path`, `HOOKS_DIR_NAME`, `HookInstallError`, `REQUIRED_HOOKS` are defined in Task 1 and used identically in Tasks 1–3 tests and the recipe. Status-check context strings (`check (ubuntu-latest)`, `check (windows-latest)`, `integration`) match the `matrix.os` job naming in Task 4/5 and the ruleset in Task 7 and `docs/setup/ci.md` in Task 6.

--- a/docs/superpowers/specs/2026-05-18-phase1-ci-gate-design.md
+++ b/docs/superpowers/specs/2026-05-18-phase1-ci-gate-design.md
@@ -1,0 +1,212 @@
+# Phase 1 — CI Gate: Design
+
+**Status:** approved in brainstorm 2026-05-18, ready for implementation plan.
+
+**Relationship to the maturity spec:** This refines the `Phase 1 — CI gate`
+section of `docs/superpowers/specs/2026-05-18-agent-core-maturity-design.md`.
+Where the two differ, **this document wins** (it carries decisions the
+umbrella spec did not settle: CPU-only integration deps, the concrete
+pre-push hook mechanism, the `check` matrix decision, concurrency). The
+umbrella spec's dependency order is unchanged: Phase 0 (done) → **Phase 1** →
+(2 ∥ 3) → 4.
+
+---
+
+## 1. Goal
+
+A CI gate so `main` is never red, with failures **rare but loud**:
+
+- Every push and PR runs the same quality gate developers run locally
+  (`just check`), on the OSes whose runtime actually diverges.
+- `main` is protected by a branch ruleset that requires the gate green.
+- A `pre-push` git hook keeps `main` green *by construction*, so CI
+  failures stay rare and therefore meaningful.
+- Failure emails stay **on** (the wanted alarm); they fire rarely because
+  the pre-push hook catches breakage before it leaves the developer's
+  machine.
+
+Phase 1 must land before Phases 2/3 so those are CI-protected.
+
+## 2. Context (verified 2026-05-18)
+
+- **Greenfield CI:** the repo has no `.github/` directory and zero branch
+  rulesets. Nothing to migrate.
+- **`justfile` exists:** `check: lint typecheck contracts test`.
+  `pyproject.toml` `addopts` already applies `-m 'not slow'`, so the
+  fast/slow split the design relies on already works. `set windows-shell
+  := ["cmd.exe", "/c"]` is already configured.
+- **No competing git hook in this repo.** `.git/hooks/` contains only
+  stock `*.sample` files. `core.hooksPath` is set (repo-local only; no
+  global) to the absolute path of `.git/hooks` — git's default made
+  explicit. The gstack secret-scan hook lives in the **separate
+  `~/.gstack/` repository** and scans *that* repo's commits, not
+  agent_core's. The umbrella spec's "leave the existing secret-scan hook
+  untouched" caveat therefore does not apply here: repointing
+  `core.hooksPath` shadows nothing.
+- **Torch/CUDA weight:** Torch lives almost entirely in
+  `agent-core-voice` (vendored Qwen3-TTS). The daemon core only passes
+  `--extra cu130` through `install.py`; it does not import torch itself.
+  `pytest` `testpaths` includes `packages/agent-core-voice/tests`, so the
+  fast suite collects voice tests.
+
+## 3. The CI workflow (`.github/workflows/ci.yml`)
+
+**Triggers:** `pull_request`, `push: [main]`, `workflow_dispatch`. Nothing
+scoped away — full visibility.
+
+**Concurrency:** group `${{ github.workflow }}-${{ github.ref }}`,
+`cancel-in-progress: true`. A new push to a PR cancels the superseded run.
+
+**Supply chain:** every third-party action is pinned by **commit SHA**
+(a tag can be moved; a SHA cannot), with a trailing comment recording the
+human-readable version.
+
+### Job `check` — the fast gate
+
+- Matrix `os: [ubuntu-latest, windows-latest]`, `fail-fast: false` (an
+  ubuntu break must not mask a Windows-only one; Windows is prod).
+- Rationale for the matrix: the OS-divergent bug surface for a Python
+  project (paths, newlines, shell/process, signals, platform-gated code)
+  splits along **Windows ↔ POSIX**. `ubuntu` is the cheap POSIX sample;
+  `windows` is prod. macOS would be a second POSIX sample at GitHub's
+  ~10× minutes multiplier with ~no unique catch (no Mac-specific code in
+  agent_core today). See §6 for when macOS earns a slot.
+- Steps:
+  1. `actions/checkout` with `fetch-depth: 0` and `fetch-tags: true`
+     (later phases' `git describe` needs full history + tags).
+  2. `astral-sh/setup-uv` (SHA-pinned), `enable-cache: true`,
+     `python-version: "3.12"`.
+  3. `extractions/setup-just` (SHA-pinned).
+  4. `uv sync --locked --all-packages` — **`--locked`**, not `--frozen`:
+     CI *must* fail on a stale lockfile.
+  5. `just check`.
+  6. `uv cache prune --ci`.
+
+### Job `integration` — daemon lifecycle (Windows only)
+
+- Runs on `windows-latest` only: bounce/refresh must hit the real prod
+  shell; it cannot be POSIX.
+- **CPU-only deps:** the daemon is installed/synced **without the
+  `cu130` extra**. A GitHub-hosted runner has no GPU; `cu130` is multi-GB
+  of wheels that can never be exercised there. The exact sync/daemon
+  install invocation that omits `cu130` is determined and verified at
+  plan time against the real daemon CLI (see §5, flagged item 1).
+- Steps:
+  1. Checkout, `setup-uv`, `setup-just` (as above).
+  2. Sync without `cu130`.
+  3. Create an ephemeral daemon: temporary `HOME` + a free port,
+     `agent-core daemon start`, poll `agent-core daemon status` until it
+     reports running (exact readiness signal verified at plan time).
+  4. `pytest -m slow` (includes the Phase 0 stale-cache regression).
+  5. **Always** tear down: an `if: always()` step runs
+     `agent-core daemon stop`.
+  6. On failure, upload the daemon log as a build artifact.
+- Because CPU-only makes this job light, it is a **required PR check**
+  (not deferred to `workflow_dispatch`-only) — a ruleset cannot require a
+  check that does not run on PRs.
+
+## 4. Pre-push hook + install recipe
+
+- **`.githooks/pre-push`** — version-controlled (so it is reviewed in
+  PRs and passes through Phase 1's own gate). A POSIX `sh` script (Git
+  for Windows ships `sh`, so it runs identically on the Windows box and on
+  macOS/Linux). It runs `just check` and forwards the exit code; non-zero
+  aborts the push. No per-OS logic in the hook.
+- **`just install-hooks`** — runs `git config core.hooksPath .githooks`
+  (relative path; resolves in the main checkout and in linked worktrees,
+  since `.githooks/` is version-controlled and present in every
+  checkout). Idempotent — re-running re-asserts the config.
+- **One-time per-clone bootstrap:** git deliberately will not auto-run
+  committed hook code, so a fresh clone or new worktree must run
+  `just install-hooks` once. This is inherent to git, not a design
+  choice; both candidate mechanisms had it, so it is accepted.
+- **`git push --no-verify`** is the deliberate emergency escape hatch.
+- **Distribution ("humans and agents get it identically"):**
+  `just install-hooks` is the single surface. It is documented in the
+  contributor bootstrap under `docs/setup/` and referenced from the
+  agent/daemon setup path, so an agent provisioning a workspace runs the
+  same recipe a human does.
+
+## 5. Branch ruleset on `main` + notification posture
+
+- **Branch ruleset** created from scratch via a `gh api` call whose exact
+  JSON payload is specified in the implementation plan (reproducible and
+  recorded, not a one-off UI click):
+  - Required status checks before merge: `check (ubuntu-latest)`,
+    `check (windows-latest)`, `integration` — all green.
+  - **Strict / up-to-date:** the branch must be current with `main`
+    before merge (no merging stale branches that passed against old
+    code).
+  - **Bypass list: the repo owner** — emergency direct push to `main`
+    preserved.
+  - **Deliberately not enabled:** required reviews (solo repo), signed
+    commits, linear history. The pre-push hook is the real enforcement;
+    the ruleset is the backstop.
+- **Notification posture** (one-time, owner's GitHub account; recorded in
+  the plan as a **manual** step — the implementer does not change account
+  settings): Settings → Notifications → Actions → **"Send notifications
+  for failed workflows only."** Failures always email (the wanted alarm);
+  successes are silent. Noise is controlled by *preventing* failures
+  (pre-push), not by muting the alarm.
+
+## 6. Testing strategy
+
+- **`just install-hooks` unit test:** in a throwaway temp git repo,
+  run the recipe and assert `git config core.hooksPath` resolves to
+  `.githooks` and the hook file is executable. Never touches the real
+  repo config.
+- **Workflow + ruleset validated by use:** the Phase 1 PR is itself the
+  first thing the new gate runs on. If `check`/`integration` do not go
+  green on Phase 1's own PR, Phase 1 is not done. No mocking CI.
+- **Hook exercised live:** every push from the moment it is installed;
+  `--no-verify` is the tested escape path.
+
+## 7. Flagged items (decisions recorded)
+
+1. **`integration` daemon must start without `cu130`.** Severity:
+   blocks the CPU-only integration job if false. Resolution: a **gating
+   plan-time verification step** — `uv sync` without the extra,
+   `agent-core daemon start`, confirm it comes up. If the daemon
+   hard-imports the GPU/Torch stack at boot, the fallback is `integration`
+   as `workflow_dispatch` + self-hosted only. This is a verification
+   step, not an assumption.
+2. **`uv sync --all-packages` in `check` pulls CPU Torch.** The fast
+   suite collects `packages/agent-core-voice/tests`, which likely import
+   Torch, so `--all-packages` is the safe correctness default. Decision:
+   **keep `--all-packages` for Phase 1** (do not expand Phase 1 scope).
+   Leaning the sync out (plus marking voice tests so they skip cleanly
+   without Torch) is recorded as a deliberate **future optimization**,
+   not Phase 1 work.
+
+## 8. Risks → mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Integration job can't run CPU-only (daemon hard-imports GPU stack) | Gating plan-time verification; fallback to `workflow_dispatch` + self-hosted (flagged item 1) |
+| Stale lockfile silently passes | `uv sync --locked` (not `--frozen`) fails CI fast |
+| Ubuntu-only failure masks a Windows-only break | Matrix includes `windows-latest`; `fail-fast: false` |
+| CI failures become ignorable noise | Pre-push keeps failures rare; "failed-only" email posture keeps the alarm meaningful |
+| Hook silently not installed on a fresh clone/worktree | Documented one-time `just install-hooks` in `docs/setup/` + agent setup path; unit-tested recipe |
+| A moved action tag injects malicious code | All third-party actions SHA-pinned |
+| `check` job slow due to Torch in `--all-packages` | Accepted for Phase 1; lean-out recorded as future optimization (flagged item 2) |
+
+## 9. Explicitly out of scope
+
+- `pre-commit` framework (redundant with `just check`; adds a toolchain
+  dependency).
+- Required reviews, signed commits, linear history on `main`.
+- macOS in the `check` matrix — revisit only when agent_core gains
+  Mac-specific code (e.g. a `launchd` auto-start analog to Phase 4's
+  Task Scheduler, or a `sys.platform == "darwin"` branch).
+- GPU/CUDA testing in CI (no GPU on hosted runners; GPU correctness is
+  validated by the real prod deploy + live-verify).
+- Phases 2–4 (versioning/releases, dev-prod instance-parameterization,
+  daemon auto-start) — separate specs/plans.
+
+## 10. One-time setup (recorded so it is not lost)
+
+- Per clone / per new worktree: `just install-hooks`.
+- Create the `main` branch ruleset (exact `gh api` call specified in the
+  implementation plan).
+- Set the GitHub Actions notification posture to "failed workflows only"
+  (owner's account; manual; not performed by the implementer).

--- a/docs/superpowers/specs/2026-05-18-phase1-ci-gate-design.md
+++ b/docs/superpowers/specs/2026-05-18-phase1-ci-gate-design.md
@@ -55,7 +55,13 @@ Phase 1 must land before Phases 2/3 so those are CI-protected.
 scoped away — full visibility.
 
 **Concurrency:** group `${{ github.workflow }}-${{ github.ref }}`,
-`cancel-in-progress: true`. A new push to a PR cancels the superseded run.
+`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.
+Superseded-run cancellation applies to PRs only — `push: [main]` runs
+always finish so every commit on `main` has a recorded green check.
+
+**Hardening:** a top-level `permissions: contents: read` restricts the
+workflow token to read-only access. Each job carries `timeout-minutes: 20`
+to prevent runaway billing from hung steps.
 
 **Supply chain:** every third-party action is pinned by **commit SHA**
 (a tag can be moved; a SHA cannot), with a trailing comment recording the
@@ -82,28 +88,26 @@ human-readable version.
   5. `just check`.
   6. `uv cache prune --ci`.
 
-### Job `integration` — daemon lifecycle (Windows only)
+### Job `integration` — slow suite (Windows only)
 
-- Runs on `windows-latest` only: bounce/refresh must hit the real prod
-  shell; it cannot be POSIX.
-- **CPU-only deps:** the daemon is installed/synced **without the
-  `cu130` extra**. A GitHub-hosted runner has no GPU; `cu130` is multi-GB
-  of wheels that can never be exercised there. The exact sync/daemon
-  install invocation that omits `cu130` is determined and verified at
-  plan time against the real daemon CLI (see §5, flagged item 1).
+- Runs on `windows-latest` only: the stale-cache regression must hit the
+  real prod shell; it cannot be POSIX.
+- **Narrow, Torch-free sync:** `uv sync --locked --package agent-core`.
+  This deliberately excludes `agent-core-voice` / `qwen-tts`. A
+  GitHub-hosted runner has no GPU; `--all-packages` here would pull
+  multi-GB Torch that can never be exercised. Do not "widen" this sync.
 - Steps:
-  1. Checkout, `setup-uv`, `setup-just` (as above).
-  2. Sync without `cu130`.
-  3. Create an ephemeral daemon: temporary `HOME` + a free port,
-     `agent-core daemon start`, poll `agent-core daemon status` until it
-     reports running (exact readiness signal verified at plan time).
-  4. `pytest -m slow` (includes the Phase 0 stale-cache regression).
-  5. **Always** tear down: an `if: always()` step runs
-     `agent-core daemon stop`.
-  6. On failure, upload the daemon log as a build artifact.
-- Because CPU-only makes this job light, it is a **required PR check**
-  (not deferred to `workflow_dispatch`-only) — a ruleset cannot require a
-  check that does not run on PRs.
+  1. Checkout, `setup-uv` (SHA-pinned, `enable-cache: true`,
+     `python-version: "3.12"`), `setup-just` (as above).
+  2. `uv sync --locked --package agent-core`.
+  3. `uv run --no-sync pytest packages/core/tests -m slow -v`.
+- The slow suite (`packages/core/tests/test_daemon_install_integration.py`)
+  is self-contained: it builds its own temporary workspace, needs no
+  running daemon, no `agent_core.yaml`, and no free port. No ephemeral
+  daemon is spun up; no teardown step is needed.
+- Because the job is light and self-contained, it is a **required PR
+  check** (not deferred to `workflow_dispatch`-only) — a ruleset cannot
+  require a check that does not run on PRs.
 
 ## 4. Pre-push hook + install recipe
 
@@ -153,8 +157,10 @@ human-readable version.
 
 - **`just install-hooks` unit test:** in a throwaway temp git repo,
   run the recipe and assert `git config core.hooksPath` resolves to
-  `.githooks` and the hook file is executable. Never touches the real
-  repo config.
+  `.githooks`. In addition, the test asserts the committed
+  `.githooks/pre-push` is tracked with git mode `100755`
+  (cross-platform-meaningful) — this check runs against the real repo,
+  not the temp repo. Never touches the real repo config.
 - **Workflow + ruleset validated by use:** the Phase 1 PR is itself the
   first thing the new gate runs on. If `check`/`integration` do not go
   green on Phase 1's own PR, Phase 1 is not done. No mocking CI.
@@ -163,13 +169,11 @@ human-readable version.
 
 ## 7. Flagged items (decisions recorded)
 
-1. **`integration` daemon must start without `cu130`.** Severity:
-   blocks the CPU-only integration job if false. Resolution: a **gating
-   plan-time verification step** — `uv sync` without the extra,
-   `agent-core daemon start`, confirm it comes up. If the daemon
-   hard-imports the GPU/Torch stack at boot, the fallback is `integration`
-   as `workflow_dispatch` + self-hosted only. This is a verification
-   step, not an assumption.
+1. **~~`integration` daemon must start without `cu130`.~~** **RESOLVED /
+   MOOT FOR CI.** The `integration` job's slow suite never starts the
+   supervised daemon — it is fully self-contained (builds its own temp
+   workspace). The question of whether the daemon can start without
+   `cu130` does not gate CI and is therefore moot for this phase.
 2. **`uv sync --all-packages` in `check` pulls CPU Torch.** The fast
    suite collects `packages/agent-core-voice/tests`, which likely import
    Torch, so `--all-packages` is the safe correctness default. Decision:
@@ -182,7 +186,7 @@ human-readable version.
 
 | Risk | Mitigation |
 |---|---|
-| Integration job can't run CPU-only (daemon hard-imports GPU stack) | Gating plan-time verification; fallback to `workflow_dispatch` + self-hosted (flagged item 1) |
+| ~~Integration job can't run CPU-only (daemon hard-imports GPU stack)~~ | MOOT — the slow suite is self-contained and never starts the daemon (flagged item 1, resolved) |
 | Stale lockfile silently passes | `uv sync --locked` (not `--frozen`) fails CI fast |
 | Ubuntu-only failure masks a Windows-only break | Matrix includes `windows-latest`; `fail-fast: false` |
 | CI failures become ignorable noise | Pre-push keeps failures rare; "failed-only" email posture keeps the alarm meaningful |

--- a/justfile
+++ b/justfile
@@ -62,3 +62,7 @@ test-channel:
 # Setup
 sync:
     uv sync --dev
+
+# Install this clone's git hooks (.githooks/) — run once per clone/worktree
+install-hooks:
+    uv run --no-sync python -m agent_core.githooks

--- a/packages/agent-core-busproxy/tests/test_cli.py
+++ b/packages/agent-core-busproxy/tests/test_cli.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 
 
 def test_cli_help_runs() -> None:
-    result = CliRunner().invoke(app, ["--help"], env={"COLUMNS": "200"})
+    result = CliRunner().invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "--agent" in result.output
     assert "--daemon-url" in result.output

--- a/packages/agent-core-busproxy/tests/test_cli.py
+++ b/packages/agent-core-busproxy/tests/test_cli.py
@@ -2,15 +2,28 @@
 
 from __future__ import annotations
 
+import re
+
 from agent_core_busproxy.__main__ import app
 from typer.testing import CliRunner
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _norm(text: str) -> str:
+    """Strip ANSI escape codes and collapse whitespace.
+
+    Typer/Rich splits option tokens with ANSI style spans under CI
+    (no COLUMNS, non-tty), so raw substring checks are unreliable.
+    """
+    return re.sub(r"\s+", " ", _ANSI_RE.sub("", text))
 
 
 def test_cli_help_runs() -> None:
     result = CliRunner().invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert "--agent" in result.output
-    assert "--daemon-url" in result.output
+    assert "--agent" in _norm(result.output)
+    assert "--daemon-url" in _norm(result.output)
 
 
 def test_cli_requires_agent() -> None:

--- a/packages/agent-core-busproxy/tests/test_cli.py
+++ b/packages/agent-core-busproxy/tests/test_cli.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 
 
 def test_cli_help_runs() -> None:
-    result = CliRunner().invoke(app, ["--help"])
+    result = CliRunner().invoke(app, ["--help"], env={"COLUMNS": "200"})
     assert result.exit_code == 0
     assert "--agent" in result.output
     assert "--daemon-url" in result.output

--- a/packages/agent-core-channel/tests/test_cli.py
+++ b/packages/agent-core-channel/tests/test_cli.py
@@ -9,7 +9,7 @@ from agent_core_channel.__main__ import app
 
 def test_cli_help_runs():
     runner = CliRunner()
-    result = runner.invoke(app, ["--help"], env={"COLUMNS": "200"})
+    result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "--agent" in result.output
     assert "--daemon-url" in result.output

--- a/packages/agent-core-channel/tests/test_cli.py
+++ b/packages/agent-core-channel/tests/test_cli.py
@@ -2,17 +2,30 @@
 
 from __future__ import annotations
 
+import re
+
 from typer.testing import CliRunner
 
 from agent_core_channel.__main__ import app
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _norm(text: str) -> str:
+    """Strip ANSI escape codes and collapse whitespace.
+
+    Typer/Rich splits option tokens with ANSI style spans under CI
+    (no COLUMNS, non-tty), so raw substring checks are unreliable.
+    """
+    return re.sub(r"\s+", " ", _ANSI_RE.sub("", text))
 
 
 def test_cli_help_runs():
     runner = CliRunner()
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert "--agent" in result.output
-    assert "--daemon-url" in result.output
+    assert "--agent" in _norm(result.output)
+    assert "--daemon-url" in _norm(result.output)
 
 
 def test_cli_requires_agent():

--- a/packages/agent-core-channel/tests/test_cli.py
+++ b/packages/agent-core-channel/tests/test_cli.py
@@ -9,7 +9,7 @@ from agent_core_channel.__main__ import app
 
 def test_cli_help_runs():
     runner = CliRunner()
-    result = runner.invoke(app, ["--help"])
+    result = runner.invoke(app, ["--help"], env={"COLUMNS": "200"})
     assert result.exit_code == 0
     assert "--agent" in result.output
     assert "--daemon-url" in result.output

--- a/packages/core/src/agent_core/daemon/install.py
+++ b/packages/core/src/agent_core/daemon/install.py
@@ -154,6 +154,7 @@ def run_install(
     venv = home / ".venv"
 
     # Step 1: create / refresh the venv with the pinned Python.
+    # --clear is required: uv >= 0.10 refuses to reuse an existing venv without it
     venv_cmd = ["uv", "venv", str(venv), "--python", python_version, "--clear"]
     try:
         result = subprocess.run(venv_cmd, capture_output=True, text=True, check=False)

--- a/packages/core/src/agent_core/daemon/install.py
+++ b/packages/core/src/agent_core/daemon/install.py
@@ -154,7 +154,7 @@ def run_install(
     venv = home / ".venv"
 
     # Step 1: create / refresh the venv with the pinned Python.
-    venv_cmd = ["uv", "venv", str(venv), "--python", python_version]
+    venv_cmd = ["uv", "venv", str(venv), "--python", python_version, "--clear"]
     try:
         result = subprocess.run(venv_cmd, capture_output=True, text=True, check=False)
     except FileNotFoundError as exc:

--- a/packages/core/src/agent_core/githooks.py
+++ b/packages/core/src/agent_core/githooks.py
@@ -53,7 +53,11 @@ def main() -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
     except subprocess.CalledProcessError as exc:
-        print(f"error: git config failed (exit {exc.returncode})", file=sys.stderr)
+        msg = f"error: git config failed (exit {exc.returncode})"
+        stderr = exc.stderr
+        if stderr:
+            msg += f"\n{stderr.rstrip()}"
+        print(msg, file=sys.stderr)
         return 1
     print(f"git hooks installed: core.hooksPath -> {HOOKS_DIR_NAME} ({hooks_dir})")
     return 0

--- a/packages/core/src/agent_core/githooks.py
+++ b/packages/core/src/agent_core/githooks.py
@@ -1,0 +1,63 @@
+"""Install this clone's version-controlled git hooks (.githooks/).
+
+`just install-hooks` wraps `main()`. Logic lives here (not in the recipe)
+so it is directly unit-testable, mirroring daemon/install.py vs
+daemon/cli.py.
+
+A relative `core.hooksPath` of ".githooks" is resolved by git relative
+to the working-tree root at hook-trigger time, so it is correct for the
+main checkout and every linked worktree (each has its own committed
+.githooks/ directory).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+HOOKS_DIR_NAME = ".githooks"
+REQUIRED_HOOKS = ("pre-push",)
+
+
+class HookInstallError(Exception):
+    """Raised when the versioned hooks directory is missing or incomplete."""
+
+
+def install_git_hooks(repo_root: Path) -> Path:
+    """Point `repo_root`'s git at `<repo_root>/.githooks`. Idempotent.
+
+    Returns the resolved hooks directory. Raises HookInstallError if
+    `.githooks/pre-push` is absent, so a broken checkout fails loudly
+    instead of silently disabling the gate.
+    """
+    repo_root = repo_root.resolve()
+    hooks_dir = repo_root / HOOKS_DIR_NAME
+    for hook in REQUIRED_HOOKS:
+        if not (hooks_dir / hook).is_file():
+            raise HookInstallError(
+                f"missing {HOOKS_DIR_NAME}/{hook} under {repo_root} — "
+                "run this from the agent_core repo root"
+            )
+    subprocess.run(
+        ["git", "-C", str(repo_root), "config", "core.hooksPath", HOOKS_DIR_NAME],
+        check=True,
+    )
+    return hooks_dir
+
+
+def main() -> int:
+    try:
+        hooks_dir = install_git_hooks(Path.cwd())
+    except HookInstallError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(f"error: git config failed (exit {exc.returncode})", file=sys.stderr)
+        return 1
+    print(f"git hooks installed: core.hooksPath -> {HOOKS_DIR_NAME} ({hooks_dir})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/core/tests/bus/test_cli_run.py
+++ b/packages/core/tests/bus/test_cli_run.py
@@ -1,6 +1,7 @@
 """Tests for `agent-core bus run` — the long-running entry point."""
 
 import asyncio
+import os
 import signal
 import sys
 from pathlib import Path
@@ -56,8 +57,23 @@ class TestBusRunCLI:
             str(cfg_path),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env={**os.environ, "PYTHONUNBUFFERED": "1"},
         )
-        await asyncio.sleep(1.0)  # let it boot
+
+        async def _wait_until_ready() -> None:
+            assert proc.stdout is not None
+            while True:
+                line = await proc.stdout.readline()
+                if not line:
+                    raise AssertionError("bus exited before it became ready")
+                if b"bus running" in line:
+                    return
+
+        # Wait for the readiness line rather than a fixed sleep: on slow CI a
+        # fixed sleep can fire SIGINT before the signal handler is installed,
+        # which default-terminates the process (returncode -2) instead of a
+        # clean shutdown.
+        await asyncio.wait_for(_wait_until_ready(), timeout=30.0)
         proc.send_signal(signal.SIGINT)
         try:
             await asyncio.wait_for(proc.wait(), timeout=10.0)

--- a/packages/core/tests/bus/test_cli_run.py
+++ b/packages/core/tests/bus/test_cli_run.py
@@ -76,9 +76,11 @@ class TestBusRunCLI:
         await asyncio.wait_for(_wait_until_ready(), timeout=30.0)
         proc.send_signal(signal.SIGINT)
         try:
-            await asyncio.wait_for(proc.wait(), timeout=10.0)
+            # communicate() drains stdout+stderr while waiting, so a chatty
+            # bus can't fill the OS pipe buffer and deadlock proc.wait().
+            await asyncio.wait_for(proc.communicate(), timeout=10.0)
         except TimeoutError:
             proc.kill()
-            await proc.wait()
+            await proc.communicate()
             pytest.fail("bus did not shut down on SIGINT")
         assert proc.returncode == 0

--- a/packages/core/tests/test_bus_log_cli.py
+++ b/packages/core/tests/test_bus_log_cli.py
@@ -51,7 +51,7 @@ def test_bus_log_show_requires_agent(sample_log: Path):
         "bus-log", "show",
         "--date", "2026-05-03",
         "--log-root", str(sample_log),
-    ], env={"COLUMNS": "200"})
+    ])
     assert result.exit_code == 2
     assert "Missing option" in result.output
     assert "--agent" in result.output

--- a/packages/core/tests/test_bus_log_cli.py
+++ b/packages/core/tests/test_bus_log_cli.py
@@ -51,7 +51,7 @@ def test_bus_log_show_requires_agent(sample_log: Path):
         "bus-log", "show",
         "--date", "2026-05-03",
         "--log-root", str(sample_log),
-    ])
+    ], env={"COLUMNS": "200"})
     assert result.exit_code == 2
     assert "Missing option" in result.output
     assert "--agent" in result.output

--- a/packages/core/tests/test_bus_log_cli.py
+++ b/packages/core/tests/test_bus_log_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -11,6 +12,17 @@ from typer.testing import CliRunner
 
 from agent_core.bus.envelope import Envelope, TextMessagePayload
 from agent_core.cli import app
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _norm(text: str) -> str:
+    """Strip ANSI escape codes and collapse whitespace.
+
+    Typer/Rich splits option tokens with ANSI style spans under CI
+    (no COLUMNS, non-tty), so raw substring checks are unreliable.
+    """
+    return re.sub(r"\s+", " ", _ANSI_RE.sub("", text))
 
 
 @pytest.fixture
@@ -53,8 +65,8 @@ def test_bus_log_show_requires_agent(sample_log: Path):
         "--log-root", str(sample_log),
     ])
     assert result.exit_code == 2
-    assert "Missing option" in result.output
-    assert "--agent" in result.output
+    assert "Missing option" in _norm(result.output)
+    assert "--agent" in _norm(result.output)
 
 
 def test_bus_log_show_projected_default_filters_to_agent(sample_log: Path):

--- a/packages/core/tests/test_daemon_install.py
+++ b/packages/core/tests/test_daemon_install.py
@@ -155,10 +155,11 @@ def test_run_install_invokes_uv_venv_then_uv_sync(
 
     run_install(home=home, workspace=workspace, extra="cu130", python_version="3.12")
 
-    # First call: uv venv ... --python 3.12
+    # First call: uv venv ... --python 3.12 --clear
     assert calls[0][:2] == ["uv", "venv"]
     assert "--python" in calls[0]
     assert "3.12" in calls[0]
+    assert "--clear" in calls[0]
     # Second call: uv sync --frozen --no-editable --no-dev --extra cu130
     assert calls[1] == [
         "uv",

--- a/packages/core/tests/test_githooks.py
+++ b/packages/core/tests/test_githooks.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from agent_core.githooks import HOOKS_DIR_NAME, HookInstallError, install_git_hooks
+from agent_core.githooks import HOOKS_DIR_NAME, HookInstallError, install_git_hooks, main
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -59,3 +59,27 @@ def test_install_raises_when_pre_push_missing(tmp_path: Path) -> None:
 
     with pytest.raises(HookInstallError, match="pre-push"):
         install_git_hooks(repo)
+
+
+def test_main_succeeds_in_repo_with_hooks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _make_hooks(repo)
+    monkeypatch.chdir(repo)
+
+    assert main() == 0
+    assert _git(repo, "config", "--get", "core.hooksPath") == HOOKS_DIR_NAME
+    assert "git hooks installed" in capsys.readouterr().out
+
+
+def test_main_returns_1_when_hooks_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)  # no .githooks directory
+    monkeypatch.chdir(repo)
+
+    assert main() == 1

--- a/packages/core/tests/test_githooks.py
+++ b/packages/core/tests/test_githooks.py
@@ -1,0 +1,61 @@
+"""Unit tests for agent_core.githooks.install_git_hooks (temp git repos only)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent_core.githooks import HOOKS_DIR_NAME, HookInstallError, install_git_hooks
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    return repo
+
+
+def _make_hooks(repo: Path) -> Path:
+    hooks = repo / HOOKS_DIR_NAME
+    hooks.mkdir()
+    (hooks / "pre-push").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    return hooks
+
+
+def test_install_sets_hookspath_to_githooks(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    hooks = _make_hooks(repo)
+
+    returned = install_git_hooks(repo)
+
+    assert returned == hooks.resolve()
+    assert _git(repo, "config", "--get", "core.hooksPath") == HOOKS_DIR_NAME
+
+
+def test_install_is_idempotent(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _make_hooks(repo)
+
+    install_git_hooks(repo)
+    install_git_hooks(repo)  # second run must not raise
+
+    assert _git(repo, "config", "--get", "core.hooksPath") == HOOKS_DIR_NAME
+
+
+def test_install_raises_when_pre_push_missing(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / HOOKS_DIR_NAME).mkdir()  # dir exists but pre-push absent
+
+    with pytest.raises(HookInstallError, match="pre-push"):
+        install_git_hooks(repo)

--- a/packages/core/tests/test_githooks.py
+++ b/packages/core/tests/test_githooks.py
@@ -83,3 +83,23 @@ def test_main_returns_1_when_hooks_missing(
     monkeypatch.chdir(repo)
 
     assert main() == 1
+
+
+def test_committed_pre_push_runs_just_check_and_is_executable() -> None:
+    """The real .githooks/pre-push must exist, invoke `just check`, and be
+    tracked with git's executable mode (100755) so it runs on a fresh clone.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    hook = repo_root / ".githooks" / "pre-push"
+    assert hook.is_file(), f"{hook} missing"
+
+    body = hook.read_text(encoding="utf-8")
+    assert "just check" in body
+
+    mode = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "--stage", ".githooks/pre-push"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.split()
+    assert mode and mode[0] == "100755", f"pre-push git mode is {mode[:1]}, want 100755"

--- a/packages/core/tests/test_githooks.py
+++ b/packages/core/tests/test_githooks.py
@@ -89,12 +89,16 @@ def test_committed_pre_push_runs_just_check_and_is_executable() -> None:
     """The real .githooks/pre-push must exist, invoke `just check`, and be
     tracked with git's executable mode (100755) so it runs on a fresh clone.
     """
-    repo_root = Path(__file__).resolve().parents[3]
+    repo_root = next(
+        p for p in Path(__file__).resolve().parents if (p / ".githooks").is_dir()
+    )
     hook = repo_root / ".githooks" / "pre-push"
     assert hook.is_file(), f"{hook} missing"
 
     body = hook.read_text(encoding="utf-8")
+    assert body.startswith("#!/bin/sh")
     assert "just check" in body
+    assert "\r\n" not in body, "pre-push contains CRLF line endings (breaks on Linux CI)"
 
     mode = subprocess.run(
         ["git", "-C", str(repo_root), "ls-files", "--stage", ".githooks/pre-push"],


### PR DESCRIPTION
## Summary

Implements Phase 1 of the agent_core maturity initiative — a greenfield CI gate so `main` is never red, with failures rare-but-loud.

- **`.github/workflows/ci.yml`**: `check` matrix (ubuntu+windows, `fail-fast: false`, `timeout-minutes: 20`) running `just check`; `integration` (windows-latest) running the self-contained slow suite via a narrow Torch-free `uv sync --locked --package agent-core`. Triggers: PR + push:main + workflow_dispatch. All third-party actions SHA-pinned. Top-level `permissions: contents: read`; `cancel-in-progress` scoped to PRs so `push:[main]` runs always finish.
- **Pre-push hook**: version-controlled `.githooks/pre-push` (`exec just check`, git mode 100755) + `just install-hooks` recipe (sets `core.hooksPath`), backed by a unit-tested `agent_core.githooks` module.
- **Branch ruleset** `phase1-main-gate` (already created, active): requires the 3 CI contexts green + branch up-to-date; owner on bypass.
- **Docs**: `docs/setup/ci.md` contributor bootstrap; Phase 1 spec reconciled with the as-built implementation.

Spec: `docs/superpowers/specs/2026-05-18-phase1-ci-gate-design.md`
Plan: `docs/superpowers/plans/2026-05-18-phase1-ci-gate.md`

## Test plan

- [ ] `check (ubuntu-latest)` green
- [ ] `check (windows-latest)` green
- [ ] `integration` green (Torch-free slow suite incl. Phase 0 regression)
- [ ] Ruleset blocks merge until all three are green
- [x] Pre-push hook ran `just check` on push (1168 passed)