### PR TITLE
Phase 1.5: local guard for missing core.hooksPath per worktree

### DIFF
--- a/docs/setup/ci.md
+++ b/docs/setup/ci.md
@@ -2,12 +2,20 @@
 
 ## One-time per clone or worktree
 
-On a fresh clone or new worktree, in this order:
+On a fresh clone OR each new `git worktree add`, in this order:
 
 ```
 uv sync          # or: just sync  — populates the env
 just install-hooks
 ```
+
+**`core.hooksPath` is per-worktree-local in git.** It does NOT carry over
+when you `git worktree add` a new linked worktree — each fresh worktree
+starts with the default `.git/hooks` (empty) and the pre-push hook will
+NOT fire until you run `just install-hooks` there. If you forget, the
+fast guard test `packages/core/tests/test_hookspath_local_guard.py` fails
+on the next `just check` with a clear "run `just install-hooks`" message
+(the guard skips in CI, where the hook isn't needed).
 
 `just install-hooks` runs `uv run --no-sync python -m agent_core.githooks`,
 which points `core.hooksPath` at the version-controlled `.githooks/`. It

--- a/packages/core/tests/test_hookspath_local_guard.py
+++ b/packages/core/tests/test_hookspath_local_guard.py
@@ -1,0 +1,47 @@
+"""Local guard: in a developer worktree, `core.hooksPath` must be set so the
+pre-push hook fires before `git push`. Skipped in CI (the runner clones
+fresh, never runs `just install-hooks`, and doesn't need a pre-push hook —
+the workflow IS the gate there).
+
+This catches the very-common "I `git worktree add`-ed a fresh worktree and
+forgot to re-run `just install-hooks`" footgun on the first `just check`
+rather than letting the bad push reach origin.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent_core.daemon.install import find_workspace_root
+from agent_core.githooks import HOOKS_DIR_NAME
+
+
+def _is_ci() -> bool:
+    # GitHub Actions, Travis, CircleCI, GitLab CI, etc. all set CI=true.
+    return os.environ.get("CI", "").lower() in {"true", "1", "yes"}
+
+
+@pytest.mark.skipif(_is_ci(), reason="CI runner — pre-push hook not used")
+def test_core_hookspath_points_at_versioned_hooks() -> None:
+    root = find_workspace_root(Path(__file__))
+    result = subprocess.run(
+        ["git", "-C", str(root), "config", "--get", "core.hooksPath"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    actual = result.stdout.strip()
+    # The recipe sets it to the relative string ".githooks"; some setups may
+    # resolve to an absolute path ending in `.githooks`. Accept either, but
+    # reject the default `.git/hooks` (no trailing `.githooks`).
+    ok = actual.endswith(HOOKS_DIR_NAME) and "/.git/hooks" not in actual.replace(
+        "\\", "/"
+    ).rstrip("/").lower()
+    assert ok, (
+        f"core.hooksPath = {actual!r} — the version-controlled pre-push hook "
+        f"will NOT fire from this worktree. Run: just install-hooks"
+    )


### PR DESCRIPTION
## Summary

Closes the Phase-1 follow-up surfaced during Phase 2: `core.hooksPath` is per-worktree-local in git, so a freshly-created `git worktree add` starts without it and the pre-push hook silently doesn't fire there until `just install-hooks` is re-run.

- `docs/setup/ci.md` — strengthens the existing per-worktree section to make the per-worktree-local nature explicit, and points at the new guard test.
- `packages/core/tests/test_hookspath_local_guard.py` — fast test that fails locally with a clear "run `just install-hooks`" message if `core.hooksPath` isn't pointing at `.githooks`. Skipped in CI (the runner has no use for the hook). Verified RED/GREEN/SKIPPED locally.

## Test plan

- [ ] `check (ubuntu-latest)` green
- [ ] `check (windows-latest)` green
- [ ] `integration` green
- [ ] Ruleset blocks merge until all three are green