### PR TITLE
feat(daemon): windows daemon auto-start (Phase 4)

### DIFF
--- a/docs/setup/daemon.md
+++ b/docs/setup/daemon.md
@@ -222,3 +222,32 @@ agents no longer launch via `uv run --project`):
 Both surfaces are stdio and reconnect independently. The old
 `{"type":"http","url":".../mcp/<agent>"}` form is the #91 failure mode —
 do not use it.
+
+## Auto-start at boot (Windows)
+
+The prod daemon can register itself with Windows Task Scheduler so it
+returns automatically after a reboot — no manual `daemon start`.
+
+```bash
+# Register the autostart task (prod only). Prompts whether to start now.
+agent-core daemon install-autostart
+
+# Remove it.
+agent-core daemon uninstall-autostart
+```
+
+`install-autostart` registers a Task Scheduler task named
+`agent-core-daemon-prod` that runs `agent-core daemon start --instance
+prod` at your logon, with restart-on-failure and start-when-available.
+It runs as your own user with least privilege (the daemon binds
+127.0.0.1 only — no admin needed).
+
+`install-autostart` requires the prod daemon to be installed first
+(`agent-core daemon install`) — it points the task at
+`~/.agent-core/.venv/Scripts/agent-core.exe`. Re-running it replaces the
+existing task (idempotent). Pass `--no-start` / `--start` to skip the
+"start now?" prompt in non-interactive use.
+
+Auto-start is prod-only and Windows-only. It brings the **daemon** back
+after a reboot; auto-launching Pepper's own Claude Code session is a
+separate, still-open problem.

--- a/docs/superpowers/plans/2026-05-22-phase4-windows-autostart.md
+++ b/docs/superpowers/plans/2026-05-22-phase4-windows-autostart.md
@@ -1,0 +1,766 @@
+# Phase 4 — Windows Daemon Auto-Start Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `agent-core daemon install-autostart` / `uninstall-autostart` so the prod daemon comes back automatically at logon after a reboot (Windows Task Scheduler).
+
+**Architecture:** A new pure/impure module `daemon/autostart.py` — `build_autostart_task` (pure) returns the Task Scheduler XML; `install_autostart` / `uninstall_autostart` (impure) shell out to `schtasks`. Two new `daemon/cli.py` commands wire them up, prod-only, with a Windows guard and an interactive "start now?" prompt.
+
+**Tech Stack:** Python 3.12, Typer, `schtasks.exe` (Windows), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-05-22-phase4-windows-autostart-design.md`
+
+**Worktree:** already created at `.worktrees/phase4-windows-autostart` on branch `feat/phase4-windows-autostart` (off `origin/main`, has Phase 3). Run all commands from inside that worktree. First, sync its venv + hooks:
+
+```bash
+cd .worktrees/phase4-windows-autostart
+uv sync
+just install-hooks
+```
+
+---
+
+## File structure
+
+### New files
+- `packages/core/src/agent_core/daemon/autostart.py` — `TASK_NAME`, `build_autostart_task` (pure), `install_autostart` / `uninstall_autostart` (impure).
+- `packages/core/tests/test_daemon_autostart.py` — unit tests for autostart.py (pure builder + faked-subprocess wrappers).
+
+### Modified files
+- `packages/core/src/agent_core/daemon/cli.py` — add `install-autostart` + `uninstall-autostart` commands.
+- `packages/core/tests/test_daemon_cli.py` — add command tests (faked subprocess) + one `slow` real-`schtasks` integration test.
+- `docs/setup/daemon.md` — add an "Auto-start at boot" section.
+
+---
+
+## Task 1: `daemon/autostart.py` — the module (TDD)
+
+**Files:**
+- Create: `packages/core/src/agent_core/daemon/autostart.py`
+- Test: `packages/core/tests/test_daemon_autostart.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Write to `packages/core/tests/test_daemon_autostart.py`:
+```python
+"""Unit tests for daemon/autostart.py — Task Scheduler registration."""
+from __future__ import annotations
+
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from agent_core.daemon.autostart import (
+    TASK_NAME,
+    build_autostart_task,
+    install_autostart,
+    uninstall_autostart,
+)
+
+# Task Scheduler XML namespace.
+_NS = {"t": "http://schemas.microsoft.com/windows/2004/02/mit/task"}
+
+
+# ---- build_autostart_task (pure) -------------------------------------------
+
+def test_task_name_constant() -> None:
+    assert TASK_NAME == "agent-core-daemon-prod"
+
+
+def test_build_autostart_task_is_well_formed_xml() -> None:
+    xml = build_autostart_task(
+        agent_core_exe=Path(r"C:\Users\x\.agent-core\.venv\Scripts\agent-core.exe"),
+        account="x",
+    )
+    # Must parse without error.
+    ET.fromstring(xml)
+
+
+def test_build_autostart_task_action_command_and_args() -> None:
+    exe = Path(r"C:\Users\x\.agent-core\.venv\Scripts\agent-core.exe")
+    xml = build_autostart_task(agent_core_exe=exe, account="x")
+    root = ET.fromstring(xml)
+    command = root.find(".//t:Actions/t:Exec/t:Command", _NS)
+    arguments = root.find(".//t:Actions/t:Exec/t:Arguments", _NS)
+    assert command is not None and command.text == str(exe)
+    assert arguments is not None
+    assert arguments.text == "daemon start --instance prod"
+
+
+def test_build_autostart_task_has_logon_trigger_for_account() -> None:
+    xml = build_autostart_task(
+        agent_core_exe=Path(r"C:\x\agent-core.exe"), account="jeffr"
+    )
+    root = ET.fromstring(xml)
+    trigger = root.find(".//t:Triggers/t:LogonTrigger", _NS)
+    assert trigger is not None
+    user = trigger.find("t:UserId", _NS)
+    assert user is not None and user.text == "jeffr"
+
+
+def test_build_autostart_task_settings() -> None:
+    xml = build_autostart_task(
+        agent_core_exe=Path(r"C:\x\agent-core.exe"), account="x"
+    )
+    root = ET.fromstring(xml)
+    settings = root.find("t:Settings", _NS)
+    assert settings is not None
+    assert settings.findtext("t:MultipleInstancesPolicy", namespaces=_NS) == "IgnoreNew"
+    assert settings.findtext("t:StartWhenAvailable", namespaces=_NS) == "true"
+    assert settings.findtext("t:ExecutionTimeLimit", namespaces=_NS) == "PT0S"
+    restart = settings.find("t:RestartOnFailure", _NS)
+    assert restart is not None
+    assert restart.findtext("t:Interval", namespaces=_NS) == "PT1M"
+    assert restart.findtext("t:Count", namespaces=_NS) == "3"
+
+
+def test_build_autostart_task_principal_is_least_privilege() -> None:
+    xml = build_autostart_task(
+        agent_core_exe=Path(r"C:\x\agent-core.exe"), account="jeffr"
+    )
+    root = ET.fromstring(xml)
+    principal = root.find(".//t:Principals/t:Principal", _NS)
+    assert principal is not None
+    assert principal.findtext("t:RunLevel", namespaces=_NS) == "LeastPrivilege"
+    assert principal.findtext("t:UserId", namespaces=_NS) == "jeffr"
+
+
+# ---- install_autostart / uninstall_autostart (impure, faked subprocess) ----
+
+def test_install_autostart_invokes_schtasks_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(cmd)
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr("agent_core.daemon.autostart.subprocess.run", fake_run)
+
+    install_autostart("<Task></Task>")
+
+    assert len(calls) == 1
+    cmd = calls[0]
+    assert cmd[0] == "schtasks"
+    assert "/create" in cmd
+    assert "/tn" in cmd and TASK_NAME in cmd
+    assert "/xml" in cmd
+    assert "/f" in cmd
+
+
+def test_install_autostart_raises_on_schtasks_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "ERROR: Access is denied."
+        return _R()
+
+    monkeypatch.setattr("agent_core.daemon.autostart.subprocess.run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        install_autostart("<Task></Task>")
+
+
+def test_uninstall_autostart_returns_true_on_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        class _R:
+            returncode = 0
+            stdout = "SUCCESS"
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr("agent_core.daemon.autostart.subprocess.run", fake_run)
+    assert uninstall_autostart() is True
+
+
+def test_uninstall_autostart_returns_false_when_task_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "ERROR: The system cannot find the file specified."
+        return _R()
+
+    monkeypatch.setattr("agent_core.daemon.autostart.subprocess.run", fake_run)
+    assert uninstall_autostart() is False
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run --no-sync pytest packages/core/tests/test_daemon_autostart.py -v`
+Expected: `ModuleNotFoundError: No module named 'agent_core.daemon.autostart'`
+
+- [ ] **Step 3: Implement `daemon/autostart.py`**
+
+Write to `packages/core/src/agent_core/daemon/autostart.py`:
+```python
+"""Windows daemon auto-start — register the prod daemon as a Task Scheduler task.
+
+Pure/impure split (project convention, mirrors build_uv_sync_command /
+run_install): `build_autostart_task` is pure (returns the Task Scheduler XML),
+`install_autostart` / `uninstall_autostart` are thin impure shells that run
+`schtasks`.
+
+Windows-only at the `schtasks` boundary. The pure builder is plain
+string-building and works on any platform, so its tests run on any CI OS.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+TASK_NAME = "agent-core-daemon-prod"
+
+
+def build_autostart_task(*, agent_core_exe: Path, account: str) -> str:
+    """Return the Task Scheduler XML registering the prod daemon at logon.
+
+    The task runs `<agent_core_exe> daemon start --instance prod` at
+    `account`'s logon, with restart-on-failure (PT1M x3), start-when-
+    available, ignore-new-instance, no execution time limit, least
+    privilege.
+    """
+    return (
+        '<?xml version="1.0" encoding="UTF-16"?>\n'
+        '<Task version="1.2" '
+        'xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n'
+        "  <RegistrationInfo>\n"
+        "    <Description>agent-core prod daemon auto-start at logon."
+        "</Description>\n"
+        "  </RegistrationInfo>\n"
+        "  <Triggers>\n"
+        "    <LogonTrigger>\n"
+        "      <Enabled>true</Enabled>\n"
+        f"      <UserId>{account}</UserId>\n"
+        "    </LogonTrigger>\n"
+        "  </Triggers>\n"
+        "  <Principals>\n"
+        '    <Principal id="Author">\n'
+        f"      <UserId>{account}</UserId>\n"
+        "      <LogonType>InteractiveToken</LogonType>\n"
+        "      <RunLevel>LeastPrivilege</RunLevel>\n"
+        "    </Principal>\n"
+        "  </Principals>\n"
+        "  <Settings>\n"
+        "    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n"
+        "    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>\n"
+        "    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\n"
+        "    <StartWhenAvailable>true</StartWhenAvailable>\n"
+        "    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>\n"
+        "    <Enabled>true</Enabled>\n"
+        "    <RestartOnFailure>\n"
+        "      <Interval>PT1M</Interval>\n"
+        "      <Count>3</Count>\n"
+        "    </RestartOnFailure>\n"
+        "  </Settings>\n"
+        '  <Actions Context="Author">\n'
+        "    <Exec>\n"
+        f"      <Command>{agent_core_exe}</Command>\n"
+        "      <Arguments>daemon start --instance prod</Arguments>\n"
+        "    </Exec>\n"
+        "  </Actions>\n"
+        "</Task>\n"
+    )
+
+
+def install_autostart(xml: str) -> None:
+    """Register (or replace) the autostart task from `xml`.
+
+    Writes the XML to a temp file (UTF-16 — the Task Scheduler XML prolog
+    declares UTF-16) and runs `schtasks /create /tn <TASK_NAME> /xml
+    <file> /f`. Raises subprocess.CalledProcessError on a non-zero exit.
+    """
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-16", suffix=".xml", delete=False
+    ) as fh:
+        fh.write(xml)
+        xml_path = fh.name
+    try:
+        result = subprocess.run(
+            ["schtasks", "/create", "/tn", TASK_NAME, "/xml", xml_path, "/f"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        Path(xml_path).unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            ["schtasks", "/create", "/tn", TASK_NAME, "/xml", "...", "/f"],
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+
+
+def uninstall_autostart() -> bool:
+    """Delete the autostart task. Returns True if a task was deleted,
+    False if no such task existed. Idempotent — never raises for a
+    missing task."""
+    result = subprocess.run(
+        ["schtasks", "/delete", "/tn", TASK_NAME, "/f"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run --no-sync pytest packages/core/tests/test_daemon_autostart.py -v`
+Expected: 10 tests pass.
+
+- [ ] **Step 5: Lint + typecheck**
+
+Run: `uv run --no-sync ruff check --fix packages/core/src/agent_core/daemon/autostart.py packages/core/tests/test_daemon_autostart.py && uv run --no-sync ruff check packages/core/src/agent_core/daemon/autostart.py packages/core/tests/test_daemon_autostart.py && uv run --no-sync mypy packages/core/src/agent_core/daemon/autostart.py`
+Expected: all clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/agent_core/daemon/autostart.py packages/core/tests/test_daemon_autostart.py
+git commit -m "feat(daemon): autostart.py — Task Scheduler XML builder + schtasks wrappers"
+```
+
+---
+
+## Task 2: `install-autostart` / `uninstall-autostart` CLI commands
+
+**Files:**
+- Modify: `packages/core/src/agent_core/daemon/cli.py`
+- Test: `packages/core/tests/test_daemon_cli.py`
+
+- [ ] **Step 1: Add the import**
+
+In `packages/core/src/agent_core/daemon/cli.py`, add to the import block
+(after the other `agent_core.daemon.*` imports):
+```python
+from agent_core.daemon import autostart
+```
+
+Importing the module (not the names) avoids any collision between the
+command function `install_autostart` and the module function
+`autostart.install_autostart`.
+
+- [ ] **Step 2: Add the two commands**
+
+Append to `packages/core/src/agent_core/daemon/cli.py` (after the
+`refresh` command, before the trailing `_git_sha_of_tag` helper — or at
+end of file, ordering does not matter to Typer):
+```python
+@app.command()
+def install_autostart(
+    instance: str | None = _INSTANCE_OPTION,
+    start: bool | None = typer.Option(
+        None,
+        "--start/--no-start",
+        help="Start the daemon now without prompting (for non-interactive use).",
+    ),
+) -> None:
+    """Register the prod daemon to auto-start at logon (Windows Task Scheduler)."""
+    inst = _resolve(instance)
+    if inst is not Instance.PROD:
+        console.print(
+            "[red]autostart is prod-only[/red] — the dev instance is started "
+            "by hand from the workspace."
+        )
+        raise typer.Exit(code=1)
+    if sys.platform != "win32":
+        console.print("[red]autostart is Windows-only.[/red]")
+        raise typer.Exit(code=1)
+
+    home = home_for(inst)
+    exe = home / ".venv" / "Scripts" / "agent-core.exe"
+    if not exe.exists():
+        console.print(
+            f"[red]prod daemon is not installed ({exe} missing).[/red]\n"
+            "   Run [bold]agent-core daemon install[/bold] first."
+        )
+        raise typer.Exit(code=1)
+
+    # USERNAME is always set on Windows; os.getlogin() is the fallback.
+    account = os.environ.get("USERNAME") or os.getlogin()
+    xml = autostart.build_autostart_task(agent_core_exe=exe, account=account)
+    try:
+        autostart.install_autostart(xml)
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]schtasks failed (exit {exc.returncode}).[/red]")
+        if exc.stderr:
+            console.print(exc.stderr.rstrip())
+        raise typer.Exit(code=1) from exc
+
+    console.print(
+        f"[green]registered autostart task '{autostart.TASK_NAME}'[/green] — "
+        "the prod daemon will start at every logon."
+    )
+
+    should_start = start
+    if should_start is None:
+        should_start = typer.confirm("Start the prod daemon now?", default=False)
+    if should_start:
+        start_daemon(instance="prod")
+
+
+@app.command()
+def uninstall_autostart(instance: str | None = _INSTANCE_OPTION) -> None:
+    """Remove the prod daemon auto-start task (Windows Task Scheduler)."""
+    inst = _resolve(instance)
+    if inst is not Instance.PROD:
+        console.print("[red]autostart is prod-only.[/red]")
+        raise typer.Exit(code=1)
+    if sys.platform != "win32":
+        console.print("[red]autostart is Windows-only.[/red]")
+        raise typer.Exit(code=1)
+
+    if autostart.uninstall_autostart():
+        console.print(
+            f"[green]removed autostart task '{autostart.TASK_NAME}'[/green]"
+        )
+    else:
+        console.print(
+            f"[yellow]no autostart task '{autostart.TASK_NAME}' to remove[/yellow]"
+        )
+```
+
+- [ ] **Step 3: Rename the `start` command to avoid the call-name collision**
+
+The `install_autostart` command above calls `start_daemon(instance="prod")`.
+The existing `start` command function must be reachable under that name.
+**Do not rename the `start` command** — instead, add a module-level
+alias right after the `start` command definition so `install_autostart`
+can call it without shadowing issues:
+
+Find the end of the `start` command (the line
+`console.print(f"[green]{inst} daemon started (PID: {proc.pid})[/green]")`)
+and immediately after the function add:
+```python
+
+
+# Alias so other commands can call `start` without ambiguity.
+start_daemon = start
+```
+
+(`start` remains the Typer command; `start_daemon` is the same function
+object, used for internal calls.)
+
+- [ ] **Step 4: Write the command tests**
+
+Append to `packages/core/tests/test_daemon_cli.py`:
+```python
+def test_install_autostart_dev_instance_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    result = runner.invoke(daemon_app, ["install-autostart", "--instance", "dev"])
+    assert result.exit_code == 1
+    assert "prod-only" in result.stdout.lower()
+
+
+def test_install_autostart_errors_when_prod_exe_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """install-autostart must refuse if the prod agent-core.exe is absent."""
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "platform", "win32")
+    result = runner.invoke(daemon_app, ["install-autostart", "--no-start"])
+    assert result.exit_code == 1
+    assert "not installed" in result.stdout.lower()
+
+
+def test_install_autostart_registers_and_skips_start_with_no_start_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "platform", "win32")
+    # Create the prod exe so the existence check passes.
+    exe = tmp_path / ".venv" / "Scripts" / "agent-core.exe"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("")
+
+    registered: list[str] = []
+
+    def fake_install(xml: str) -> None:
+        registered.append(xml)
+
+    started: list[str] = []
+
+    def fake_start(instance: str | None = None) -> None:
+        started.append("start")
+
+    monkeypatch.setattr("agent_core.daemon.autostart.install_autostart", fake_install)
+    monkeypatch.setattr("agent_core.daemon.cli.start_daemon", fake_start)
+
+    result = runner.invoke(daemon_app, ["install-autostart", "--no-start"])
+    assert result.exit_code == 0, result.stdout
+    assert len(registered) == 1  # task registered
+    assert started == []  # --no-start skipped the daemon start
+
+
+def test_install_autostart_starts_with_start_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "platform", "win32")
+    exe = tmp_path / ".venv" / "Scripts" / "agent-core.exe"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("")
+
+    monkeypatch.setattr(
+        "agent_core.daemon.autostart.install_autostart", lambda xml: None
+    )
+    started: list[str] = []
+    monkeypatch.setattr(
+        "agent_core.daemon.cli.start_daemon",
+        lambda instance=None: started.append("start"),
+    )
+
+    result = runner.invoke(daemon_app, ["install-autostart", "--start"])
+    assert result.exit_code == 0, result.stdout
+    assert started == ["start"]
+
+
+def test_uninstall_autostart_reports_removed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        "agent_core.daemon.autostart.uninstall_autostart", lambda: True
+    )
+    result = runner.invoke(daemon_app, ["uninstall-autostart"])
+    assert result.exit_code == 0
+    assert "removed" in result.stdout.lower()
+
+
+def test_uninstall_autostart_idempotent_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        "agent_core.daemon.autostart.uninstall_autostart", lambda: False
+    )
+    result = runner.invoke(daemon_app, ["uninstall-autostart"])
+    assert result.exit_code == 0  # not an error
+    assert "no autostart task" in result.stdout.lower()
+```
+
+- [ ] **Step 5: Run the daemon test suite**
+
+Run: `uv run --no-sync pytest packages/core/tests/test_daemon_cli.py packages/core/tests/test_daemon_autostart.py -v`
+Expected: all pass. If a test fails because `monkeypatch.setattr(sys, "platform", ...)` does not take effect, confirm the command reads `sys.platform` at call time (it does — the code references `sys.platform` directly inside the command body).
+
+- [ ] **Step 6: Lint + typecheck**
+
+Run: `uv run --no-sync ruff check --fix packages/core && uv run --no-sync ruff check packages/core && uv run --no-sync mypy packages/core/src/agent_core/daemon/cli.py`
+Expected: all clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/agent_core/daemon/cli.py packages/core/tests/test_daemon_cli.py
+git commit -m "feat(daemon): install-autostart + uninstall-autostart commands"
+```
+
+---
+
+## Task 3: Slow integration test + docs
+
+**Files:**
+- Modify: `packages/core/tests/test_daemon_autostart.py` (add one `slow` test)
+- Modify: `docs/setup/daemon.md`
+
+- [ ] **Step 1: Add the slow real-`schtasks` integration test**
+
+Append to `packages/core/tests/test_daemon_autostart.py`:
+```python
+import shutil
+import sys
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    sys.platform != "win32" or shutil.which("schtasks") is None,
+    reason="schtasks is Windows-only",
+)
+def test_build_xml_is_accepted_by_real_schtasks() -> None:
+    """The XML build_autostart_task emits must be accepted by the real
+    `schtasks`. Registers under a throwaway name, queries it back, deletes
+    it — never touches the real 'agent-core-daemon-prod' task.
+    """
+    test_task = "agent-core-daemon-phase4-itest"
+    xml = build_autostart_task(
+        agent_core_exe=Path(r"C:\Windows\System32\cmd.exe"),
+        account="itest",
+    )
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-16", suffix=".xml", delete=False
+    ) as fh:
+        fh.write(xml)
+        xml_path = fh.name
+    try:
+        create = subprocess.run(
+            ["schtasks", "/create", "/tn", test_task, "/xml", xml_path, "/f"],
+            capture_output=True, text=True, check=False,
+        )
+        assert create.returncode == 0, (
+            f"schtasks rejected the XML: {create.stdout} {create.stderr}"
+        )
+        query = subprocess.run(
+            ["schtasks", "/query", "/tn", test_task],
+            capture_output=True, text=True, check=False,
+        )
+        assert query.returncode == 0
+        assert test_task in query.stdout
+    finally:
+        Path(xml_path).unlink(missing_ok=True)
+        subprocess.run(
+            ["schtasks", "/delete", "/tn", test_task, "/f"],
+            capture_output=True, text=True, check=False,
+        )
+```
+
+Note: the `account="itest"` in this test is a non-existent user. `schtasks
+/create` validates the XML structure but for a `LogonTrigger`/`Principal`
+with a bogus account it may warn or fail. If `schtasks` rejects the bogus
+account, change the test to use the real current account:
+`os.getlogin()` (add `import os`). The real account always exists on the
+runner. Prefer `os.getlogin()` for robustness.
+
+- [ ] **Step 2: Run the slow test**
+
+Run: `uv run --no-sync pytest packages/core/tests/test_daemon_autostart.py -v -m slow`
+Expected: PASS on Windows. If `schtasks /create` fails on the account,
+apply the `os.getlogin()` fix from Step 1's note and re-run.
+
+- [ ] **Step 3: Add the daemon.md autostart section**
+
+Append to `docs/setup/daemon.md`:
+```markdown
+## Auto-start at boot (Windows)
+
+The prod daemon can register itself with Windows Task Scheduler so it
+returns automatically after a reboot — no manual `daemon start`.
+
+```bash
+# Register the autostart task (prod only). Prompts whether to start now.
+agent-core daemon install-autostart
+
+# Remove it.
+agent-core daemon uninstall-autostart
+```
+
+`install-autostart` registers a Task Scheduler task named
+`agent-core-daemon-prod` that runs `agent-core daemon start --instance
+prod` at your logon, with restart-on-failure and start-when-available.
+It runs as your own user with least privilege (the daemon binds
+127.0.0.1 only — no admin needed).
+
+`install-autostart` requires the prod daemon to be installed first
+(`agent-core daemon install`) — it points the task at
+`~/.agent-core/.venv/Scripts/agent-core.exe`. Re-running it replaces the
+existing task (idempotent). Pass `--no-start` / `--start` to skip the
+"start now?" prompt in non-interactive use.
+
+Auto-start is prod-only and Windows-only. It brings the **daemon** back
+after a reboot; auto-launching Pepper's own Claude Code session is a
+separate, still-open problem.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/tests/test_daemon_autostart.py docs/setup/daemon.md
+git commit -m "test(daemon): slow real-schtasks integration test; docs(daemon): autostart section"
+```
+
+---
+
+## Task 4: Final validation + PR
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Full `just check`**
+
+Run: `just check`
+Expected: PASS — lint, typecheck, contracts, all fast tests green.
+
+- [ ] **Step 2: Review the commit history**
+
+Run: `git log origin/main..HEAD --oneline`
+Expected: spec + plan + Tasks 1-3 commits, all conventional-commit messages.
+
+- [ ] **Step 3: Push + open the PR**
+
+```bash
+git push -u origin feat/phase4-windows-autostart
+```
+
+Then (PR title MUST be lowercase after the `type(scope):` prefix — the
+pr-title-lint `subjectPattern` rejects an uppercase subject):
+```bash
+gh pr create --title "feat(daemon): windows daemon auto-start (Phase 4)" --body-file - <<'EOF'
+## Summary
+- New `agent-core daemon install-autostart` / `uninstall-autostart` commands
+- Registers a Windows Task Scheduler task that starts the prod daemon at logon
+- New pure/impure module `daemon/autostart.py` (`build_autostart_task` pure → Task Scheduler XML; `install_autostart`/`uninstall_autostart` impure → `schtasks`)
+- Prod-only, Windows-only, no admin; idempotent; `--start/--no-start` flag else interactive prompt
+
+Spec: `docs/superpowers/specs/2026-05-22-phase4-windows-autostart-design.md`
+Plan: `docs/superpowers/plans/2026-05-22-phase4-windows-autostart.md`
+
+## Test plan
+- [ ] All phase1-main-gate checks green (ubuntu + windows + integration + PR title)
+- [ ] After merge: `agent-core daemon install-autostart` on the box, then reboot to confirm the daemon returns
+EOF
+```
+
+- [ ] **Step 4: Drive CI green**
+
+Wait for all four checks (`check (ubuntu-latest)`, `check (windows-latest)`,
+`integration`, `Validate PR title`). The PR title above is already
+lowercase-subject compliant. Do NOT bypass the gate. Report the PR URL
+and green status; squash-merge is the human step.
+
+---
+
+## Self-review check
+
+Spec coverage:
+- §2.1 `install-autostart` (prod guard, exe check, register, start prompt/flag) — Task 2
+- §2.2 `uninstall-autostart` (prod guard, idempotent delete) — Task 2
+- §3.1 XML import mechanism — Task 1 (`install_autostart` writes UTF-16 temp file + `schtasks /create /xml`)
+- §3.2 task definition (name, LogonTrigger, Exec action, settings, LeastPrivilege principal) — Task 1 (`build_autostart_task`) + its tests
+- §4.1 `autostart.py` pure/impure split — Task 1
+- §4.2 cli.py commands — Task 2
+- §5 error handling (non-Windows guard, missing exe, schtasks failure, idempotency) — Task 2 (guards) + Task 1 (`uninstall_autostart` returns False not raise)
+- §6 testing (pure builder heavy, faked-subprocess command tests, one slow integration test, non-Windows guard) — Tasks 1, 2, 3
+- §7 rollout — Task 4 (PR) + Task 3 (docs)
+
+No spec section uncovered. No placeholders. Type/name consistency
+checked: `TASK_NAME`, `build_autostart_task(*, agent_core_exe, account)`,
+`install_autostart(xml)`, `uninstall_autostart() -> bool`, the
+`autostart` module import, the `start_daemon` alias, and the command
+function names `install_autostart` / `uninstall_autostart` (Typer →
+`install-autostart` / `uninstall-autostart`) are used consistently
+across all tasks.

--- a/docs/superpowers/specs/2026-05-22-phase4-windows-autostart-design.md
+++ b/docs/superpowers/specs/2026-05-22-phase4-windows-autostart-design.md
@@ -1,0 +1,176 @@
+# Phase 4 — Daemon Auto-Start at Boot (Windows): Design
+
+**Date:** 2026-05-22
+**Status:** brainstormed; pending implementation plan
+**Relationship to the maturity spec:** Implements the `Phase 4 — Daemon
+auto-start at boot` section of
+`docs/superpowers/specs/2026-05-18-agent-core-maturity-design.md`. Where
+they differ, **this document wins**. Builds on Phase 3 (the
+`--instance {prod|dev}` daemon surface, merged in PR #108).
+
+---
+
+## 1. Goal
+
+The prod daemon should come back automatically after a machine reboot, so
+Pepper and Wren are available without Jeff manually running
+`agent-core daemon start`. Today a reboot leaves the daemon down until
+Jeff notices and restarts it by hand.
+
+Phase 4 adds two commands that register / remove a Windows Task Scheduler
+task. The task starts the **prod** daemon at logon.
+
+Out of scope (per umbrella spec): Pepper-session auto-launch — its
+blocker (the Claude Code onboarding/preview prompt on version drift) is
+unsolved. Phase 4 ensures only the *daemon* returns after a reboot. See
+§7 for the pointer to the always-on-Pepper goal.
+
+## 2. Commands
+
+Two new `agent-core daemon` subcommands. Both are **prod-only**,
+localhost-only, no-admin.
+
+### 2.1 `agent-core daemon install-autostart`
+
+1. Resolve the instance. **Prod only** — `--instance dev` errors,
+   consistent with Phase 3's `install --instance dev` rejection.
+2. Verify the prod daemon exe exists at
+   `~/.agent-core/.venv/Scripts/agent-core.exe`. If missing, error:
+   *"prod daemon is not installed — run `agent-core daemon install`
+   first"*. Auto-start cannot point at an exe that does not exist.
+3. Build the Task Scheduler XML (pure) and register it via
+   `schtasks /create … /f` (idempotent — `/f` replaces an existing
+   task of the same name).
+4. **Prompt:** `Start the prod daemon now? [y/N]`. On yes, call
+   `start(instance="prod")`. A `--start/--no-start` flag overrides the
+   prompt for non-interactive use (scripts, tests); when neither is
+   passed and stdin is interactive, the prompt is shown.
+
+### 2.2 `agent-core daemon uninstall-autostart`
+
+1. Prod-only guard (same as above).
+2. Delete the Task Scheduler task via `schtasks /delete … /f`.
+   Idempotent: if the task does not exist, report that and exit 0 — not
+   an error.
+
+## 3. The registered Task Scheduler task
+
+### 3.1 Why XML import (not `schtasks` flags, not PowerShell)
+
+`schtasks /create` command-line flags cannot express the full settings
+set this phase needs — restart-on-failure count, "start when available,"
+and the multiple-instances policy live only in the Task Scheduler **XML
+schema**. So the mechanism is: build the XML, write it to a temp file,
+`schtasks /create /tn <name> /xml <file> /f`. PowerShell
+`Register-ScheduledTask` could also do it, but XML-as-data is a cleaner
+return value for a pure function than a PowerShell script string.
+
+### 3.2 Task definition
+
+- **Name:** `agent-core-daemon-prod`
+- **Trigger:** `LogonTrigger` scoped to the current user account.
+- **Action:** `Exec` —
+  command `~/.agent-core/.venv/Scripts/agent-core.exe`,
+  arguments `daemon start --instance prod`.
+- **Settings:**
+  - `RestartOnFailure` — interval `PT1M`, count `3` (small retry).
+  - `StartWhenAvailable` — `true` (run a missed start as soon as
+    possible).
+  - `MultipleInstancesPolicy` — `IgnoreNew` (never start a second
+    daemon; `daemon start` also self-guards via the PID file).
+  - `ExecutionTimeLimit` — `PT0S` (no time limit — the daemon is
+    long-running).
+- **Principal:** runs as the current user, `LeastPrivilege` run level
+  (no admin; the daemon binds 127.0.0.1 only).
+
+## 4. Code structure
+
+Pure/impure split per project convention (mirrors
+`build_uv_sync_command` pure / `run_install` impure).
+
+### 4.1 New — `packages/core/src/agent_core/daemon/autostart.py`
+
+- `TASK_NAME = "agent-core-daemon-prod"` — module constant.
+- `build_autostart_task(*, agent_core_exe: Path, account: str) -> str`
+  — **pure**: returns the Task Scheduler XML as a string. Deterministic,
+  no I/O. The single source of the task definition; fully
+  unit-testable.
+- `install_autostart(xml: str) -> None` — **impure** thin shell: writes
+  `xml` to a temp file, runs
+  `schtasks /create /tn <TASK_NAME> /xml <file> /f`, raises
+  `subprocess.CalledProcessError` on a non-zero exit.
+- `uninstall_autostart() -> bool` — **impure**: runs
+  `schtasks /delete /tn <TASK_NAME> /f`; returns `True` if a task was
+  deleted, `False` if `schtasks` reported the task did not exist.
+
+### 4.2 Modified — `packages/core/src/agent_core/daemon/cli.py`
+
+Adds the two `@app.command()` functions `install_autostart` /
+`uninstall_autostart` (Typer maps the underscores to
+`install-autostart` / `uninstall-autostart`). They:
+- Reuse the Phase 3 `_resolve` + the prod-only guard.
+- Resolve `agent_core_exe` from the prod home
+  (`home / ".venv" / "Scripts" / "agent-core.exe"`) and the account
+  from `os.getlogin()` (or the `USERNAME` env var).
+- Call into `autostart.py`.
+- `install-autostart` runs the start-now prompt / flag.
+
+## 5. Error handling
+
+- **Non-Windows platform:** `schtasks` does not exist. Both commands
+  check `sys.platform == "win32"` and error cleanly
+  (*"autostart is Windows-only"*) on other platforms. The pure
+  `build_autostart_task` is platform-agnostic string-building — its
+  tests run on any CI OS.
+- **Prod exe missing:** `install-autostart` errors before touching
+  `schtasks` (see §2.1 step 2).
+- **`schtasks` non-zero exit on create:** surfaces the returncode +
+  stderr; the command exits non-zero.
+- **Re-running `install-autostart`:** `/f` replaces the existing task —
+  idempotent.
+- **`uninstall-autostart` with no task:** not an error (exit 0).
+
+## 6. Testing strategy
+
+All fast (the Phase 1 `check` gate) except one slow integration test.
+
+- **`build_autostart_task` (pure)** — the bulk of coverage, no I/O:
+  the returned XML parses (via `xml.etree.ElementTree`); contains the
+  exact action command path and `daemon start --instance prod`
+  arguments; has a `LogonTrigger`; has `RestartOnFailure` (interval +
+  count), `StartWhenAvailable`, `IgnoreNew`, and no execution time
+  limit; the principal is `LeastPrivilege` for the supplied account.
+- **`install-autostart` command** — `schtasks` faked via a monkeypatched
+  subprocess runner: errors when the prod exe is missing; errors on
+  `--instance dev`; `--no-start` skips the daemon start; `--start`
+  calls `start`.
+- **`uninstall_autostart`** — faked subprocess: returns `True` on a
+  successful delete, `False` when `schtasks` reports the task is
+  absent.
+- **Non-Windows guard** — on a non-`win32` platform the commands error
+  cleanly; `build_autostart_task` still works.
+- **One `slow`-marked integration test** — registers a task under a
+  **throwaway test-only name** (never `agent-core-daemon-prod`), queries
+  it back via `schtasks /query`, then deletes it. Proves the XML the
+  pure function emits is actually accepted by the real `schtasks`.
+  Skipped on non-Windows.
+
+## 7. Rollout
+
+1. Phase 4 PR (`autostart.py` + the two cli commands + tests + a
+   `docs/setup/daemon.md` section on auto-start) → passes
+   `phase1-main-gate` → squash-merged via the gate.
+2. After merge: on the box, once the prod daemon is installed,
+   `agent-core daemon install-autostart` — registers the task, answer
+   the start-now prompt. The daemon now returns on every logon.
+3. **Always-on-Pepper:** Phase 4 closes the *daemon* half of the 24/7
+   goal. The remaining half — auto-launching Pepper's own Claude Code
+   session — stays blocked on the onboarding/preview prompt and is
+   tracked separately, not in this phase.
+
+## 8. The maturity initiative after Phase 4
+
+Phases 0, 1, 1.5, 2, 2.5, 3, 4 complete the umbrella maturity spec.
+Known remaining follow-up outside the phase sequence: **issue #107** —
+the release-please ↔ CI automation gap (PAT / GitHub App), independent
+of Phase 4.

--- a/packages/core/src/agent_core/daemon/autostart.py
+++ b/packages/core/src/agent_core/daemon/autostart.py
@@ -1,0 +1,112 @@
+"""Windows daemon auto-start — register the prod daemon as a Task Scheduler task.
+
+Pure/impure split (project convention, mirrors build_uv_sync_command /
+run_install): `build_autostart_task` is pure (returns the Task Scheduler XML),
+`install_autostart` / `uninstall_autostart` are thin impure shells that run
+`schtasks`.
+
+Windows-only at the `schtasks` boundary. The pure builder is plain
+string-building and works on any platform, so its tests run on any CI OS.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+TASK_NAME = "agent-core-daemon-prod"
+
+
+def build_autostart_task(*, agent_core_exe: Path, account: str) -> str:
+    """Return the Task Scheduler XML registering the prod daemon at logon.
+
+    The task runs `<agent_core_exe> daemon start --instance prod` at
+    `account`'s logon, with restart-on-failure (PT1M x3), start-when-
+    available, ignore-new-instance, no execution time limit, least
+    privilege.
+    """
+    return (
+        '<?xml version="1.0" encoding="UTF-16"?>\n'
+        '<Task version="1.2" '
+        'xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n'
+        "  <RegistrationInfo>\n"
+        "    <Description>agent-core prod daemon auto-start at logon."
+        "</Description>\n"
+        "  </RegistrationInfo>\n"
+        "  <Triggers>\n"
+        "    <LogonTrigger>\n"
+        "      <Enabled>true</Enabled>\n"
+        f"      <UserId>{account}</UserId>\n"
+        "    </LogonTrigger>\n"
+        "  </Triggers>\n"
+        "  <Principals>\n"
+        '    <Principal id="Author">\n'
+        f"      <UserId>{account}</UserId>\n"
+        "      <LogonType>InteractiveToken</LogonType>\n"
+        "      <RunLevel>LeastPrivilege</RunLevel>\n"
+        "    </Principal>\n"
+        "  </Principals>\n"
+        "  <Settings>\n"
+        "    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n"
+        "    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>\n"
+        "    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\n"
+        "    <StartWhenAvailable>true</StartWhenAvailable>\n"
+        "    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>\n"
+        "    <Enabled>true</Enabled>\n"
+        "    <RestartOnFailure>\n"
+        "      <Interval>PT1M</Interval>\n"
+        "      <Count>3</Count>\n"
+        "    </RestartOnFailure>\n"
+        "  </Settings>\n"
+        '  <Actions Context="Author">\n'
+        "    <Exec>\n"
+        f"      <Command>{agent_core_exe}</Command>\n"
+        "      <Arguments>daemon start --instance prod</Arguments>\n"
+        "    </Exec>\n"
+        "  </Actions>\n"
+        "</Task>\n"
+    )
+
+
+def install_autostart(xml: str) -> None:
+    """Register (or replace) the autostart task from `xml`.
+
+    Writes the XML to a temp file (UTF-16 — the Task Scheduler XML prolog
+    declares UTF-16) and runs `schtasks /create /tn <TASK_NAME> /xml
+    <file> /f`. Raises subprocess.CalledProcessError on a non-zero exit.
+    """
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-16", suffix=".xml", delete=False
+    ) as fh:
+        fh.write(xml)
+        xml_path = fh.name
+    try:
+        result = subprocess.run(
+            ["schtasks", "/create", "/tn", TASK_NAME, "/xml", xml_path, "/f"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        Path(xml_path).unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            ["schtasks", "/create", "/tn", TASK_NAME, "/xml", "...", "/f"],
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+
+
+def uninstall_autostart() -> bool:
+    """Delete the autostart task. Returns True if a task was deleted,
+    False if no such task existed. Idempotent — never raises for a
+    missing task."""
+    result = subprocess.run(
+        ["schtasks", "/delete", "/tn", TASK_NAME, "/f"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0

--- a/packages/core/src/agent_core/daemon/cli.py
+++ b/packages/core/src/agent_core/daemon/cli.py
@@ -19,6 +19,7 @@ overrides the home dir directly (test escape hatch).
 
 from __future__ import annotations
 
+import getpass
 import os
 import subprocess
 import sys
@@ -417,8 +418,10 @@ def install_autostart(
         )
         raise typer.Exit(code=1)
 
-    # USERNAME is always set on Windows; os.getlogin() is the fallback.
-    account = os.environ.get("USERNAME") or os.getlogin()
+    # getpass.getuser() resolves the username cross-platform from env vars
+    # (USER / USERNAME / ...) without os.getlogin(), which fails on headless
+    # hosts.
+    account = getpass.getuser()
     xml = autostart.build_autostart_task(agent_core_exe=exe, account=account)
     try:
         autostart.install_autostart(xml)

--- a/packages/core/src/agent_core/daemon/cli.py
+++ b/packages/core/src/agent_core/daemon/cli.py
@@ -401,7 +401,7 @@ def install_autostart(
     inst = _resolve(instance)
     if inst is not Instance.PROD:
         console.print(
-            "[red]autostart is prod-only[/red] — the dev instance is started "
+            "[red]autostart is prod-only[/red] — the source instance is started "
             "by hand from the workspace."
         )
         raise typer.Exit(code=1)

--- a/packages/core/src/agent_core/daemon/cli.py
+++ b/packages/core/src/agent_core/daemon/cli.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from agent_core.daemon import autostart
 from agent_core.daemon.config_template import build_default_config
 from agent_core.daemon.install import (
     InstallStamp,
@@ -161,6 +162,10 @@ def start(instance: str | None = _INSTANCE_OPTION) -> None:
     )
     write_pid(pid_file, proc.pid)
     console.print(f"[green]{inst} daemon started (PID: {proc.pid})[/green]")
+
+
+# Alias so other commands can call `start` without ambiguity.
+start_daemon = start
 
 
 @app.command()
@@ -380,3 +385,77 @@ def _git_sha_of_tag(tag: str) -> str:
     if result.returncode != 0:
         return "unknown"
     return result.stdout.strip() or "unknown"
+
+
+@app.command()
+def install_autostart(
+    instance: str | None = _INSTANCE_OPTION,
+    start: bool | None = typer.Option(
+        None,
+        "--start/--no-start",
+        help="Start the daemon now without prompting (for non-interactive use).",
+    ),
+) -> None:
+    """Register the prod daemon to auto-start at logon (Windows Task Scheduler)."""
+    inst = _resolve(instance)
+    if inst is not Instance.PROD:
+        console.print(
+            "[red]autostart is prod-only[/red] — the dev instance is started "
+            "by hand from the workspace."
+        )
+        raise typer.Exit(code=1)
+    if sys.platform != "win32":
+        console.print("[red]autostart is Windows-only.[/red]")
+        raise typer.Exit(code=1)
+
+    home = home_for(inst)
+    exe = home / ".venv" / "Scripts" / "agent-core.exe"
+    if not exe.exists():
+        console.print(
+            f"[red]prod daemon is not installed ({exe} missing).[/red]\n"
+            "   Run [bold]agent-core daemon install[/bold] first."
+        )
+        raise typer.Exit(code=1)
+
+    # USERNAME is always set on Windows; os.getlogin() is the fallback.
+    account = os.environ.get("USERNAME") or os.getlogin()
+    xml = autostart.build_autostart_task(agent_core_exe=exe, account=account)
+    try:
+        autostart.install_autostart(xml)
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]schtasks failed (exit {exc.returncode}).[/red]")
+        if exc.stderr:
+            console.print(exc.stderr.rstrip())
+        raise typer.Exit(code=1) from exc
+
+    console.print(
+        f"[green]registered autostart task '{autostart.TASK_NAME}'[/green] — "
+        "the prod daemon will start at every logon."
+    )
+
+    should_start = start
+    if should_start is None:
+        should_start = typer.confirm("Start the prod daemon now?", default=False)
+    if should_start:
+        start_daemon(instance="prod")
+
+
+@app.command()
+def uninstall_autostart(instance: str | None = _INSTANCE_OPTION) -> None:
+    """Remove the prod daemon auto-start task (Windows Task Scheduler)."""
+    inst = _resolve(instance)
+    if inst is not Instance.PROD:
+        console.print("[red]autostart is prod-only.[/red]")
+        raise typer.Exit(code=1)
+    if sys.platform != "win32":
+        console.print("[red]autostart is Windows-only.[/red]")
+        raise typer.Exit(code=1)
+
+    if autostart.uninstall_autostart():
+        console.print(
+            f"[green]removed autostart task '{autostart.TASK_NAME}'[/green]"
+        )
+    else:
+        console.print(
+            f"[yellow]no autostart task '{autostart.TASK_NAME}' to remove[/yellow]"
+        )

--- a/packages/core/tests/test_daemon_autostart.py
+++ b/packages/core/tests/test_daemon_autostart.py
@@ -153,3 +153,53 @@ def test_uninstall_autostart_returns_false_when_task_absent(
 
     monkeypatch.setattr("agent_core.daemon.autostart.subprocess.run", fake_run)
     assert uninstall_autostart() is False
+
+
+@pytest.mark.slow
+def test_build_xml_is_accepted_by_real_schtasks() -> None:
+    """The XML build_autostart_task emits must be accepted by the real
+    `schtasks`. Registers under a throwaway name, queries it back, deletes
+    it — never touches the real 'agent-core-daemon-prod' task.
+    """
+    import os
+    import shutil
+    import sys
+    import tempfile
+
+    if sys.platform != "win32" or shutil.which("schtasks") is None:
+        pytest.skip("schtasks is Windows-only")
+
+    test_task = "agent-core-daemon-phase4-itest"
+    # Use the real current account — schtasks validates the principal/trigger
+    # account exists.
+    account = os.environ.get("USERNAME") or os.getlogin()
+    xml = build_autostart_task(
+        agent_core_exe=Path(r"C:\Windows\System32\cmd.exe"),
+        account=account,
+    )
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-16", suffix=".xml", delete=False
+    ) as fh:
+        fh.write(xml)
+        xml_path = fh.name
+    try:
+        create = subprocess.run(
+            ["schtasks", "/create", "/tn", test_task, "/xml", xml_path, "/f"],
+            capture_output=True, text=True, check=False,
+        )
+        assert create.returncode == 0, (
+            f"schtasks rejected the XML: {create.stdout} {create.stderr}"
+        )
+        query = subprocess.run(
+            ["schtasks", "/query", "/tn", test_task],
+            capture_output=True, text=True, check=False,
+        )
+        assert query.returncode == 0
+        assert test_task in query.stdout
+    finally:
+        Path(xml_path).unlink(missing_ok=True)
+        subprocess.run(
+            ["schtasks", "/delete", "/tn", test_task, "/f"],
+            capture_output=True, text=True, check=False,
+        )

--- a/packages/core/tests/test_daemon_autostart.py
+++ b/packages/core/tests/test_daemon_autostart.py
@@ -1,0 +1,155 @@
+"""Unit tests for daemon/autostart.py — Task Scheduler registration."""
+from __future__ import annotations
+
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from agent_core.daemon.autostart import (
+    TASK_NAME,
+    build_autostart_task,
+    install_autostart,
+    uninstall_autostart,
+)
+
+# Task Scheduler XML namespace.
+_NS = {"t": "http://schemas.microsoft.com/windows/2004/02/mit/task"}
+
+
+# ---- build_autostart_task (pure) -------------------------------------------
+
+def test_task_name_constant() -> None:
+    assert TASK_NAME == "agent-core-daemon-prod"
+
+
+def test_build_autostart_task_is_well_formed_xml() -> None:
+    xml = build_autostart_task(
+        agent_core_exe=Path(r"C:\Users\x\.agent-core\.venv\Scripts\agent-core.exe"),
+        account="x",
+    )
+    # Must parse without error.
+    ET.fromstring(xml)
+
+
+def test_build_autostart_task_action_command_and_args() -> None:
+    exe = Path(r"C:\Users\x\.agent-core\.venv\Scripts\agent-core.exe")
+    xml = build_autostart_task(agent_core_exe=exe, account="x")
+    root = ET.fromstring(xml)
+    command = root.find(".//t:Actions/t:Exec/t:Command", _NS)
+    arguments = root.find(".//t:Actions/t:Exec/t:Arguments", _NS)
+    assert command is not None and command.text == str(exe)
+    assert arguments is not None
+    assert arguments.text == "daemon start --instance prod"
+
+
+def test_build_autostart_task_has_logon_trigger_for_account() -> None:
+    xml = build_autostart_task(
+        agent_core_exe=Path(r"C:\x\agent-core.exe"), account="jeffr"
+    )
+    root = ET.fromstring(xml)
+    trigger = root.find(".//t:Triggers/t:LogonTrigger", _NS)
+    assert trigger is not None
+    user = trigger.find("t:UserId", _NS)
+    assert user is not None and user.text == "jeffr"
+
+
+def test_build_autostart_task_settings() -> None:
+    xml = build_autostart_task(
+        agent_core_exe=Path(r"C:\x\agent-core.exe"), account="x"
+    )
+    root = ET.fromstring(xml)
+    settings = root.find("t:Settings", _NS)
+    assert settings is not None
+    assert settings.findtext("t:MultipleInstancesPolicy", namespaces=_NS) == "IgnoreNew"
+    assert settings.findtext("t:StartWhenAvailable", namespaces=_NS) == "true"
+    assert settings.findtext("t:ExecutionTimeLimit", namespaces=_NS) == "PT0S"
+    restart = settings.find("t:RestartOnFailure", _NS)
+    assert restart is not None
+    assert restart.findtext("t:Interval", namespaces=_NS) == "PT1M"
+    assert restart.findtext("t:Count", namespaces=_NS) == "3"
+
+
+def test_build_autostart_task_principal_is_least_privilege() -> None:
+    xml = build_autostart_task(
+        agent_core_exe=Path(r"C:\x\agent-core.exe"), account="jeffr"
+    )
+    root = ET.fromstring(xml)
+    principal = root.find(".//t:Principals/t:Principal", _NS)
+    assert principal is not None
+    assert principal.findtext("t:RunLevel", namespaces=_NS) == "LeastPrivilege"
+    assert principal.findtext("t:UserId", namespaces=_NS) == "jeffr"
+
+
+# ---- install_autostart / uninstall_autostart (impure, faked subprocess) ----
+
+def test_install_autostart_invokes_schtasks_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(cmd)
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr("agent_core.daemon.autostart.subprocess.run", fake_run)
+
+    install_autostart("<Task></Task>")
+
+    assert len(calls) == 1
+    cmd = calls[0]
+    assert cmd[0] == "schtasks"
+    assert "/create" in cmd
+    assert "/tn" in cmd and TASK_NAME in cmd
+    assert "/xml" in cmd
+    assert "/f" in cmd
+
+
+def test_install_autostart_raises_on_schtasks_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "ERROR: Access is denied."
+        return _R()
+
+    monkeypatch.setattr("agent_core.daemon.autostart.subprocess.run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        install_autostart("<Task></Task>")
+
+
+def test_uninstall_autostart_returns_true_on_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        class _R:
+            returncode = 0
+            stdout = "SUCCESS"
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr("agent_core.daemon.autostart.subprocess.run", fake_run)
+    assert uninstall_autostart() is True
+
+
+def test_uninstall_autostart_returns_false_when_task_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "ERROR: The system cannot find the file specified."
+        return _R()
+
+    monkeypatch.setattr("agent_core.daemon.autostart.subprocess.run", fake_run)
+    assert uninstall_autostart() is False

--- a/packages/core/tests/test_daemon_autostart.py
+++ b/packages/core/tests/test_daemon_autostart.py
@@ -161,7 +161,7 @@ def test_build_xml_is_accepted_by_real_schtasks() -> None:
     `schtasks`. Registers under a throwaway name, queries it back, deletes
     it — never touches the real 'agent-core-daemon-prod' task.
     """
-    import os
+    import getpass
     import shutil
     import sys
     import tempfile
@@ -172,7 +172,7 @@ def test_build_xml_is_accepted_by_real_schtasks() -> None:
     test_task = "agent-core-daemon-phase4-itest"
     # Use the real current account — schtasks validates the principal/trigger
     # account exists.
-    account = os.environ.get("USERNAME") or os.getlogin()
+    account = getpass.getuser()
     xml = build_autostart_task(
         agent_core_exe=Path(r"C:\Windows\System32\cmd.exe"),
         account=account,

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -419,20 +419,25 @@ def test_start_without_config_points_at_init(
 
 
 @pytest.mark.slow
-def test_prod_and_dev_daemons_coexist(
+def test_prod_and_source_daemons_coexist(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A prod and a dev daemon run simultaneously on different ports,
+    """A prod and a source daemon run simultaneously on different ports,
     each isolated — stopping one does not disturb the other.
 
     Both instances are driven through the AGENT_CORE_HOME escape hatch
     (one home per call), proving the core property: two daemons, two
     homes, two ports, independent lifecycle.
+
+    Pre-rename name was ``test_prod_and_dev_daemons_coexist``; renamed
+    after main's dev→source cutover (--instance dev is now an unknown
+    value, so the original ``init --instance dev`` line errored at
+    parse time).
     """
     import yaml as _yaml
 
     prod_home = tmp_path / "prod"
-    dev_home = tmp_path / "dev"
+    source_home = tmp_path / "source"
 
     def _run(args: list[str], home: Path):
         monkeypatch.setenv("AGENT_CORE_HOME", str(home))
@@ -440,11 +445,11 @@ def test_prod_and_dev_daemons_coexist(
 
     # Scaffold minimal configs.
     assert _run(["init"], prod_home).exit_code == 0
-    assert _run(["init", "--instance", "dev"], dev_home).exit_code == 0
+    assert _run(["init", "--instance", "source"], source_home).exit_code == 0
 
     # Rewrite each config to a free, distinct port to avoid clashing with
     # a real daemon on 8789/8788.
-    for home, port in ((prod_home, 8991), (dev_home, 8992)):
+    for home, port in ((prod_home, 8991), (source_home, 8992)):
         cfg = home / "agent_core.yaml"
         data = _yaml.safe_load(cfg.read_text())
         data["http"]["bind_port"] = port
@@ -452,27 +457,27 @@ def test_prod_and_dev_daemons_coexist(
 
     try:
         assert _run(["start"], prod_home).exit_code == 0
-        assert _run(["start"], dev_home).exit_code == 0
+        assert _run(["start"], source_home).exit_code == 0
 
         # Give both a moment to come up.
         for _ in range(40):
             prod_pid = read_pid(prod_home / "daemon.pid")
-            dev_pid = read_pid(dev_home / "daemon.pid")
-            if prod_pid and dev_pid and is_alive(prod_pid) and is_alive(dev_pid):
+            source_pid = read_pid(source_home / "daemon.pid")
+            if prod_pid and source_pid and is_alive(prod_pid) and is_alive(source_pid):
                 break
             time.sleep(0.1)
 
         # Both alive.
         assert "is running" in _run(["status"], prod_home).stdout
-        assert "is running" in _run(["status"], dev_home).stdout
+        assert "is running" in _run(["status"], source_home).stdout
 
-        # Stop prod — dev must still be alive.
+        # Stop prod — source must still be alive.
         assert _run(["stop"], prod_home).exit_code == 0
-        assert "is running" in _run(["status"], dev_home).stdout
+        assert "is running" in _run(["status"], source_home).stdout
         assert "not running" in _run(["status"], prod_home).stdout
     finally:
         _run(["stop"], prod_home)
-        _run(["stop"], dev_home)
+        _run(["stop"], source_home)
 
 
 def test_install_autostart_source_instance_errors(

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -475,11 +475,16 @@ def test_prod_and_dev_daemons_coexist(
         _run(["stop"], dev_home)
 
 
-def test_install_autostart_dev_instance_errors(
+def test_install_autostart_source_instance_errors(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """install-autostart against the source instance must fail loudly with
+    a clear "prod-only" message. Source runs editable from the workspace .venv
+    and is started by hand; auto-starting it would silently launch dev code at
+    logon. The PR's original test used --instance dev; renamed to --instance
+    source after main's dev→source cutover."""
     monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
-    result = runner.invoke(daemon_app, ["install-autostart", "--instance", "dev"])
+    result = runner.invoke(daemon_app, ["install-autostart", "--instance", "source"])
     assert result.exit_code == 1
     assert "prod-only" in result.stdout.lower()
 

--- a/packages/core/tests/test_daemon_cli.py
+++ b/packages/core/tests/test_daemon_cli.py
@@ -417,3 +417,157 @@ def test_start_without_config_points_at_init(
     assert result.exit_code == 1
     assert "daemon init" in result.stdout
 
+
+@pytest.mark.slow
+def test_prod_and_dev_daemons_coexist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A prod and a dev daemon run simultaneously on different ports,
+    each isolated — stopping one does not disturb the other.
+
+    Both instances are driven through the AGENT_CORE_HOME escape hatch
+    (one home per call), proving the core property: two daemons, two
+    homes, two ports, independent lifecycle.
+    """
+    import yaml as _yaml
+
+    prod_home = tmp_path / "prod"
+    dev_home = tmp_path / "dev"
+
+    def _run(args: list[str], home: Path):
+        monkeypatch.setenv("AGENT_CORE_HOME", str(home))
+        return runner.invoke(daemon_app, args)
+
+    # Scaffold minimal configs.
+    assert _run(["init"], prod_home).exit_code == 0
+    assert _run(["init", "--instance", "dev"], dev_home).exit_code == 0
+
+    # Rewrite each config to a free, distinct port to avoid clashing with
+    # a real daemon on 8789/8788.
+    for home, port in ((prod_home, 8991), (dev_home, 8992)):
+        cfg = home / "agent_core.yaml"
+        data = _yaml.safe_load(cfg.read_text())
+        data["http"]["bind_port"] = port
+        cfg.write_text(_yaml.safe_dump(data), encoding="utf-8")
+
+    try:
+        assert _run(["start"], prod_home).exit_code == 0
+        assert _run(["start"], dev_home).exit_code == 0
+
+        # Give both a moment to come up.
+        for _ in range(40):
+            prod_pid = read_pid(prod_home / "daemon.pid")
+            dev_pid = read_pid(dev_home / "daemon.pid")
+            if prod_pid and dev_pid and is_alive(prod_pid) and is_alive(dev_pid):
+                break
+            time.sleep(0.1)
+
+        # Both alive.
+        assert "is running" in _run(["status"], prod_home).stdout
+        assert "is running" in _run(["status"], dev_home).stdout
+
+        # Stop prod — dev must still be alive.
+        assert _run(["stop"], prod_home).exit_code == 0
+        assert "is running" in _run(["status"], dev_home).stdout
+        assert "not running" in _run(["status"], prod_home).stdout
+    finally:
+        _run(["stop"], prod_home)
+        _run(["stop"], dev_home)
+
+
+def test_install_autostart_dev_instance_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    result = runner.invoke(daemon_app, ["install-autostart", "--instance", "dev"])
+    assert result.exit_code == 1
+    assert "prod-only" in result.stdout.lower()
+
+
+def test_install_autostart_errors_when_prod_exe_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """install-autostart must refuse if the prod agent-core.exe is absent."""
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "platform", "win32")
+    result = runner.invoke(daemon_app, ["install-autostart", "--no-start"])
+    assert result.exit_code == 1
+    assert "not installed" in result.stdout.lower()
+
+
+def test_install_autostart_registers_and_skips_start_with_no_start_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "platform", "win32")
+    # Create the prod exe so the existence check passes.
+    exe = tmp_path / ".venv" / "Scripts" / "agent-core.exe"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("")
+
+    registered: list[str] = []
+
+    def fake_install(xml: str) -> None:
+        registered.append(xml)
+
+    started: list[str] = []
+
+    def fake_start(instance: str | None = None) -> None:
+        started.append("start")
+
+    monkeypatch.setattr("agent_core.daemon.autostart.install_autostart", fake_install)
+    monkeypatch.setattr("agent_core.daemon.cli.start_daemon", fake_start)
+
+    result = runner.invoke(daemon_app, ["install-autostart", "--no-start"])
+    assert result.exit_code == 0, result.stdout
+    assert len(registered) == 1  # task registered
+    assert started == []  # --no-start skipped the daemon start
+
+
+def test_install_autostart_starts_with_start_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "platform", "win32")
+    exe = tmp_path / ".venv" / "Scripts" / "agent-core.exe"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("")
+
+    monkeypatch.setattr(
+        "agent_core.daemon.autostart.install_autostart", lambda xml: None
+    )
+    started: list[str] = []
+    monkeypatch.setattr(
+        "agent_core.daemon.cli.start_daemon",
+        lambda instance=None: started.append("start"),
+    )
+
+    result = runner.invoke(daemon_app, ["install-autostart", "--start"])
+    assert result.exit_code == 0, result.stdout
+    assert started == ["start"]
+
+
+def test_uninstall_autostart_reports_removed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        "agent_core.daemon.autostart.uninstall_autostart", lambda: True
+    )
+    result = runner.invoke(daemon_app, ["uninstall-autostart"])
+    assert result.exit_code == 0
+    assert "removed" in result.stdout.lower()
+
+
+def test_uninstall_autostart_idempotent_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_CORE_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        "agent_core.daemon.autostart.uninstall_autostart", lambda: False
+    )
+    result = runner.invoke(daemon_app, ["uninstall-autostart"])
+    assert result.exit_code == 0  # not an error
+    assert "no autostart task" in result.stdout.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32' and extra != 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130'",
@@ -88,9 +88,9 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (extra != 'extra-16-agent-core-voice-cpu' and extra != 'extra-16-agent-core-voice-cu130')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
     { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "extra == 'extra-16-agent-core-voice-cu130'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/8e/ac2a9566747a93f8be36ee08532eb0160558b07630a081a6056a9f89bf1d/accelerate-1.12.0.tar.gz", hash = "sha256:70988c352feb481887077d2ab845125024b2a137a5090d6d7a32b57d03a45df6", size = 398399, upload-time = "2025-11-21T11:27:46.973Z" }
@@ -320,10 +320,10 @@ dependencies = [
 
 [package.optional-dependencies]
 cpu = [
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
 ]
 cu130 = [
     { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
@@ -1034,7 +1034,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
@@ -1069,34 +1069,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -2557,7 +2557,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2600,7 +2600,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2613,7 +2613,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2645,9 +2645,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "nvidia-cusparse", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2660,7 +2660,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3565,9 +3565,9 @@ dependencies = [
     { name = "onnxruntime" },
     { name = "soundfile" },
     { name = "sox" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
     { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (extra != 'extra-16-agent-core-voice-cpu' and extra != 'extra-16-agent-core-voice-cu130')" },
-    { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
+    { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
     { name = "torchaudio", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "extra == 'extra-16-agent-core-voice-cu130'" },
     { name = "transformers" },
 ]
@@ -4275,18 +4275,19 @@ name = "torch"
 version = "2.12.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'darwin'",
     "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "fsspec", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "jinja2", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "networkx", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "setuptools", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "sympy", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "filelock", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "fsspec", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "jinja2", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "networkx", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "setuptools", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "sympy", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", upload-time = "2026-05-12T16:20:12Z" },
@@ -4362,7 +4363,6 @@ resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
@@ -4374,13 +4374,13 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "fsspec", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "jinja2", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "networkx", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "setuptools", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "sympy", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "typing-extensions", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
+    { name = "filelock", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "fsspec", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "jinja2", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "networkx", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "setuptools", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "sympy", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:b9d0e8eed0af9321ffb12b75f4aca371b071254f12cf75875d5a8e7cc8f52b51", upload-time = "2026-05-12T23:16:33Z" },
@@ -4465,6 +4465,7 @@ name = "torchaudio"
 version = "2.11.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'darwin'",
     "python_full_version < '3.13' and sys_platform == 'darwin'",
@@ -4526,7 +4527,6 @@ resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",


### PR DESCRIPTION
## Summary
- New `agent-core daemon install-autostart` / `uninstall-autostart` commands
- Registers a Windows Task Scheduler task that starts the prod daemon at logon
- New pure/impure module `daemon/autostart.py` (`build_autostart_task` pure → Task Scheduler XML; `install_autostart`/`uninstall_autostart` impure → `schtasks`)
- Prod-only, Windows-only, no admin; idempotent; `--start/--no-start` flag else interactive prompt

Spec: `docs/superpowers/specs/2026-05-22-phase4-windows-autostart-design.md`
Plan: `docs/superpowers/plans/2026-05-22-phase4-windows-autostart.md`

## Test plan
- [ ] All phase1-main-gate checks green (ubuntu + windows + integration + PR title)
- [ ] After merge: `agent-core daemon install-autostart` on the box, then reboot to confirm the daemon returns