### PR TITLE
feat(#114): unified discord_send envelope shape + strict-mode validator

### DIFF
--- a/docs/superpowers/plans/2026-05-23-issue-114-discord-send-unified-envelope.md
+++ b/docs/superpowers/plans/2026-05-23-issue-114-discord-send-unified-envelope.md
@@ -1,0 +1,1635 @@
+# Issue #114 — Unified `discord_send` envelope shape Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Spec:** `docs/superpowers/specs/2026-05-23-issue-114-discord-send-unified-envelope-design.md` (committed at `eabe993`).
+>
+> **Branch:** `feat/issue-114-discord-send-unified-envelope` (worktree at `.worktrees/issue-114-discord-send/`).
+>
+> **Issue:** [#114](https://github.com/jeffrichley/agent_core/issues/114).
+
+**Goal:** Add one canonical `tool=discord_send` to the Discord adapter and a strict-mode shape validator that publishes failed-delivery `Acknowledgment` envelopes (urgency=yellow) on unrecognized fields, closing the silent-drop class on the discord-send surface without touching the bus envelope schema.
+
+**Architecture:** New pure-function `shape_validator` module owns a catalog of recognized envelope shapes and returns `Recognized(shape_name, deprecation_log_line_or_None)` or `Unrecognized(fields, canonical_equivalent)`. `DiscordEndpoint.deliver()` calls the validator at the top, gates dispatch on recognized, and publishes a failed-delivery `Acknowledgment` via the existing `_reply()` machinery on unrecognized. New `_DiscordSendArgs` Pydantic model with `extra="forbid"` is the second strict layer at dispatch time. Old tool names (`send`, `send_discord_message`) and the existing `TextMessage + metadata.discord.*` routes continue to deliver with one structured deprecation-log line per call.
+
+**Tech Stack:** Python 3.12, pytest, pytest-asyncio, Pydantic v2, ruff, mypy, uv workspace.
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `packages/agent-core-discord/src/agent_core_discord/shape_validator.py` | NEW — `Recognized` / `Unrecognized` dataclasses, recognized-shape catalog, `validate()` entry point | Create |
+| `packages/agent-core-discord/tests/test_shape_validator.py` | NEW — pure-function unit tests for validator (catalog hits, unrecognized detection, nested-path, multi-field) | Create |
+| `packages/agent-core-discord/src/agent_core_discord/args.py` | Add `_DiscordSendArgs` Pydantic model with `extra="forbid"` | Modify |
+| `packages/agent-core-discord/tests/test_discord_send_args.py` | NEW — Pydantic-validation tests for `_DiscordSendArgs` | Create |
+| `packages/agent-core-discord/src/agent_core_discord/endpoint.py` | `_TOOL_ALIASES` add `discord_send`, `_dispatch` route it, `deliver()` call validator, `_send` extend empty-send message | Modify |
+| `packages/agent-core-discord/tests/test_endpoint_outbound.py` | Load-bearing regression test, back-compat regression tests, multi-field-unrecognized / empty-send / validator-exception integration tests | Modify (append) |
+
+---
+
+## Phase 1 — Validator module
+
+### Task 1: `shape_validator.py` skeleton with dataclasses and module structure
+
+**Files:**
+- Create: `packages/agent-core-discord/src/agent_core_discord/shape_validator.py`
+- Test: `packages/agent-core-discord/tests/test_shape_validator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-discord/tests/test_shape_validator.py`:
+
+```python
+"""Unit tests for shape_validator — the pure-function recognized-shape catalog
+for the Discord adapter's strict-mode envelope validation.
+
+The validator is PURE: no I/O, no Discord client, no chrome.* / discord.*
+imports. These tests construct envelopes directly and assert on the
+returned ShapeValidation value.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from agent_core.bus.envelope import (
+    Envelope,
+    TextMessagePayload,
+    ToolInvocationPayload,
+)
+from agent_core_discord.shape_validator import (
+    Recognized,
+    Unrecognized,
+    validate,
+)
+
+
+def _make_env(*, kind, payload, metadata=None, from_="test-sender"):
+    """Helper: build an Envelope with sensible defaults for validator tests."""
+    return Envelope(
+        id="env-abc",
+        correlation_id="corr-1",
+        to="discord-test",
+        kind=kind,
+        payload=payload,
+        metadata=metadata or {},
+        created_at=datetime.now(UTC),
+        from_=from_,
+    )
+
+
+def test_recognized_and_unrecognized_are_frozen_dataclasses():
+    """Both ShapeValidation variants are frozen so test assertions can compare
+    by value and Recognized/Unrecognized can be used as dict keys later."""
+    r = Recognized(shape_name="x", deprecation_log_line=None)
+    u = Unrecognized(fields=["a"], canonical_equivalent="b")
+    with pytest.raises(Exception):
+        r.shape_name = "y"  # frozen
+    with pytest.raises(Exception):
+        u.fields = ["c"]    # frozen
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_shape_validator.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'agent_core_discord.shape_validator'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/agent-core-discord/src/agent_core_discord/shape_validator.py`:
+
+```python
+"""shape_validator — pure-function recognized-shape catalog for the Discord
+adapter's strict-mode envelope validation.
+
+Closes the silent-drop class on the discord-send surface (#114). The
+adapter calls validate(envelope) at the top of deliver(): on
+Unrecognized, a yellow failed-delivery Acknowledgment is published to
+the sender with the canonical equivalent named; on Recognized + a
+deprecation_log_line, a structured log fires and dispatch proceeds; on
+Recognized + None (the canonical shape), dispatch proceeds silently.
+
+PURE module: no I/O, no Discord client, no global state. Unit-testable
+in isolation. See docs/superpowers/specs/2026-05-23-issue-114-discord-
+send-unified-envelope-design.md for the full design.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agent_core.bus.envelope import Envelope
+
+
+@dataclass(frozen=True)
+class Recognized:
+    """Validator outcome: the envelope matches a known shape.
+
+    shape_name: stable identifier for the matched shape, used as the
+        aggregation key in deprecation-readiness telemetry.
+    deprecation_log_line: human-readable message for the structured
+        deprecation log when the shape is legacy. None for the canonical
+        shape (no log emitted for the happy path).
+    """
+
+    shape_name: str
+    deprecation_log_line: str | None
+
+
+@dataclass(frozen=True)
+class Unrecognized:
+    """Validator outcome: the envelope carries fields the adapter does
+    not route.
+
+    fields: the unrecognized field path(s). For nested-path inputs
+        ('metadata.discord.foo.bar.baz' with 'foo' unknown), this is
+        the first unknown prefix ('metadata.discord.foo'), not the
+        leaves.
+    canonical_equivalent: human-readable hint for the sender's failed-
+        delivery Acknowledgment note, naming the canonical way to send
+        the same intent.
+    """
+
+    fields: list[str]
+    canonical_equivalent: str
+
+
+ShapeValidation = Recognized | Unrecognized
+
+
+def validate(envelope: Envelope) -> ShapeValidation:
+    """Validate that the Discord adapter has routing for every field on
+    envelope. Returns Recognized(shape_name, deprecation_log_line_or_None)
+    or Unrecognized(fields, canonical_equivalent).
+
+    Stub: real implementation lands in Tasks 2-4.
+    """
+    raise NotImplementedError("validate() stub — implementation in Tasks 2-4")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_shape_validator.py -v
+```
+
+Expected: PASS — `test_recognized_and_unrecognized_are_frozen_dataclasses PASSED`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-114-discord-send
+git add packages/agent-core-discord/src/agent_core_discord/shape_validator.py packages/agent-core-discord/tests/test_shape_validator.py
+git commit -m "feat(#114): shape_validator skeleton + frozen dataclasses"
+```
+
+---
+
+### Task 2: validate() — recognized ToolInvocation tool shapes (canonical, send, send_discord_message)
+
+**Files:**
+- Modify: `packages/agent-core-discord/src/agent_core_discord/shape_validator.py`
+- Test: `packages/agent-core-discord/tests/test_shape_validator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test_shape_validator.py`:
+
+```python
+def test_canonical_discord_send_returns_recognized_no_deprecation():
+    """The canonical tool=discord_send + canonical args is the new happy
+    path; no deprecation log fires."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="discord_send",
+            args={"channel_id": "123", "text": "hi"},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "canonical_discord_send"
+    assert result.deprecation_log_line is None
+
+
+def test_legacy_tool_send_returns_recognized_with_deprecation():
+    """tool=send is the pre-#114 internal canonical; ships as a legacy
+    alias after #114 with a deprecation-log line."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="send",
+            args={"channel_id": "123", "text": "hi"},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_tool_send"
+    assert result.deprecation_log_line is not None
+    assert "tool=discord_send" in result.deprecation_log_line
+
+
+def test_legacy_tool_send_discord_message_returns_recognized_with_deprecation():
+    """tool=send_discord_message is the existing public alias; ships as a
+    legacy alias after #114 with a deprecation-log line."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="send_discord_message",
+            args={"channel_id": "123", "text": "hi", "embeds": [{"title": "x"}]},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_tool_send_discord_message"
+    assert result.deprecation_log_line is not None
+    assert "tool=discord_send" in result.deprecation_log_line
+
+
+def test_other_tool_invocation_is_non_send_tool():
+    """Non-send tools (edit, react, fetch, etc.) are outside the
+    validator's strict-mode scope. They return Recognized with shape
+    'non_send_tool' so deliver() does not gate on them."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="edit",
+            args={"channel_id": "123", "message_id": "456", "text": "edited"},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "non_send_tool"
+    assert result.deprecation_log_line is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_shape_validator.py -v
+```
+
+Expected: 4 new tests FAIL with `NotImplementedError`.
+
+- [ ] **Step 3: Implement validate() for ToolInvocation**
+
+Replace the stub `validate()` body in `shape_validator.py` and add the supporting `_KNOWN_*` sets + `_validate_tool_invocation` helper. Insert above `validate()`:
+
+```python
+# Recognized arg names for the new canonical _DiscordSendArgs model.
+# Keep in lockstep with packages/agent-core-discord/src/agent_core_discord/
+# args.py:_DiscordSendArgs field set. The test_canonical_keys_in_sync test
+# (Task 5) asserts the lockstep.
+_KNOWN_CANONICAL_SEND_ARGS: frozenset[str] = frozenset({
+    "channel_id",
+    "text",
+    "embeds",
+    "files",
+    "reply_to",
+    "allowed_mentions",
+    "components",
+    "cleanup_inbound_message_id",
+})
+
+# Recognized arg names for the existing _SendArgs (legacy `tool=send` /
+# `tool=send_discord_message` routes). Must stay in lockstep with
+# args.py:_SendArgs. allowed_mentions and components are NOT in this
+# set — those are canonical-only future-proof slots, not exposed on the
+# legacy routes.
+_KNOWN_LEGACY_SEND_ARGS: frozenset[str] = frozenset({
+    "channel_id",
+    "text",
+    "embeds",
+    "reply_to",
+    "files",
+    "cleanup_inbound_message_id",
+})
+
+
+def _validate_tool_invocation(envelope: Envelope) -> ShapeValidation:
+    payload = envelope.payload
+    tool = getattr(payload, "tool", "") or ""
+    args = getattr(payload, "args", {}) or {}
+
+    if tool == "discord_send":
+        unrecognized = _unrecognized_arg_keys(args, _KNOWN_CANONICAL_SEND_ARGS)
+        if unrecognized:
+            return Unrecognized(
+                fields=[f"args.{k}" for k in unrecognized],
+                canonical_equivalent=(
+                    "tool=discord_send accepts "
+                    f"{sorted(_KNOWN_CANONICAL_SEND_ARGS)}"
+                ),
+            )
+        return Recognized("canonical_discord_send", None)
+
+    if tool in ("send", "send_discord_message"):
+        unrecognized = _unrecognized_arg_keys(args, _KNOWN_LEGACY_SEND_ARGS)
+        if unrecognized:
+            return Unrecognized(
+                fields=[f"args.{k}" for k in unrecognized],
+                canonical_equivalent=(
+                    f"tool=discord_send with {', '.join(unrecognized)} in args"
+                ),
+            )
+        return Recognized(
+            f"legacy_tool_{tool}",
+            f"deprecated_shape: tool={tool} — use tool=discord_send",
+        )
+
+    # All other tools (edit, react, fetch, list_channels, create_poll, etc.)
+    # are outside the strict-mode scope. deliver() does not block on them.
+    return Recognized("non_send_tool", None)
+
+
+def _unrecognized_arg_keys(args: object, known: frozenset[str]) -> list[str]:
+    if not isinstance(args, dict):
+        return []
+    return sorted(set(args.keys()) - known)
+```
+
+Replace the stub `validate()` body:
+
+```python
+def validate(envelope: Envelope) -> ShapeValidation:
+    if envelope.kind == "ToolInvocation":
+        return _validate_tool_invocation(envelope)
+    if envelope.kind == "TextMessage":
+        # TextMessage handling lands in Task 3.
+        raise NotImplementedError("TextMessage validation — Task 3")
+    # Kinds outside ToolInvocation / TextMessage (Event, Cancellation,
+    # Progress, Acknowledgment) are not in the strict-mode scope; the
+    # adapter's existing else-branch handles them with an unsupported-kind
+    # warning Ack. The validator returns Recognized so deliver() does not
+    # double-handle them.
+    return Recognized("non_send_kind", None)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_shape_validator.py -v
+```
+
+Expected: 5 tests PASS (the original + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-114-discord-send
+git add packages/agent-core-discord/src/agent_core_discord/shape_validator.py packages/agent-core-discord/tests/test_shape_validator.py
+git commit -m "feat(#114): shape_validator handles ToolInvocation shapes"
+```
+
+---
+
+### Task 3: validate() — recognized TextMessage shapes (4 catalog entries)
+
+**Files:**
+- Modify: `packages/agent-core-discord/src/agent_core_discord/shape_validator.py`
+- Test: `packages/agent-core-discord/tests/test_shape_validator.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test_shape_validator.py`:
+
+```python
+def test_textmessage_plain_text_returns_recognized_with_deprecation():
+    """The most-common legacy shape: TextMessage with channel_id only."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hello"),
+        metadata={"discord": {"channel_id": "123"}},
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_textmessage_plain"
+    assert result.deprecation_log_line is not None
+
+
+def test_textmessage_with_embeds_returns_recognized_with_deprecation():
+    """The poster-child shape from #114 — routed since a278c68 but
+    still legacy. Embed presence determines the shape_name."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text=""),
+        metadata={"discord": {"channel_id": "123", "embeds": [{"title": "x"}]}},
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_textmessage_embeds"
+    assert result.deprecation_log_line is not None
+
+
+def test_textmessage_with_reply_to_returns_recognized_with_deprecation():
+    """reply_to legacy shape. message_id alias also tested via a fallback
+    test below."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="reply"),
+        metadata={
+            "discord": {"channel_id": "123", "reply_to": "456"},
+        },
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_textmessage_reply"
+    assert result.deprecation_log_line is not None
+
+
+def test_textmessage_no_discord_metadata_is_non_discord():
+    """TextMessage envelopes with no metadata.discord block at all are
+    not discord-bound; validator returns Recognized so deliver() doesn't
+    treat the absence of routing as a failure."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hi"),
+        metadata={},
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "non_discord_text_message"
+    assert result.deprecation_log_line is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_shape_validator.py -v
+```
+
+Expected: 4 new tests FAIL with `NotImplementedError`.
+
+- [ ] **Step 3: Implement TextMessage path in validate()**
+
+Insert above `validate()` (after the existing helpers):
+
+```python
+# Recognized keys under metadata.discord on OUTBOUND TextMessage
+# envelopes. INBOUND-only keys (message_id, guild_id, author_id,
+# author_display_name, is_dm) are not in this set — they are set by
+# the adapter when publishing inbound, and a sender that sets them on
+# an outbound is doing something the adapter does not route. Flag as
+# Unrecognized so the silent-drop class is closed (Task 4).
+_KNOWN_DISCORD_META_OUTBOUND_KEYS: frozenset[str] = frozenset({
+    "channel_id",
+    "embeds",
+    "reply_to",
+})
+
+
+def _validate_text_message(envelope: Envelope) -> ShapeValidation:
+    metadata = envelope.metadata or {}
+    discord_meta = metadata.get("discord")
+
+    if discord_meta is None:
+        # TextMessage without metadata.discord is not discord-bound.
+        # Adapter's existing routing handles this via outbound_channel_id
+        # fallback or _ToolError.
+        return Recognized("non_discord_text_message", None)
+
+    if not isinstance(discord_meta, dict):
+        # metadata.discord is present but malformed (string, list, etc.).
+        return Unrecognized(
+            fields=["metadata.discord"],
+            canonical_equivalent=(
+                "tool=discord_send with channel_id in args (metadata.discord "
+                "must be an object)"
+            ),
+        )
+
+    # Unrecognized-key detection lands in Task 4. For now, recognize
+    # legacy shapes by the most-discriminating field present.
+    if "embeds" in discord_meta:
+        return Recognized(
+            "legacy_textmessage_embeds",
+            "deprecated_shape: TextMessage + metadata.discord.embeds — "
+            "use tool=discord_send with embeds in args",
+        )
+    if "reply_to" in discord_meta:
+        return Recognized(
+            "legacy_textmessage_reply",
+            "deprecated_shape: TextMessage + metadata.discord.reply_to — "
+            "use tool=discord_send with reply_to in args",
+        )
+    if "channel_id" in discord_meta:
+        return Recognized(
+            "legacy_textmessage_plain",
+            "deprecated_shape: TextMessage + metadata.discord.channel_id — "
+            "use tool=discord_send with text in args",
+        )
+    # Ambiguous discord_meta block (e.g., empty {} or only message_id).
+    return Recognized(
+        "legacy_textmessage_ambiguous",
+        "deprecated_shape: TextMessage + metadata.discord without channel_id",
+    )
+```
+
+Replace the `raise NotImplementedError("TextMessage validation — Task 3")` line in `validate()` with a call:
+
+```python
+def validate(envelope: Envelope) -> ShapeValidation:
+    if envelope.kind == "ToolInvocation":
+        return _validate_tool_invocation(envelope)
+    if envelope.kind == "TextMessage":
+        return _validate_text_message(envelope)
+    return Recognized("non_send_kind", None)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_shape_validator.py -v
+```
+
+Expected: 9 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-114-discord-send
+git add packages/agent-core-discord/src/agent_core_discord/shape_validator.py packages/agent-core-discord/tests/test_shape_validator.py
+git commit -m "feat(#114): shape_validator handles TextMessage shapes"
+```
+
+---
+
+### Task 4: validate() — unrecognized fields, multi-field, and nested-path handling
+
+**Files:**
+- Modify: `packages/agent-core-discord/src/agent_core_discord/shape_validator.py`
+- Test: `packages/agent-core-discord/tests/test_shape_validator.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test_shape_validator.py`:
+
+```python
+def test_textmessage_with_unrecognized_metadata_field_returns_unrecognized():
+    """The load-bearing case: an outbound carries a metadata.discord.*
+    field the adapter does not route. Validator must flag it so the Ack
+    can be published — silent-drop is what #114 closes."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hi"),
+        metadata={"discord": {"channel_id": "123", "mystery_field": "X"}},
+    )
+    result = validate(env)
+    assert isinstance(result, Unrecognized)
+    assert result.fields == ["metadata.discord.mystery_field"]
+    assert "discord_send" in result.canonical_equivalent
+    assert "mystery_field" in result.canonical_equivalent
+
+
+def test_textmessage_with_multiple_unrecognized_fields_returns_all():
+    """Multi-field case enumerates all unrecognized fields in one Ack
+    rather than fragmenting across N redeliveries."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hi"),
+        metadata={"discord": {
+            "channel_id": "123",
+            "mystery_field": "X",
+            "another_unknown": "Y",
+        }},
+    )
+    result = validate(env)
+    assert isinstance(result, Unrecognized)
+    # Order is sorted for determinism in the Ack note.
+    assert result.fields == [
+        "metadata.discord.another_unknown",
+        "metadata.discord.mystery_field",
+    ]
+
+
+def test_toolinvocation_canonical_with_unrecognized_arg_returns_unrecognized():
+    """args-level strict-mode for the canonical tool. The Pydantic
+    extra='forbid' on _DiscordSendArgs catches this at dispatch too;
+    the validator catches it before dispatch."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="discord_send",
+            args={"channel_id": "123", "text": "hi", "mystery_arg": "X"},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Unrecognized)
+    assert result.fields == ["args.mystery_arg"]
+    assert "discord_send" in result.canonical_equivalent
+
+
+def test_toolinvocation_legacy_with_unrecognized_arg_returns_unrecognized():
+    """Legacy tool with a new field the legacy args model never wired."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="send_discord_message",
+            args={"channel_id": "123", "text": "hi", "allowed_mentions": {}},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Unrecognized)
+    assert result.fields == ["args.allowed_mentions"]
+    assert "discord_send" in result.canonical_equivalent
+    assert "allowed_mentions" in result.canonical_equivalent
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_shape_validator.py -v
+```
+
+Expected: 4 new tests FAIL — the `_validate_text_message` does not yet check unrecognized metadata.discord.* keys; tests for legacy ToolInvocation with non-canonical args should already pass via the existing `_unrecognized_arg_keys` logic.
+
+- [ ] **Step 3: Tighten _validate_text_message to detect unrecognized metadata.discord.* keys**
+
+Modify `_validate_text_message` in `shape_validator.py` — insert the unrecognized-key check immediately after the `isinstance(discord_meta, dict)` guard and before the shape-naming branches:
+
+```python
+def _validate_text_message(envelope: Envelope) -> ShapeValidation:
+    metadata = envelope.metadata or {}
+    discord_meta = metadata.get("discord")
+
+    if discord_meta is None:
+        return Recognized("non_discord_text_message", None)
+
+    if not isinstance(discord_meta, dict):
+        return Unrecognized(
+            fields=["metadata.discord"],
+            canonical_equivalent=(
+                "tool=discord_send with channel_id in args (metadata.discord "
+                "must be an object)"
+            ),
+        )
+
+    # Unrecognized-key detection. Senders that set metadata.discord.*
+    # fields the adapter does not route get a failed-delivery Ack — this
+    # is the load-bearing closure of the silent-drop class.
+    unrecognized_keys = sorted(
+        set(discord_meta.keys()) - _KNOWN_DISCORD_META_OUTBOUND_KEYS
+    )
+    if unrecognized_keys:
+        return Unrecognized(
+            fields=[f"metadata.discord.{k}" for k in unrecognized_keys],
+            canonical_equivalent=(
+                f"tool=discord_send with {', '.join(unrecognized_keys)} in args"
+            ),
+        )
+
+    # Recognized legacy shape — name by most-discriminating field.
+    if "embeds" in discord_meta:
+        return Recognized(
+            "legacy_textmessage_embeds",
+            "deprecated_shape: TextMessage + metadata.discord.embeds — "
+            "use tool=discord_send with embeds in args",
+        )
+    if "reply_to" in discord_meta:
+        return Recognized(
+            "legacy_textmessage_reply",
+            "deprecated_shape: TextMessage + metadata.discord.reply_to — "
+            "use tool=discord_send with reply_to in args",
+        )
+    if "channel_id" in discord_meta:
+        return Recognized(
+            "legacy_textmessage_plain",
+            "deprecated_shape: TextMessage + metadata.discord.channel_id — "
+            "use tool=discord_send with text in args",
+        )
+    return Recognized(
+        "legacy_textmessage_ambiguous",
+        "deprecated_shape: TextMessage + metadata.discord without channel_id",
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_shape_validator.py -v
+```
+
+Expected: 13 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-114-discord-send
+git add packages/agent-core-discord/src/agent_core_discord/shape_validator.py packages/agent-core-discord/tests/test_shape_validator.py
+git commit -m "feat(#114): shape_validator detects unrecognized fields"
+```
+
+---
+
+## Phase 2 — Args model
+
+### Task 5: `_DiscordSendArgs` Pydantic model with extra="forbid"
+
+**Files:**
+- Modify: `packages/agent-core-discord/src/agent_core_discord/args.py`
+- Test: `packages/agent-core-discord/tests/test_discord_send_args.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-discord/tests/test_discord_send_args.py`:
+
+```python
+"""Unit tests for _DiscordSendArgs — the strict canonical args model
+for tool=discord_send (#114).
+
+The model uses extra='forbid' as the second strict layer behind the
+envelope-level shape_validator: a typo on the args side raises
+ValidationError at dispatch, which translates to a yellow Ack via the
+existing _ToolError path. No silent drop.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from agent_core_discord.args import _DiscordSendArgs
+
+
+def test_canonical_minimal_text_send_accepted():
+    """channel_id + text is the smallest valid canonical args."""
+    args = _DiscordSendArgs(channel_id="123", text="hi")
+    assert args.channel_id == "123"
+    assert args.text == "hi"
+    assert args.embeds is None
+    assert args.files is None
+
+
+def test_all_optional_fields_accepted_independently():
+    """Each optional field is accepted on its own. Spot-check the field
+    set rather than enumerating exhaustively."""
+    _DiscordSendArgs(channel_id="1", embeds=[{"title": "x"}])
+    _DiscordSendArgs(channel_id="1", files=["/tmp/a"])
+    _DiscordSendArgs(channel_id="1", reply_to="456")
+    _DiscordSendArgs(channel_id="1", allowed_mentions={"users": []})
+    _DiscordSendArgs(channel_id="1", components=[{"type": 1}])
+    _DiscordSendArgs(channel_id="1", cleanup_inbound_message_id="789")
+
+
+def test_missing_channel_id_raises():
+    with pytest.raises(ValidationError) as exc:
+        _DiscordSendArgs(text="hi")
+    assert "channel_id" in str(exc.value)
+
+
+def test_empty_channel_id_raises():
+    """channel_id is required and must be non-empty."""
+    with pytest.raises(ValidationError):
+        _DiscordSendArgs(channel_id="")
+
+
+def test_extra_field_rejected_by_forbid():
+    """extra='forbid' is the contract: any unknown field at the args
+    level raises ValidationError. The shape_validator should catch this
+    case BEFORE Pydantic, but this is the defense-in-depth layer."""
+    with pytest.raises(ValidationError) as exc:
+        _DiscordSendArgs(channel_id="123", text="hi", mystery_field="X")
+    msg = str(exc.value)
+    assert "mystery_field" in msg or "extra" in msg.lower()
+
+
+def test_canonical_keys_in_sync_with_validator_catalog():
+    """The canonical args field set must stay in lockstep with
+    shape_validator._KNOWN_CANONICAL_SEND_ARGS. A drift between them
+    would surface as a sender being rejected by one layer but accepted
+    by the other."""
+    from agent_core_discord.shape_validator import _KNOWN_CANONICAL_SEND_ARGS
+
+    model_fields = set(_DiscordSendArgs.model_fields.keys())
+    assert model_fields == _KNOWN_CANONICAL_SEND_ARGS
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_discord_send_args.py -v
+```
+
+Expected: 6 tests FAIL with `ImportError: cannot import name '_DiscordSendArgs' from 'agent_core_discord.args'`.
+
+- [ ] **Step 3: Append _DiscordSendArgs to args.py**
+
+Append to `packages/agent-core-discord/src/agent_core_discord/args.py`:
+
+```python
+class _DiscordSendArgs(BaseModel):
+    """Canonical args for tool=discord_send (#114).
+
+    Pydantic extra='forbid' is the second strict layer behind the
+    envelope-level shape_validator. The validator catches unrecognized
+    fields BEFORE dispatch (yellow Ack via _reply); ValidationError
+    here catches them at dispatch (yellow Ack via _ToolError). Both
+    paths surface to the sender — no silent drop.
+
+    The canonical field set must stay in lockstep with
+    shape_validator._KNOWN_CANONICAL_SEND_ARGS. The
+    test_canonical_keys_in_sync_with_validator_catalog test asserts
+    the invariant.
+
+    allowed_mentions and components are future-proof slots: the args
+    model accepts them, but the adapter's _send() does not yet pass
+    them through to discord.py. A caller that sets them today gets a
+    successful send with the option silently unapplied. A future
+    ticket adds the wiring in _send when there is named demand; no
+    args-model migration needed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str = Field(min_length=1)
+    text: str | None = None
+    embeds: list[dict[str, Any]] | None = None
+    files: list[str] | None = None
+    reply_to: str | None = None
+    allowed_mentions: dict[str, Any] | None = None
+    components: list[dict[str, Any]] | None = None
+    cleanup_inbound_message_id: str | None = None
+```
+
+Required imports at the top of `args.py` (verify they are already present; add any missing):
+
+```python
+from typing import Any
+from pydantic import BaseModel, ConfigDict, Field
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_discord_send_args.py packages/agent-core-discord/tests/test_shape_validator.py -v
+```
+
+Expected: 6 args tests PASS + 13 validator tests still PASS. The lockstep test asserts the cross-module invariant.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-114-discord-send
+git add packages/agent-core-discord/src/agent_core_discord/args.py packages/agent-core-discord/tests/test_discord_send_args.py
+git commit -m "feat(#114): _DiscordSendArgs strict args model"
+```
+
+---
+
+## Phase 3 — endpoint.py integration
+
+### Task 6: Wire `discord_send` into _TOOL_ALIASES and _dispatch
+
+**Files:**
+- Modify: `packages/agent-core-discord/src/agent_core_discord/endpoint.py`
+- Test: `packages/agent-core-discord/tests/test_endpoint_outbound.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test_endpoint_outbound.py` (locate existing fixtures and follow their pattern; the test uses the existing `make_endpoint` / fake-client harness):
+
+```python
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_discord_send_to_internal_send(make_endpoint):
+    """tool=discord_send must reach _send via _dispatch. Verifies the
+    new entry in _TOOL_ALIASES and the _dispatch table."""
+    endpoint, fake_client = make_endpoint()
+    await endpoint.start(_FakeBus())
+
+    args = {"channel_id": "123", "text": "hi"}
+    env = _build_tool_invocation_envelope(tool="discord_send", args=args)
+    await endpoint.deliver(env)
+    assert fake_client.last_send_call is not None
+    assert fake_client.last_send_call["channel"] == "123"
+    assert fake_client.last_send_call["content"] == "hi"
+```
+
+(The `make_endpoint`, `_FakeBus`, `_build_tool_invocation_envelope` helpers should already exist in the test module from the existing parameterized verb tests added in #83 / #84. If a helper is missing, add a minimal one alongside the new test — but do NOT refactor existing helpers.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_dispatch_routes_discord_send_to_internal_send -v
+```
+
+Expected: FAIL with `_ToolError: unknown tool 'discord_send'`.
+
+- [ ] **Step 3: Add the alias and dispatch case**
+
+In `packages/agent-core-discord/src/agent_core_discord/endpoint.py`, modify the `_TOOL_ALIASES` dict (currently around line 67) — add the canonical passthrough:
+
+```python
+_TOOL_ALIASES: dict[str, str] = {
+    "send_discord_message": "send",
+    "discord_send": "discord_send",  # #114: canonical passthrough
+    "edit_message": "edit",
+    "add_reaction": "react",
+    "fetch_messages": "fetch",
+}
+```
+
+Then in `_dispatch` (currently around line 778), add the `discord_send` case immediately BEFORE the `send` case so the canonical name routes through the strict `_DiscordSendArgs` validation:
+
+```python
+        if tool == "discord_send":
+            from agent_core_discord.args import _DiscordSendArgs
+            return await self._send(
+                _v(_DiscordSendArgs, _inject_channel_id(args))
+            )
+        if tool == "send":
+            return await self._send(_v(_SendArgs, _inject_channel_id(args)))
+```
+
+(Top-of-file import of `_DiscordSendArgs` is preferred; the inline import shown here is acceptable if the import-grouping convention of the file already uses inline imports for newer optional types. Match what is already there.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_dispatch_routes_discord_send_to_internal_send -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-114-discord-send
+git add packages/agent-core-discord/src/agent_core_discord/endpoint.py packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "feat(#114): wire tool=discord_send through _dispatch"
+```
+
+---
+
+### Task 7: Extend `_send` empty-send guard to include `files`
+
+**Files:**
+- Modify: `packages/agent-core-discord/src/agent_core_discord/endpoint.py`
+- Test: `packages/agent-core-discord/tests/test_endpoint_outbound.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test_endpoint_outbound.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_discord_send_with_no_payload_raises_explicit_error(make_endpoint):
+    """tool=discord_send with no text, no embeds, no files must produce
+    a clear yellow Ack naming all three options, not just text/embeds."""
+    endpoint, _fake_client = make_endpoint()
+    await endpoint.start(_FakeBus())
+
+    args = {"channel_id": "123"}
+    env = _build_tool_invocation_envelope(tool="discord_send", args=args)
+    bus = endpoint._handle  # the fake bus used for outbound Acks
+    await endpoint.deliver(env)
+
+    # The Acknowledgment fired with a note listing all three payload
+    # options.
+    last_ack = bus.last_published_envelope
+    assert last_ack.kind == "Acknowledgment"
+    assert last_ack.urgency == "yellow"
+    assert "text" in last_ack.payload.note
+    assert "embeds" in last_ack.payload.note
+    assert "files" in last_ack.payload.note
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_discord_send_with_no_payload_raises_explicit_error -v
+```
+
+Expected: FAIL — current message says `"send: one of 'text' or 'embeds' is required"` and does not include `files`.
+
+- [ ] **Step 3: Extend the guard message in `_send`**
+
+In `endpoint.py`, find `_send` (currently around line 1386) and change the first line:
+
+```python
+    async def _send(self, args: _SendArgs) -> dict:
+        if args.text is None and not args.embeds and not args.files:
+            raise _ToolError(
+                "send: one of 'text', 'embeds', or 'files' is required"
+            )
+        ch = await self._resolve_channel(args.channel_id)
+        # ... (rest unchanged)
+```
+
+The single-line code change inside `_send` is: replace `if args.text is None and not args.embeds:` with `if args.text is None and not args.embeds and not args.files:` and update the error message to `"send: one of 'text', 'embeds', or 'files' is required"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_endpoint_outbound.py -v
+```
+
+Expected: new test PASSES; no existing test regresses (the existing `_send` callers all pass `text` or `embeds`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-114-discord-send
+git add packages/agent-core-discord/src/agent_core_discord/endpoint.py packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "feat(#114): _send empty-send guard names 'files'"
+```
+
+---
+
+### Task 8: Integrate validator into `deliver()` and route unrecognized to failed-delivery Ack
+
+**Files:**
+- Modify: `packages/agent-core-discord/src/agent_core_discord/endpoint.py`
+- Test: `packages/agent-core-discord/tests/test_endpoint_outbound.py`
+
+- [ ] **Step 1: Write the failing test (load-bearing regression test from spec §Testing)**
+
+Append to `test_endpoint_outbound.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_unrecognized_field_produces_failed_delivery_ack(make_endpoint):
+    """LOAD-BEARING regression test (spec Testing §). The single test
+    that proves the silent-drop class is closed for this surface.
+
+    Construct a TextMessage envelope with metadata.discord.mystery_field,
+    hand it to DiscordEndpoint.deliver(), assert:
+      (a) no Discord API call was made;
+      (b) a yellow Acknowledgment was published with the right
+          in_reply_to and a note naming the unrecognized field;
+      (c) the inbound was acked (so it does not redeliver);
+      (d) _send was never reached.
+    """
+    endpoint, fake_client = make_endpoint()
+    bus = _FakeBus()
+    await endpoint.start(bus)
+
+    env = _build_text_message_envelope(
+        text="hi",
+        metadata={"discord": {
+            "channel_id": "123",
+            "mystery_field": "X",
+        }},
+    )
+    original_id = env.id
+
+    await endpoint.deliver(env)
+
+    # (a) No Discord API call.
+    assert fake_client.last_send_call is None, (
+        "validator failed to gate: dispatch reached the Discord client"
+    )
+
+    # (b) Yellow Ack with right in_reply_to and the unrecognized field
+    # named in the note.
+    ack = bus.last_published_envelope
+    assert ack is not None, "no failed-delivery Ack was published"
+    assert ack.kind == "Acknowledgment"
+    assert ack.urgency == "yellow"
+    assert ack.in_reply_to == original_id
+    assert "metadata.discord.mystery_field" in ack.payload.note
+    assert "discord_send" in ack.payload.note
+
+    # (c) The inbound was acked.
+    assert original_id in bus.acked_envelope_ids
+
+    # (d) _send was never reached — fake_client.send_call_count is 0.
+    assert fake_client.send_call_count == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_unrecognized_field_produces_failed_delivery_ack -v
+```
+
+Expected: FAIL — `deliver()` today does not call the validator; the TextMessage routes through `_deliver_text_message`, which does NOT see `mystery_field`, silently ignores it, and proceeds to deliver via `_send`.
+
+- [ ] **Step 3: Wire the validator into `deliver()`**
+
+Add the import near the top of `endpoint.py` (alongside existing `from agent_core_discord.*` imports):
+
+```python
+from agent_core_discord.shape_validator import (
+    Recognized,
+    Unrecognized,
+    validate as validate_shape,
+)
+```
+
+In `deliver()` (currently around line 655), prepend the validator step. The modified body:
+
+```python
+    async def deliver(self, envelope: Envelope) -> None:
+        if self._handle is None:
+            raise EndpointUnavailable(f"discord '{self.name}' not started")
+
+        # #114: strict-mode validator. Only consulted for kinds the
+        # adapter dispatches (TextMessage / ToolInvocation); other kinds
+        # fall through to the existing else-branch unchanged.
+        if envelope.kind in ("TextMessage", "ToolInvocation"):
+            validation = validate_shape(envelope)
+            if isinstance(validation, Unrecognized):
+                log.warning(
+                    "discord(%s): unrecognized_shape event",
+                    self.name,
+                    extra={
+                        "event": "unrecognized_shape",
+                        "envelope_kind": envelope.kind,
+                        "unrecognized_fields": validation.fields,
+                        "sender": envelope.from_,
+                        "envelope_id": envelope.id,
+                        "canonical_equivalent": validation.canonical_equivalent,
+                    },
+                )
+                field_list = validation.fields
+                if len(field_list) == 1:
+                    note = (
+                        f"Unrecognized field {field_list[0]!r} on "
+                        f"{envelope.kind}. Canonical: "
+                        f"{validation.canonical_equivalent}"
+                    )
+                else:
+                    note = (
+                        f"Unrecognized fields {field_list} on "
+                        f"{envelope.kind}. Canonical: "
+                        f"{validation.canonical_equivalent}"
+                    )
+                await self._reply(envelope, note, urgency="yellow")
+                await self._handle.ack(envelope.id)
+                return
+            if validation.deprecation_log_line:
+                log.warning(
+                    "discord(%s): deprecated_shape event",
+                    self.name,
+                    extra={
+                        "event": "deprecated_shape",
+                        "shape_name": validation.shape_name,
+                        "sender": envelope.from_,
+                        "envelope_id": envelope.id,
+                        "canonical_equivalent": "tool=discord_send",
+                    },
+                )
+
+        # ... existing kind-branch unchanged below ...
+        if envelope.kind == "TextMessage":
+            # (existing body)
+            ...
+```
+
+(Preserve the existing body of the kind-branches verbatim. The new code lands strictly ABOVE them; nothing inside the existing branches changes.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_endpoint_outbound.py::test_unrecognized_field_produces_failed_delivery_ack -v
+```
+
+Expected: PASS.
+
+```bash
+uv run pytest packages/agent-core-discord/tests/ -v
+```
+
+Expected: all tests PASS (including the existing back-compat tests, which carry recognized shapes and so flow through the validator's `Recognized` path).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-114-discord-send
+git add packages/agent-core-discord/src/agent_core_discord/endpoint.py packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "feat(#114): deliver() routes unrecognized envelopes to failed-delivery Ack"
+```
+
+---
+
+## Phase 4 — Back-compat regression coverage + remaining integration tests
+
+### Task 9: Back-compat regression tests with deprecation-log assertions
+
+**Files:**
+- Modify: `packages/agent-core-discord/tests/test_endpoint_outbound.py`
+
+- [ ] **Step 1: Write the failing tests (all four documented legacy shapes + log capture)**
+
+Append to `test_endpoint_outbound.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_legacy_textmessage_plain_still_delivers_and_logs_deprecation(
+    make_endpoint, caplog
+):
+    """Back-compat shape #1: TextMessage + metadata.discord.channel_id
+    plain text. Must still deliver. Must emit a structured
+    deprecation_shape log line keyed by shape_name."""
+    endpoint, fake_client = make_endpoint()
+    await endpoint.start(_FakeBus())
+
+    env = _build_text_message_envelope(
+        text="hi",
+        metadata={"discord": {"channel_id": "123"}},
+    )
+    with caplog.at_level("WARNING"):
+        await endpoint.deliver(env)
+
+    assert fake_client.last_send_call is not None
+    assert fake_client.last_send_call["content"] == "hi"
+    deprecated_logs = [
+        r for r in caplog.records
+        if getattr(r, "event", None) == "deprecated_shape"
+    ]
+    assert len(deprecated_logs) == 1
+    assert deprecated_logs[0].shape_name == "legacy_textmessage_plain"
+    assert deprecated_logs[0].sender == env.from_
+    assert deprecated_logs[0].envelope_id == env.id
+    assert deprecated_logs[0].canonical_equivalent == "tool=discord_send"
+
+
+@pytest.mark.asyncio
+async def test_legacy_send_discord_message_with_embeds_still_delivers_and_logs(
+    make_endpoint, caplog
+):
+    """Back-compat shape #2: ToolInvocation + tool=send_discord_message
+    + args.{channel_id, text, embeds}."""
+    endpoint, fake_client = make_endpoint()
+    await endpoint.start(_FakeBus())
+
+    env = _build_tool_invocation_envelope(
+        tool="send_discord_message",
+        args={"channel_id": "123", "text": "hi", "embeds": [{"title": "x"}]},
+    )
+    with caplog.at_level("WARNING"):
+        await endpoint.deliver(env)
+
+    assert fake_client.last_send_call is not None
+    deprecated_logs = [
+        r for r in caplog.records
+        if getattr(r, "event", None) == "deprecated_shape"
+    ]
+    assert len(deprecated_logs) == 1
+    assert deprecated_logs[0].shape_name == "legacy_tool_send_discord_message"
+
+
+@pytest.mark.asyncio
+async def test_legacy_send_discord_message_with_files_still_delivers_and_logs(
+    make_endpoint, caplog, tmp_path
+):
+    """Back-compat shape #3: ToolInvocation + tool=send_discord_message
+    + args.{channel_id, text, files} (verified 2026-05-11)."""
+    endpoint, fake_client = make_endpoint()
+    await endpoint.start(_FakeBus())
+
+    fake_file = tmp_path / "qa.zip"
+    fake_file.write_bytes(b"\x00")
+
+    env = _build_tool_invocation_envelope(
+        tool="send_discord_message",
+        args={"channel_id": "123", "text": "ship it", "files": [str(fake_file)]},
+    )
+    with caplog.at_level("WARNING"):
+        await endpoint.deliver(env)
+
+    assert fake_client.last_send_call is not None
+    deprecated_logs = [
+        r for r in caplog.records
+        if getattr(r, "event", None) == "deprecated_shape"
+    ]
+    assert len(deprecated_logs) == 1
+    assert deprecated_logs[0].shape_name == "legacy_tool_send_discord_message"
+
+
+@pytest.mark.asyncio
+async def test_legacy_textmessage_with_embeds_still_delivers_and_logs(
+    make_endpoint, caplog
+):
+    """Back-compat shape #4: the poster-child. TextMessage + metadata.
+    discord.embeds was routed by commit a278c68; after #114 it still
+    routes but the deprecation log fires."""
+    endpoint, fake_client = make_endpoint()
+    await endpoint.start(_FakeBus())
+
+    env = _build_text_message_envelope(
+        text="",
+        metadata={"discord": {
+            "channel_id": "123",
+            "embeds": [{"title": "x"}],
+        }},
+    )
+    with caplog.at_level("WARNING"):
+        await endpoint.deliver(env)
+
+    assert fake_client.last_send_call is not None
+    deprecated_logs = [
+        r for r in caplog.records
+        if getattr(r, "event", None) == "deprecated_shape"
+    ]
+    assert len(deprecated_logs) == 1
+    assert deprecated_logs[0].shape_name == "legacy_textmessage_embeds"
+```
+
+- [ ] **Step 2: Run tests to verify they fail OR pass**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_endpoint_outbound.py -v -k legacy
+```
+
+Expected: 4 new tests should PASS if Task 8 wired the deprecation log correctly. If any fail because the log line is missing or wrong-shape, fix the structured-log emission in Task 8's `deliver()` body to match the assertions.
+
+- [ ] **Step 3: (If any test failed) Fix the log emission**
+
+The test contract: each `deprecated_shape` log record carries `event`, `shape_name`, `sender`, `envelope_id`, and `canonical_equivalent` as `extra=` keys. Cross-reference the Task 8 implementation; ensure the `extra=` dict matches the test assertions exactly.
+
+- [ ] **Step 4: Re-run tests to verify all pass**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_endpoint_outbound.py -v
+```
+
+Expected: all tests PASS, including the new 4 back-compat regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-114-discord-send
+git add packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "test(#114): back-compat regression coverage for the 4 documented legacy shapes"
+```
+
+---
+
+### Task 10: Multi-field unrecognized + canonical-path + validator-internal-exception integration tests
+
+**Files:**
+- Modify: `packages/agent-core-discord/tests/test_endpoint_outbound.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test_endpoint_outbound.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_multi_field_unrecognized_produces_one_ack_listing_all_fields(
+    make_endpoint,
+):
+    """When two or more unrecognized fields land on the same envelope,
+    ONE failed-delivery Ack lists all of them. Senders see the full
+    failure surface in one delivery, not in N redeliveries."""
+    endpoint, fake_client = make_endpoint()
+    bus = _FakeBus()
+    await endpoint.start(bus)
+
+    env = _build_text_message_envelope(
+        text="hi",
+        metadata={"discord": {
+            "channel_id": "123",
+            "mystery_one": "X",
+            "mystery_two": "Y",
+        }},
+    )
+    await endpoint.deliver(env)
+
+    assert fake_client.last_send_call is None
+    ack = bus.last_published_envelope
+    assert ack.kind == "Acknowledgment"
+    assert ack.urgency == "yellow"
+    # Both fields named in the note.
+    assert "metadata.discord.mystery_one" in ack.payload.note
+    assert "metadata.discord.mystery_two" in ack.payload.note
+    # Only ONE Ack published.
+    assert bus.publish_count == 1
+
+
+@pytest.mark.asyncio
+async def test_canonical_discord_send_delivers_silently_no_deprecation_log(
+    make_endpoint, caplog
+):
+    """The canonical path: tool=discord_send + canonical args delivers
+    and emits NO deprecation log. The deprecation-readiness telemetry
+    must see clean canonical sends as 'no event recorded'."""
+    endpoint, fake_client = make_endpoint()
+    await endpoint.start(_FakeBus())
+
+    env = _build_tool_invocation_envelope(
+        tool="discord_send",
+        args={"channel_id": "123", "text": "hi"},
+    )
+    with caplog.at_level("WARNING"):
+        await endpoint.deliver(env)
+
+    assert fake_client.last_send_call is not None
+    deprecated_logs = [
+        r for r in caplog.records
+        if getattr(r, "event", None) == "deprecated_shape"
+    ]
+    assert deprecated_logs == []
+
+
+@pytest.mark.asyncio
+async def test_validator_internal_exception_produces_yellow_ack(
+    make_endpoint, monkeypatch
+):
+    """If the validator itself raises (catalog bug, malformed envelope
+    from a test fixture), deliver()'s existing exception handler must
+    catch it and produce a yellow Ack with the error in the note. The
+    inbound must still be acked so no redelivery storm happens."""
+    endpoint, fake_client = make_endpoint()
+    bus = _FakeBus()
+    await endpoint.start(bus)
+
+    # Force validate() to raise.
+    def _boom(_env):
+        raise RuntimeError("catalog bug for test")
+
+    monkeypatch.setattr(
+        "agent_core_discord.endpoint.validate_shape", _boom
+    )
+
+    env = _build_tool_invocation_envelope(
+        tool="discord_send",
+        args={"channel_id": "123", "text": "hi"},
+    )
+    await endpoint.deliver(env)
+
+    # _send was NOT reached.
+    assert fake_client.send_call_count == 0
+    # Yellow Ack with "validator failed" in the note.
+    ack = bus.last_published_envelope
+    assert ack.urgency == "yellow"
+    assert "validator failed" in ack.payload.note.lower() or "error" in ack.payload.note.lower()
+    # Inbound was acked.
+    assert env.id in bus.acked_envelope_ids
+```
+
+- [ ] **Step 2: Run tests to verify they fail OR pass**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_endpoint_outbound.py -v -k "multi_field or canonical_discord_send_delivers or validator_internal_exception"
+```
+
+Expected: multi_field and canonical tests should PASS off the back of Task 8. validator_internal_exception test may need a small adjustment in `deliver()`'s exception handling — the existing handler wraps `_dispatch` but the new validator call sits ABOVE the dispatch try/except. Wrap the validator call in its own try/except inside `deliver()`:
+
+```python
+        if envelope.kind in ("TextMessage", "ToolInvocation"):
+            try:
+                validation = validate_shape(envelope)
+            except Exception as exc:
+                log.exception("discord(%s): validator raised", self.name)
+                await self._reply(
+                    envelope,
+                    f"validator failed: {exc!r}",
+                    urgency="yellow",
+                )
+                await self._handle.ack(envelope.id)
+                return
+            # ... rest of the validator branch unchanged ...
+```
+
+- [ ] **Step 3: Apply the validator-exception wrap and re-run**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/test_endpoint_outbound.py -v
+```
+
+Expected: all tests in the file PASS.
+
+- [ ] **Step 4: Run the full discord adapter test suite to confirm no regressions**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/ -v
+```
+
+Expected: all discord adapter tests PASS (back-compat suite + new tests + existing inbound/resolver/recent-inbounds suites).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-114-discord-send
+git add packages/agent-core-discord/src/agent_core_discord/endpoint.py packages/agent-core-discord/tests/test_endpoint_outbound.py
+git commit -m "feat(#114): validator exception wrap + multi-field / canonical / exception integration tests"
+```
+
+---
+
+### Task 11: Final ruff + mypy + full package test sweep, then open PR
+
+**Files:** No code changes — verification only.
+
+- [ ] **Step 1: Run the full discord adapter test suite**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest packages/agent-core-discord/tests/ -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 2: Run ruff over the package**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run ruff check packages/agent-core-discord/
+```
+
+Expected: no errors. If errors, fix inline (do not commit ruff fixes mixed with feature commits — fix in a separate `style(#114): ruff`).
+
+- [ ] **Step 3: Run mypy over the package**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run mypy packages/agent-core-discord/
+```
+
+Expected: no errors. If type errors, fix in a separate `chore(#114): mypy` commit.
+
+- [ ] **Step 4: Run the full repo test suite for one cross-cutting safety check**
+
+```bash
+cd .worktrees/issue-114-discord-send
+uv run pytest -q
+```
+
+Expected: all tests PASS. The bus envelope schema is unchanged, so cross-cutting damage is structurally unlikely; this is the belt-and-suspenders pass before opening the PR.
+
+- [ ] **Step 5: Push the branch and open the PR**
+
+```bash
+cd .worktrees/issue-114-discord-send
+git push -u origin feat/issue-114-discord-send-unified-envelope
+gh pr create \
+  --base main \
+  --head feat/issue-114-discord-send-unified-envelope \
+  --title "feat(#114): unified discord_send envelope shape + strict-mode validator" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Closes #114. Adds one canonical `tool=discord_send` to the Discord adapter and a strict-mode shape validator that publishes failed-delivery `Acknowledgment` envelopes (urgency=yellow) on unrecognized fields. Closes the silent-drop class on the discord-send surface without touching the bus envelope schema.
+
+## Design
+
+See `docs/superpowers/specs/2026-05-23-issue-114-discord-send-unified-envelope-design.md`.
+
+## What ships
+
+- New `tool=discord_send` with `_DiscordSendArgs(extra="forbid")`.
+- New `shape_validator` pure-function module with recognized-shape catalog.
+- `DiscordEndpoint.deliver()` calls the validator at the top; unrecognized envelopes get a yellow failed-delivery Ack with the canonical equivalent named in the note; recognized-but-legacy envelopes get a structured `deprecated_shape` log line and proceed to deliver.
+- Old shapes (`tool=send`, `tool=send_discord_message`, `TextMessage + metadata.discord.{channel_id, embeds, reply_to}`) continue to deliver. Senders are NOT broken.
+
+## Test plan
+
+- [ ] `uv run pytest packages/agent-core-discord/tests/ -v` passes locally.
+- [ ] Load-bearing test `test_unrecognized_field_produces_failed_delivery_ack` passes — proves the silent-drop class is closed.
+- [ ] Back-compat regression suite passes for all four documented legacy shapes, with deprecation-log assertions.
+- [ ] `uv run pytest -q` (full repo) passes.
+- [ ] `uv run ruff check packages/agent-core-discord/` is clean.
+- [ ] `uv run mypy packages/agent-core-discord/` is clean.
+
+## Migration
+
+Pepper will move her own send-paths plus the relevant memory entries to `tool=discord_send` after this lands, so the deprecation-log lines start dropping and the deprecation-readiness telemetry has data for the eventual removal ticket.
+
+## Next-ticket triggers (deferred)
+
+- Removal of deprecated shapes (gated on deprecation-readiness telemetry).
+- Generalization to other surfaces (Slack, email) — rule-of-three.
+- `allowed_mentions` / `components` wiring through `_send` — earned by named symptom.
+EOF
+)"
+```
+
+Expected: PR URL printed. Report the URL back to the controller.
+
+- [ ] **Step 6: Final commit (only if any post-test fixups landed)**
+
+If Steps 2 or 3 required a separate `style(#114): ruff` or `chore(#114): mypy` commit, push the updated branch:
+
+```bash
+cd .worktrees/issue-114-discord-send
+git push origin feat/issue-114-discord-send-unified-envelope
+```
+
+Otherwise no commit needed — the PR has the full feature.

--- a/docs/superpowers/specs/2026-05-23-issue-114-discord-send-unified-envelope-design.md
+++ b/docs/superpowers/specs/2026-05-23-issue-114-discord-send-unified-envelope-design.md
@@ -1,0 +1,308 @@
+# Issue #114 — Unified `discord_send` envelope shape (Design)
+
+> **Status:** Drafted 2026-05-23. Pending spec-review approval.
+>
+> **Issue:** [#114](https://github.com/jeffrichley/agent_core/issues/114) — `discord: unified discord_send envelope shape`.
+>
+> **Scope:** Add a canonical `tool=discord_send` to the Discord adapter. Close the silent-drop class on unrecognized fields via an adapter-side strict-mode validator that publishes a failed-delivery `Acknowledgment` to the sender with the canonical equivalent named. No bus envelope schema change; existing shapes continue to deliver via back-compat with a deprecation-warning log. Deprecation removal is a follow-up ticket gated on telemetry.
+
+## Problem
+
+Discord-bound envelopes can take two structurally different shapes depending on payload:
+
+- **Plain text:** `TextMessage` + `metadata.discord.channel_id`.
+- **Embeds / files:** `ToolInvocation` + `tool=send_discord_message` + `args.{channel_id, text, embeds | files}`.
+
+Senders have to remember which shape to use for which payload. The mistake mode is silent: an embed payload sent via `TextMessage` + `metadata.discord.embeds` was historically accepted (the bus returned `status: published`), never delivered to Discord, never produced a failed-delivery `Acknowledgment` to the sender. The publish-side success signal was honest; the routing-side drop was silent.
+
+The specific poster-child case (`TextMessage` + `metadata.discord.embeds`) is now routed by `_deliver_text_message` per commit [`a278c68`](https://github.com/jeffrichley/agent_core/commit/a278c68) ("feat(briefs): DiscordEmbedDestination + bus-mediated embed delivery (T11)"). That commit added the routing as a side-effect of an unrelated briefs feature, not as a deliberate fix to the silent-drop class. The pattern that produced the original bug — the adapter using `.get()` on metadata namespaces without enforcing a recognized-shape contract — still lives everywhere else in `endpoint.py`. New fields added in future tickets (e.g., `components`, `modals`, the typed-Task work in #117) will produce the same class of silent-drop unless we converge on one canonical shape and tighten the adapter's strict-mode posture.
+
+### Concrete failure mode (2026-05-23, Pepper)
+
+Pepper sent an embed payload via `TextMessage` + `metadata.discord.embeds`. The bus returned `status: published`; no Discord message was created; no failed-delivery `Acknowledgment` came back. Pepper diagnosed the wrong-shape choice only because she'd made the same mistake before. The fact that her current code path now happens to deliver (per `a278c68`) does not eliminate the class — it just shifted the next victim to whatever field the adapter next reads via `.get()` without recognition.
+
+### Goal of this ticket
+
+Close the silent-drop *class* for the discord-send surface. Two-part fix:
+
+1. **One canonical shape that always works** — `tool=discord_send` with unified args. Senders no longer choose between two shapes.
+2. **Adapter-side strict-mode** — any envelope carrying a field the adapter does not have routing for produces a failed-delivery `Acknowledgment` to the sender (yellow urgency) with the canonical equivalent named in the note. No more silent drops.
+
+## Out of scope
+
+- **Adding a new envelope kind to the closed union.** Considered (Option A in brainstorming); rejected in favor of a new `ToolInvocation` tool name (Option B). Reasoning: A required a real schema migration (every `kind`-switching consumer in the codebase + tests + rendering layer), and A's only earned benefit — publish-time rejection of ambiguous old shapes — is achievable at the adapter layer via the strict-mode validator at zero schema cost.
+- **Removal of the deprecated shapes.** Old shapes continue to deliver after this ticket lands. Removal is a follow-up ticket gated on deprecation-readiness telemetry (see "Next-ticket triggers" below).
+- **Closing `.get()` silent-drop patterns elsewhere in this adapter or in other adapters.** Class-shape applies; per-instance fixes await their own named symptoms (rule-of-three for any cross-cutting extraction).
+- **Generalizing to other surfaces** (`slack_send`, `email_send`, `notion_send`). No current symptom, no current adapter. When the second similar adapter ships, extract a shared shape-validator utility per rule-of-three.
+- **Args expansion beyond Discord-supported send fields.** Interaction handlers, modal responses, voice-channel commands, etc. are separate capabilities and earn their own tools / arg models.
+- **Bus-side schema validation.** The bus continues to validate only the envelope structure (closed `kind` union, payload-discriminator match). Per-adapter shape contracts live in the adapter, not in the bus.
+
+## Design
+
+### Architecture
+
+Three moves, all inside the existing schema (no new envelope kind):
+
+**1. New canonical tool.** Add `discord_send` to the Discord adapter's tool table. Args are one unified shape: `{channel_id (required), text?, embeds?, files?, reply_to?, allowed_mentions?, components?, cleanup_inbound_message_id?}` (the same eight fields enumerated in Components §2). The adapter routes by what is present — text-only is one path, `+embeds` another, `+files` another, `+reply_to` wraps as a reply. One sender shape that always works.
+
+**2. Strict-mode validator at adapter entry.** Every envelope handed to `DiscordEndpoint.deliver()` is matched against a routing-exists check before dispatch. The check answers one question: *does the adapter have routing code that consumes every field present on this envelope?* If yes → deliver (with a deprecation-warning log if the shape is not the canonical `discord_send`). If no → publish a failed-delivery `Acknowledgment` to the sender immediately, with a note naming the unrecognized field(s) and the canonical equivalent. The validator is what closes the silent-drop *class*, not just the poster-child case.
+
+**3. Old shapes as back-compat aliases.** The existing tool names (`send`, `send_discord_message`) and the existing `TextMessage` + `metadata.discord.*` routes continue to deliver. Each routed call emits one structured deprecation-warning log line. No bus-side schema changes; no in-flight sender breaks on day one.
+
+### Components
+
+#### 1. `packages/core/src/agent_core/bus/envelope.py` — no changes
+
+Closed-union envelope schema stays. Explicit non-change anchors the no-schema-migration promise. No consumer that switches on `kind` needs to learn a new value. No discriminated-union update; no validator wiring; no tests touched at the bus layer.
+
+#### 2. New `_DiscordSendArgs` Pydantic model in `packages/agent-core-discord/args.py`
+
+```python
+from typing import Any
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _DiscordSendArgs(BaseModel):
+    """Canonical discord_send args. Unified field set; strict on extras.
+
+    Pydantic extra='forbid' is the second strict layer behind the
+    envelope-level shape_validator: a typo on the args side raises
+    ValidationError at dispatch and surfaces as a yellow Acknowledgment
+    via the existing _ToolError → _reply path, rather than being
+    silently dropped.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str = Field(min_length=1)
+    text: str | None = None
+    embeds: list[dict[str, Any]] | None = None
+    files: list[str] | None = None
+    reply_to: str | None = None
+    allowed_mentions: dict[str, Any] | None = None
+    components: list[dict[str, Any]] | None = None
+    cleanup_inbound_message_id: str | None = None
+```
+
+Field rationale: `channel_id` is the one required field — every discord-send needs a destination. `text`, `embeds`, `files` are the three payload kinds (at least one required at dispatch time, see Error Handling §5). `reply_to` triggers Discord's native reply UI. `cleanup_inbound_message_id` is the existing typing-cleanup field from `_SendArgs` (`#84`), preserved for parity.
+
+**`allowed_mentions` and `components` are future-proof slots, not wired in v1.** They are Discord-supported send-time options that the adapter does not currently expose; the args model accepts them (so the strict-mode contract does not reject a forward-looking caller), but the v1 implementation does not pass them through to `discord.py` and the `_send` body does not consume them. A future ticket that earns the symptom adds one line in `_send` per field, with no args-model migration. Until then, callers passing them get a successful send with the option silently unapplied. (Acceptable because `extra="forbid"` is rejecting the *unknown* — these are *known but unwired*; the next ticket closes the wiring gap when there is named demand.)
+
+#### 3. NEW `packages/agent-core-discord/shape_validator.py` module
+
+Pure-function home for the recognized-shape catalog. Same architectural shape as the AI Cliché Detector's `ignore.js` / `clicktofix.js`: zero side effects, no I/O, no `chrome.*` / `discord.*` imports — fully unit-testable in isolation.
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Recognized:
+    """Validator outcome: the envelope matches a known shape."""
+    shape_name: str
+    deprecation_log_line: str | None  # None for canonical, str for legacy
+
+
+@dataclass(frozen=True)
+class Unrecognized:
+    """Validator outcome: the envelope carries fields the adapter does
+    not route. The Ack note names the first unrecognized prefix and the
+    canonical equivalent so the sender has a teaching moment instead of
+    a silent drop."""
+    fields: list[str]            # first unrecognized prefix per branch
+    canonical_equivalent: str    # "tool=discord_send with <X> in args"
+
+
+ShapeValidation = Recognized | Unrecognized
+
+
+def validate(envelope) -> ShapeValidation: ...
+```
+
+The catalog enumerates ~7–8 recognized shapes:
+- `ToolInvocation + tool=discord_send + canonical args` → `Recognized("canonical", None)`.
+- `ToolInvocation + tool=send + canonical args` → `Recognized("legacy_tool_send", deprecation_line)`.
+- `ToolInvocation + tool=send_discord_message + canonical args` → `Recognized("legacy_tool_send_discord_message", deprecation_line)`.
+- `TextMessage + metadata.discord.channel_id` (plain text) → `Recognized("legacy_textmessage_plain", deprecation_line)`.
+- `TextMessage + metadata.discord.embeds` → `Recognized("legacy_textmessage_embeds", deprecation_line)` (poster-child, routed since `a278c68`).
+- `TextMessage + metadata.discord.reply_to` → `Recognized("legacy_textmessage_reply", deprecation_line)`.
+- `TextMessage + payload.attachments` (file list) → `Recognized("legacy_textmessage_files", deprecation_line)`.
+
+Nested-path handling: the catalog operates at the field-path level; an unknown step short-circuits the walk and the Ack names the step where the catalog ran out of routes. `metadata.discord.foo.bar.baz` with `foo` unknown produces `Unrecognized(fields=['metadata.discord.foo'], ...)` — not an enumeration of leaves.
+
+Multi-field handling: when multiple unrecognized fields exist at the same level, all are enumerated in one `Unrecognized.fields` list so the sender sees the full failure surface in one Ack, not in N redeliveries.
+
+#### 4. `packages/agent-core-discord/src/agent_core_discord/endpoint.py` — three additions
+
+**4a. `_TOOL_ALIASES` table** (around line 67): add `discord_send` as a passthrough; keep `send_discord_message → send` for back-compat.
+
+```python
+_TOOL_ALIASES: dict[str, str] = {
+    "send_discord_message": "send",   # existing legacy alias
+    "discord_send": "discord_send",   # NEW: canonical passthrough
+    "edit_message": "edit",
+    "add_reaction": "react",
+    "fetch_messages": "fetch",
+}
+```
+
+**4b. `_dispatch`** (around line 778): add the `discord_send` case routing to the existing internal send handler. `send` continues to route there too.
+
+```python
+if tool == "discord_send":
+    return await self._send(_v(_DiscordSendArgs, _inject_channel_id(args)))
+if tool == "send":
+    return await self._send(_v(_SendArgs, _inject_channel_id(args)))
+```
+
+(`_DiscordSendArgs` is the new strict model; `_SendArgs` stays for back-compat through the legacy `send` route. Internal handler name `_send` stays; rename to `_canonical_send` is optional cleanup and not load-bearing.)
+
+**4c. `deliver()`** (around line 655): call `shape_validator.validate(envelope)` at the top, before the kind-branch.
+
+```python
+async def deliver(self, envelope: Envelope) -> None:
+    if self._handle is None:
+        raise EndpointUnavailable(f"discord '{self.name}' not started")
+
+    # Existing kind-gate: only TextMessage and ToolInvocation pass through
+    # to the validator. Other kinds fall through to the existing
+    # "unsupported kind" branch below.
+    if envelope.kind in ("TextMessage", "ToolInvocation"):
+        validation = shape_validator.validate(envelope)
+        if isinstance(validation, Unrecognized):
+            log.warning(
+                "discord(%s): unrecognized_shape event",
+                self.name,
+                extra={
+                    "event": "unrecognized_shape",
+                    "envelope_kind": envelope.kind,
+                    "unrecognized_fields": validation.fields,
+                    "sender": envelope.from_,
+                    "envelope_id": envelope.id,
+                    "canonical_equivalent": validation.canonical_equivalent,
+                },
+            )
+            note = (
+                f"Unrecognized field{'s' if len(validation.fields) > 1 else ''} "
+                f"{validation.fields if len(validation.fields) > 1 else repr(validation.fields[0])} "
+                f"on {envelope.kind}. Canonical: {validation.canonical_equivalent}"
+            )
+            await self._reply(envelope, note, urgency="yellow")
+            await self._handle.ack(envelope.id)
+            return
+        if validation.deprecation_log_line:
+            log.warning(
+                "discord(%s): deprecated_shape event",
+                self.name,
+                extra={
+                    "event": "deprecated_shape",
+                    "shape_name": validation.shape_name,
+                    "sender": envelope.from_,
+                    "envelope_id": envelope.id,
+                    "canonical_equivalent": "tool=discord_send",
+                },
+            )
+
+    # ... existing dispatch path (unchanged) ...
+```
+
+#### 5. Failed-delivery `Acknowledgment` note shape
+
+Uses the existing `_reply(incoming, note, urgency="yellow")` machinery (`endpoint.py` line 836). No new exception type, no new envelope kind — the failed-delivery Ack is structurally identical to today's tool-error Acks; only the `note` text shape is new.
+
+Note text:
+- **Single unrecognized field:** `"Unrecognized field 'metadata.discord.mystery_field' on TextMessage. Canonical: tool=discord_send with mystery_field in args."`
+- **Multiple unrecognized fields:** `"Unrecognized fields ['metadata.discord.mystery_field', 'metadata.discord.other_unknown'] on TextMessage. Canonical: tool=discord_send with the corresponding args."`
+
+Correlation: `_reply` already sets `in_reply_to=incoming.id` (line 847), so the sender's `Acknowledgment` listener correlates with the original envelope without any changes.
+
+### Data Flow
+
+Flow per envelope arriving at `DiscordEndpoint.deliver()`:
+
+**1. Kind gate (existing).** If `envelope.kind` is not `TextMessage` or `ToolInvocation`, fall through to the existing else-branch (warning Ack, inbound acked). Validator not consulted.
+
+**2. Validator runs.** `shape_validator.validate(envelope)` produces one of:
+
+  a. **`Recognized` + canonical** (`ToolInvocation` + `tool=discord_send`): no log. Proceed to dispatch.
+
+  b. **`Recognized` + deprecated** (every other recognized shape — `tool=send_discord_message`, `TextMessage` + `metadata.discord.{channel_id, embeds, files, reply_to}`): emit a structured deprecation log line (`event="deprecated_shape"`, `shape_name`, `sender`, `envelope_id`, `canonical_equivalent`). Proceed to dispatch.
+
+  c. **`Unrecognized`**:
+   - Emit a structured failure log line (`event="unrecognized_shape"`, `envelope_kind`, `unrecognized_fields`, `sender`, `envelope_id`, `canonical_equivalent`). The failure path is more telemetry-valuable than the warning path; both deserve coverage.
+   - Publish a failed-delivery `Acknowledgment` via existing `_reply(incoming, note, urgency="yellow")` with the canonical-equivalent text in the note.
+   - Ack the inbound (`self._handle.ack(envelope.id)`) so it does not redeliver.
+   - Return without dispatching.
+
+**3. Dispatch** (recognized cases only): existing routing path. `_deliver_text_message` for `TextMessage`; `_dispatch(tool, args, envelope)` for `ToolInvocation`. Both paths converge on `_send` for the canonical message-out.
+
+**4. Result `Acknowledgment`s unchanged.** Successful sends (canonical or back-compat) produce the existing green-on-success / yellow-on-partial Ack pattern. The ONLY new Ack type is the validator-emitted yellow failed-delivery Ack from path 2c. Senders see no new Ack noise for normal sends; the deprecation signal lives in logs, not in result Acks.
+
+Two design calls baked into the flow:
+
+- **Structured log schema, not free-form prose.** Field names fixed: `event`, `shape_name`, `envelope_kind`, `sender`, `envelope_id`, `unrecognized_fields`, `canonical_equivalent`. Aggregation by `event + shape_name` answers "is anyone still using old shapes" for the eventual deprecation-removal ticket. Without a schema, telemetry can't make that call.
+- **Unrecognized-path ordering.** Publish failed-delivery Ack first, then ack the inbound. Existing `_reply` (line 856 of `endpoint.py`) catches and logs its own publish failures, so the inbound-ack is reachable either way; the ordering is for log-trace clarity (the outbound Ack is the meaningful event; the inbound-ack is bookkeeping).
+
+### Error Handling
+
+Five error surfaces, defended in layers using existing machinery:
+
+**1. Validator-internal exception.** If `shape_validator.validate()` itself raises (catalog bug, malformed envelope from a test fixture), `deliver()` catches via the existing exception handler and produces a yellow Ack: `"validator failed: <repr(exc)>"`. Inbound acked, no redelivery. Same pattern as today's `except Exception` around dispatch (`endpoint.py` lines 671–673).
+
+**2. Pydantic `_DiscordSendArgs` `ValidationError`** (canonical-path-only — missing `channel_id`, typo, type mismatch). Caught at the existing `_v(model, raw)` helper (`endpoint.py` lines 781–785) which already translates `ValidationError → _ToolError → yellow Ack`. No new code; `extra="forbid"` makes the failure surface earlier and cleaner.
+
+**3. Multi-field unrecognized envelope.** ONE failed-delivery Ack listing all unrecognized fields, not N Acks. Reasoning: senders should see the full failure surface in one delivery, not chase N redeliveries. Note text uses plural form: `"Unrecognized fields [...] on <Kind>. Canonical: tool=discord_send with the corresponding args."`
+
+**4. Failed-delivery Ack publish failure** (network blip, bus down). Existing `_reply` already catches and logs (`"discord reply publish failed for %s"`, line 856–857). Inbound is acked regardless, so no redelivery storm. *Footnoted trade:* in the deeply-broken-bus scenario where both the original dispatch and the failed-delivery Ack fail to publish, the sender does not see the failure. Defensible trade — "no redelivery storm" chosen over "guaranteed failure visibility" for the rare double-failure case. Noted here explicitly so it is not forgotten.
+
+**5. Empty-send guard** (`tool=discord_send` with no `text`, no `embeds`, no `files`). Existing `_send()` already raises `_ToolError("send: one of 'text' or 'embeds' is required")` (line 1387–1388). Spec extends the message to include `files`: `"send: one of 'text', 'embeds', or 'files' is required"`. Yellow Ack via the existing path. Single-line code change.
+
+Two error-handling decisions baked in:
+
+- **No new exception types.** `_ToolError` covers the user-error class; the failed-delivery Ack uses `_reply` directly without going through `_ToolError`. Failed-delivery is a shape error caught BEFORE dispatch, not a tool error.
+- **No retries.** A bad shape stays bad on redelivery. Inbound is acked once the failed-delivery Ack is published; the sender owns the fix.
+
+### Testing
+
+**Load-bearing regression test** — the single test that proves we kept the silent-drop-class promise to Jeff:
+
+`test_unrecognized_field_produces_failed_delivery_ack` in `packages/agent-core-discord/tests/test_endpoint_outbound.py`. End-to-end behavior test. Construct a `TextMessage` envelope with `metadata.discord.mystery_field`, hand it to `DiscordEndpoint.deliver()`, assert:
+- (a) no Discord API call was made;
+- (b) a yellow `Acknowledgment` envelope was published with `in_reply_to=<original_envelope_id>` and a note containing `"Unrecognized field 'metadata.discord.mystery_field'"`;
+- (c) the inbound was acked;
+- (d) `_send` was never reached.
+
+**Validator unit tests** (NEW `packages/agent-core-discord/tests/test_shape_validator.py`):
+- Per recognized shape (one row per catalog entry, ~7–8): validator returns `Recognized(shape_name, deprecation_log_line_or_None)`.
+- Per unrecognized shape: `Unrecognized(fields, canonical_equivalent)` with the right text.
+- Nested-path: `metadata.discord.foo.bar.baz` returns `Unrecognized(fields=['metadata.discord.foo'], ...)` — first unknown step.
+- Multi-field at same level: enumerates all unrecognized fields in one return value.
+
+**Args unit tests** (NEW `packages/agent-core-discord/tests/test_discord_send_args.py`):
+- `extra="forbid"` rejects `_DiscordSendArgs(channel_id="X", mystery_field="Y")` with `ValidationError`.
+- Required `channel_id` rejection.
+- Each optional field independently accepted.
+
+**Endpoint integration tests** (extending `test_endpoint_outbound.py`):
+- Canonical path: `tool=discord_send` + canonical args delivers, no log, green Ack.
+- Deprecated paths (one row per recognized old shape): delivers, structured deprecation log line emitted with all named fields (`event`, `shape_name`, `sender`, `envelope_id`, `canonical_equivalent`) — not just `event + shape_name`. The full-schema assertion is the contract test for the structured-log schema.
+- Multi-field unrecognized: ONE failed-delivery Ack listing both fields.
+- Empty-send guard: `discord_send` with no text/embeds/files → yellow Ack with the extended `"one of 'text', 'embeds', or 'files' is required"` message.
+- Validator-internal-exception: catalog bug → yellow Ack with `"validator failed: ..."`.
+
+**Back-compat regression tests** (each also asserts the deprecation log fires):
+- `TextMessage + metadata.discord.channel_id` (plain text).
+- `ToolInvocation + tool=send_discord_message + args.{channel_id, text, embeds}`.
+- `ToolInvocation + tool=send_discord_message + args.{channel_id, text, files}`.
+- `TextMessage + metadata.discord.embeds` (the poster-child, now also asserted via test).
+
+The aggregation key (`event="deprecated_shape"` + `shape_name`) is what the deprecation-removal ticket later watches.
+
+**Test count expectation:** ~15–20 new tests.
+
+## Next-ticket triggers (deferred)
+
+- **Deprecation removal of old shapes.** Triggered when the deprecation-readiness telemetry (aggregating on `event="deprecated_shape"` + `shape_name`) shows no usage of a given legacy shape for N days. Per-shape removal allowed; not all-or-nothing.
+- **Generalization to other surfaces.** Triggered when a second adapter (Slack, email, Notion) earns a similar class of silent-drop bug. At N=2 of the pattern extract a shared `shape_validator` utility (rule of three).
+- **Cross-adapter `.get()` audit.** Triggered if a second silent-drop bug is discovered elsewhere in this adapter or another. The pattern is bounded enough today; broaden when class-shape is named twice.
+- **Args-model expansion** for newer Discord send-time features (interactions, modals, voice). Triggered by named symptom in agent code, not pre-emptively. The `_DiscordSendArgs` model with `extra="forbid"` makes each addition a one-line localized change.

--- a/packages/agent-core-discord/src/agent_core_discord/args.py
+++ b/packages/agent-core-discord/src/agent_core_discord/args.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class _SendArgs(BaseModel):
@@ -118,3 +118,37 @@ class _CreateThreadArgs(BaseModel):
 class _SendTypingArgs(BaseModel):
     channel_id: str = Field(min_length=1)
     duration_seconds: float = Field(default=5.0, ge=0.5, le=10.0)
+
+
+class _DiscordSendArgs(BaseModel):
+    """Canonical args for tool=discord_send (#114).
+
+    Pydantic extra='forbid' is the second strict layer behind the
+    envelope-level shape_validator. The validator catches unrecognized
+    fields BEFORE dispatch (yellow Ack via _reply); ValidationError
+    here catches them at dispatch (yellow Ack via _ToolError). Both
+    paths surface to the sender — no silent drop.
+
+    The canonical field set must stay in lockstep with
+    shape_validator._KNOWN_CANONICAL_SEND_ARGS. The
+    test_canonical_keys_in_sync_with_validator_catalog test asserts
+    the invariant.
+
+    allowed_mentions and components are future-proof slots: the args
+    model accepts them, but the adapter's _send() does not yet pass
+    them through to discord.py. A caller that sets them today gets a
+    successful send with the option silently unapplied. A future
+    ticket adds the wiring in _send when there is named demand; no
+    args-model migration needed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str = Field(min_length=1)
+    text: str | None = None
+    embeds: list[dict[str, Any]] | None = None
+    files: list[str] | None = None
+    reply_to: str | None = None
+    allowed_mentions: dict[str, Any] | None = None
+    components: list[dict[str, Any]] | None = None
+    cleanup_inbound_message_id: str | None = None

--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -59,6 +59,8 @@ from agent_core_discord.send_retry import channel_send_with_retries
 from agent_core_discord.shape_validator import (
     Recognized,
     Unrecognized,
+)
+from agent_core_discord.shape_validator import (
     validate as validate_shape,
 )
 from agent_core_discord.sigil import parse_sigil

--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -41,6 +41,7 @@ from agent_core_discord.args import (
     _CreatePollArgs,
     _CreateScheduledEventArgs,
     _CreateThreadArgs,
+    _DiscordSendArgs,
     _DownloadAttachmentsArgs,
     _EditArgs,
     _FetchArgs,
@@ -65,6 +66,7 @@ log = logging.getLogger(__name__)
 # Pepper-facing tool names from cutover #03 map to the internal dispatcher keys.
 _TOOL_ALIASES: dict[str, str] = {
     "send_discord_message": "send",
+    "discord_send": "discord_send",  # #114: canonical passthrough
     "edit_message": "edit",
     "add_reaction": "react",
     "fetch_messages": "fetch",
@@ -803,6 +805,10 @@ class DiscordEndpoint:
                         raw["cleanup_inbound_message_id"] = cid
             return raw
 
+        if tool == "discord_send":
+            return await self._send(
+                _v(_DiscordSendArgs, _inject_channel_id(args))
+            )
         if tool == "send":
             return await self._send(_v(_SendArgs, _inject_channel_id(args)))
         if tool == "edit":

--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -1390,8 +1390,10 @@ class DiscordEndpoint:
             await msg.remove_reaction(emoji, self._client.user)
 
     async def _send(self, args: _SendArgs) -> dict:
-        if args.text is None and not args.embeds:
-            raise _ToolError("send: one of 'text' or 'embeds' is required")
+        if args.text is None and not args.embeds and not args.files:
+            raise _ToolError(
+                "send: one of 'text', 'embeds', or 'files' is required"
+            )
         ch = await self._resolve_channel(args.channel_id)
 
         # Build embeds list (validate via discord.Embed.from_dict).

--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -56,6 +56,11 @@ from agent_core_discord.args import (
 from agent_core_discord.briefing import build_briefing_embeds
 from agent_core_discord.chunking import smart_chunk_discord
 from agent_core_discord.send_retry import channel_send_with_retries
+from agent_core_discord.shape_validator import (
+    Recognized,
+    Unrecognized,
+    validate as validate_shape,
+)
 from agent_core_discord.sigil import parse_sigil
 
 if TYPE_CHECKING:
@@ -658,6 +663,63 @@ class DiscordEndpoint:
         """Handle ToolInvocation and TextMessage envelopes."""
         if self._handle is None:
             raise EndpointUnavailable(f"discord '{self.name}' not started")
+
+        # #114: strict-mode validator. Only consulted for kinds the adapter
+        # dispatches (TextMessage / ToolInvocation); other kinds fall through
+        # to the existing else-branch unchanged.
+        if envelope.kind in ("TextMessage", "ToolInvocation"):
+            try:
+                validation = validate_shape(envelope)
+            except Exception as exc:
+                log.exception("discord(%s): validator raised", self.name)
+                await self._reply(
+                    envelope,
+                    f"validator failed: {exc!r}",
+                    urgency="yellow",
+                )
+                await self._handle.ack(envelope.id)
+                return
+            if isinstance(validation, Unrecognized):
+                log.warning(
+                    "discord(%s): unrecognized_shape event",
+                    self.name,
+                    extra={
+                        "event": "unrecognized_shape",
+                        "envelope_kind": envelope.kind,
+                        "unrecognized_fields": validation.fields,
+                        "sender": envelope.from_,
+                        "envelope_id": envelope.id,
+                        "canonical_equivalent": validation.canonical_equivalent,
+                    },
+                )
+                field_list = validation.fields
+                if len(field_list) == 1:
+                    note = (
+                        f"Unrecognized field {field_list[0]!r} on "
+                        f"{envelope.kind}. Canonical: "
+                        f"{validation.canonical_equivalent}"
+                    )
+                else:
+                    note = (
+                        f"Unrecognized fields {field_list} on "
+                        f"{envelope.kind}. Canonical: "
+                        f"{validation.canonical_equivalent}"
+                    )
+                await self._reply(envelope, note, urgency="yellow")
+                await self._handle.ack(envelope.id)
+                return
+            if isinstance(validation, Recognized) and validation.deprecation_log_line:
+                log.warning(
+                    "discord(%s): deprecated_shape event",
+                    self.name,
+                    extra={
+                        "event": "deprecated_shape",
+                        "shape_name": validation.shape_name,
+                        "sender": envelope.from_,
+                        "envelope_id": envelope.id,
+                        "canonical_equivalent": "tool=discord_send",
+                    },
+                )
 
         if envelope.kind == "TextMessage":
             try:

--- a/packages/agent-core-discord/src/agent_core_discord/shape_validator.py
+++ b/packages/agent-core-discord/src/agent_core_discord/shape_validator.py
@@ -1,0 +1,66 @@
+"""shape_validator — pure-function recognized-shape catalog for the Discord
+adapter's strict-mode envelope validation.
+
+Closes the silent-drop class on the discord-send surface (#114). The
+adapter calls validate(envelope) at the top of deliver(): on
+Unrecognized, a yellow failed-delivery Acknowledgment is published to
+the sender with the canonical equivalent named; on Recognized + a
+deprecation_log_line, a structured log fires and dispatch proceeds; on
+Recognized + None (the canonical shape), dispatch proceeds silently.
+
+PURE module: no I/O, no Discord client, no global state. Unit-testable
+in isolation. See docs/superpowers/specs/2026-05-23-issue-114-discord-
+send-unified-envelope-design.md for the full design.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agent_core.bus.envelope import Envelope
+
+
+@dataclass(frozen=True)
+class Recognized:
+    """Validator outcome: the envelope matches a known shape.
+
+    shape_name: stable identifier for the matched shape, used as the
+        aggregation key in deprecation-readiness telemetry.
+    deprecation_log_line: human-readable message for the structured
+        deprecation log when the shape is legacy. None for the canonical
+        shape (no log emitted for the happy path).
+    """
+
+    shape_name: str
+    deprecation_log_line: str | None
+
+
+@dataclass(frozen=True)
+class Unrecognized:
+    """Validator outcome: the envelope carries fields the adapter does
+    not route.
+
+    fields: the unrecognized field path(s). For nested-path inputs
+        ('metadata.discord.foo.bar.baz' with 'foo' unknown), this is
+        the first unknown prefix ('metadata.discord.foo'), not the
+        leaves.
+    canonical_equivalent: human-readable hint for the sender's failed-
+        delivery Acknowledgment note, naming the canonical way to send
+        the same intent.
+    """
+
+    fields: list[str]
+    canonical_equivalent: str
+
+
+ShapeValidation = Recognized | Unrecognized
+
+
+def validate(envelope: Envelope) -> ShapeValidation:
+    """Validate that the Discord adapter has routing for every field on
+    envelope. Returns Recognized(shape_name, deprecation_log_line_or_None)
+    or Unrecognized(fields, canonical_equivalent).
+
+    Stub: real implementation lands in Tasks 2-4.
+    """
+    raise NotImplementedError("validate() stub — implementation in Tasks 2-4")

--- a/packages/agent-core-discord/src/agent_core_discord/shape_validator.py
+++ b/packages/agent-core-discord/src/agent_core_discord/shape_validator.py
@@ -55,12 +55,93 @@ class Unrecognized:
 
 ShapeValidation = Recognized | Unrecognized
 
+# Recognized arg names for the new canonical _DiscordSendArgs model.
+# Keep in lockstep with packages/agent-core-discord/src/agent_core_discord/
+# args.py:_DiscordSendArgs field set. The test_canonical_keys_in_sync test
+# (Task 5) asserts the lockstep.
+_KNOWN_CANONICAL_SEND_ARGS: frozenset[str] = frozenset({
+    "channel_id",
+    "text",
+    "embeds",
+    "files",
+    "reply_to",
+    "allowed_mentions",
+    "components",
+    "cleanup_inbound_message_id",
+})
+
+# Recognized arg names for the existing _SendArgs (legacy `tool=send` /
+# `tool=send_discord_message` routes). Must stay in lockstep with
+# args.py:_SendArgs. allowed_mentions and components are NOT in this
+# set — those are canonical-only future-proof slots, not exposed on the
+# legacy routes.
+_KNOWN_LEGACY_SEND_ARGS: frozenset[str] = frozenset({
+    "channel_id",
+    "text",
+    "embeds",
+    "reply_to",
+    "files",
+    "cleanup_inbound_message_id",
+})
+
+
+def _validate_tool_invocation(envelope: Envelope) -> ShapeValidation:
+    payload = envelope.payload
+    tool = getattr(payload, "tool", "") or ""
+    args = getattr(payload, "args", {}) or {}
+
+    if tool == "discord_send":
+        unrecognized = _unrecognized_arg_keys(args, _KNOWN_CANONICAL_SEND_ARGS)
+        if unrecognized:
+            return Unrecognized(
+                fields=[f"args.{k}" for k in unrecognized],
+                canonical_equivalent=(
+                    "tool=discord_send accepts "
+                    f"{sorted(_KNOWN_CANONICAL_SEND_ARGS)}"
+                ),
+            )
+        return Recognized("canonical_discord_send", None)
+
+    if tool in ("send", "send_discord_message"):
+        unrecognized = _unrecognized_arg_keys(args, _KNOWN_LEGACY_SEND_ARGS)
+        if unrecognized:
+            return Unrecognized(
+                fields=[f"args.{k}" for k in unrecognized],
+                canonical_equivalent=(
+                    f"tool=discord_send with {', '.join(unrecognized)} in args"
+                ),
+            )
+        return Recognized(
+            f"legacy_tool_{tool}",
+            f"deprecated_shape: tool={tool} — use tool=discord_send",
+        )
+
+    # All other tools (edit, react, fetch, list_channels, create_poll, etc.)
+    # are outside the strict-mode scope. deliver() does not block on them.
+    return Recognized("non_send_tool", None)
+
+
+def _unrecognized_arg_keys(args: object, known: frozenset[str]) -> list[str]:
+    if not isinstance(args, dict):
+        return []
+    return sorted(set(args.keys()) - known)
+
 
 def validate(envelope: Envelope) -> ShapeValidation:
     """Validate that the Discord adapter has routing for every field on
     envelope. Returns Recognized(shape_name, deprecation_log_line_or_None)
     or Unrecognized(fields, canonical_equivalent).
 
-    Stub: real implementation lands in Tasks 2-4.
+    ToolInvocation shapes covered in Task 2; TextMessage handling in Task 3.
     """
-    raise NotImplementedError("validate() stub — implementation in Tasks 2-4")
+    if envelope.kind == "ToolInvocation":
+        return _validate_tool_invocation(envelope)
+    if envelope.kind == "TextMessage":
+        # TextMessage handling lands in Task 3.
+        raise NotImplementedError("TextMessage validation — Task 3")
+    # Kinds outside ToolInvocation / TextMessage (Event, Cancellation,
+    # Progress, Acknowledgment) are not in the strict-mode scope; the
+    # adapter's existing else-branch handles them with an unsupported-kind
+    # warning Ack. The validator returns Recognized so deliver() does not
+    # double-handle them.
+    return Recognized("non_send_kind", None)

--- a/packages/agent-core-discord/src/agent_core_discord/shape_validator.py
+++ b/packages/agent-core-discord/src/agent_core_discord/shape_validator.py
@@ -160,8 +160,21 @@ def _validate_text_message(envelope: Envelope) -> ShapeValidation:
             ),
         )
 
-    # Unrecognized-key detection lands in Task 4. For now, recognize
-    # legacy shapes by the most-discriminating field present.
+    # Unrecognized-key detection. Senders that set metadata.discord.*
+    # fields the adapter does not route get a failed-delivery Ack — this
+    # is the load-bearing closure of the silent-drop class.
+    unrecognized_keys = sorted(
+        set(discord_meta.keys()) - _KNOWN_DISCORD_META_OUTBOUND_KEYS
+    )
+    if unrecognized_keys:
+        return Unrecognized(
+            fields=[f"metadata.discord.{k}" for k in unrecognized_keys],
+            canonical_equivalent=(
+                f"tool=discord_send with {', '.join(unrecognized_keys)} in args"
+            ),
+        )
+
+    # Recognized legacy shape — name by most-discriminating field.
     if "embeds" in discord_meta:
         return Recognized(
             "legacy_textmessage_embeds",

--- a/packages/agent-core-discord/src/agent_core_discord/shape_validator.py
+++ b/packages/agent-core-discord/src/agent_core_discord/shape_validator.py
@@ -127,21 +127,76 @@ def _unrecognized_arg_keys(args: object, known: frozenset[str]) -> list[str]:
     return sorted(set(args.keys()) - known)
 
 
+# Recognized keys under metadata.discord on OUTBOUND TextMessage
+# envelopes. INBOUND-only keys (message_id, guild_id, author_id,
+# author_display_name, is_dm) are not in this set — they are set by
+# the adapter when publishing inbound, and a sender that sets them on
+# an outbound is doing something the adapter does not route. Flag as
+# Unrecognized so the silent-drop class is closed (Task 4).
+_KNOWN_DISCORD_META_OUTBOUND_KEYS: frozenset[str] = frozenset({
+    "channel_id",
+    "embeds",
+    "reply_to",
+})
+
+
+def _validate_text_message(envelope: Envelope) -> ShapeValidation:
+    metadata = envelope.metadata or {}
+    discord_meta = metadata.get("discord")
+
+    if discord_meta is None:
+        # TextMessage without metadata.discord is not discord-bound.
+        # Adapter's existing routing handles this via outbound_channel_id
+        # fallback or _ToolError.
+        return Recognized("non_discord_text_message", None)
+
+    if not isinstance(discord_meta, dict):
+        # metadata.discord is present but malformed (string, list, etc.).
+        return Unrecognized(
+            fields=["metadata.discord"],
+            canonical_equivalent=(
+                "tool=discord_send with channel_id in args (metadata.discord "
+                "must be an object)"
+            ),
+        )
+
+    # Unrecognized-key detection lands in Task 4. For now, recognize
+    # legacy shapes by the most-discriminating field present.
+    if "embeds" in discord_meta:
+        return Recognized(
+            "legacy_textmessage_embeds",
+            "deprecated_shape: TextMessage + metadata.discord.embeds — "
+            "use tool=discord_send with embeds in args",
+        )
+    if "reply_to" in discord_meta:
+        return Recognized(
+            "legacy_textmessage_reply",
+            "deprecated_shape: TextMessage + metadata.discord.reply_to — "
+            "use tool=discord_send with reply_to in args",
+        )
+    if "channel_id" in discord_meta:
+        return Recognized(
+            "legacy_textmessage_plain",
+            "deprecated_shape: TextMessage + metadata.discord.channel_id — "
+            "use tool=discord_send with text in args",
+        )
+    # Ambiguous discord_meta block (e.g., empty {} or only message_id).
+    return Recognized(
+        "legacy_textmessage_ambiguous",
+        "deprecated_shape: TextMessage + metadata.discord without channel_id",
+    )
+
+
 def validate(envelope: Envelope) -> ShapeValidation:
     """Validate that the Discord adapter has routing for every field on
     envelope. Returns Recognized(shape_name, deprecation_log_line_or_None)
     or Unrecognized(fields, canonical_equivalent).
 
-    ToolInvocation shapes covered in Task 2; TextMessage handling in Task 3.
+    ToolInvocation and TextMessage shapes covered; unrecognized-field
+    detection (multi-field, nested) tightens in Task 4.
     """
     if envelope.kind == "ToolInvocation":
         return _validate_tool_invocation(envelope)
     if envelope.kind == "TextMessage":
-        # TextMessage handling lands in Task 3.
-        raise NotImplementedError("TextMessage validation — Task 3")
-    # Kinds outside ToolInvocation / TextMessage (Event, Cancellation,
-    # Progress, Acknowledgment) are not in the strict-mode scope; the
-    # adapter's existing else-branch handles them with an unsupported-kind
-    # warning Ack. The validator returns Recognized so deliver() does not
-    # double-handle them.
+        return _validate_text_message(envelope)
     return Recognized("non_send_kind", None)

--- a/packages/agent-core-discord/src/agent_core_discord/shape_validator.py
+++ b/packages/agent-core-discord/src/agent_core_discord/shape_validator.py
@@ -128,14 +128,18 @@ def _unrecognized_arg_keys(args: object, known: frozenset[str]) -> list[str]:
 
 
 # Recognized keys under metadata.discord on OUTBOUND TextMessage
-# envelopes. INBOUND-only keys (message_id, guild_id, author_id,
+# envelopes. Pure INBOUND-only keys (guild_id, author_id,
 # author_display_name, is_dm) are not in this set — they are set by
 # the adapter when publishing inbound, and a sender that sets them on
 # an outbound is doing something the adapter does not route. Flag as
 # Unrecognized so the silent-drop class is closed (Task 4).
+# NOTE: message_id is included here — while the adapter also sets it
+# on inbound envelopes, _deliver_text_message() reads it on OUTBOUND
+# envelopes as a legacy reply-target alias for reply_to.
 _KNOWN_DISCORD_META_OUTBOUND_KEYS: frozenset[str] = frozenset({
     "channel_id",
     "embeds",
+    "message_id",
     "reply_to",
 })
 

--- a/packages/agent-core-discord/tests/test_attachment_retention.py
+++ b/packages/agent-core-discord/tests/test_attachment_retention.py
@@ -7,7 +7,6 @@ import time
 from pathlib import Path
 
 import pytest
-
 from agent_core_discord.endpoint import DiscordEndpoint
 
 

--- a/packages/agent-core-discord/tests/test_discord_send_args.py
+++ b/packages/agent-core-discord/tests/test_discord_send_args.py
@@ -64,3 +64,19 @@ def test_canonical_keys_in_sync_with_validator_catalog():
 
     model_fields = set(_DiscordSendArgs.model_fields.keys())
     assert model_fields == _KNOWN_CANONICAL_SEND_ARGS
+
+
+def test_legacy_keys_in_sync_with_validator_catalog():
+    """The legacy args field set (_SendArgs, used by tool=send and the
+    tool=send_discord_message alias) must stay in lockstep with
+    shape_validator._KNOWN_LEGACY_SEND_ARGS. Drift here would mean the
+    validator produces Unrecognized for envelopes that _dispatch
+    happily routes — a silent split.
+
+    Mirror of test_canonical_keys_in_sync_with_validator_catalog for
+    the legacy surface. Per the final-review feedback on #114."""
+    from agent_core_discord.args import _SendArgs
+    from agent_core_discord.shape_validator import _KNOWN_LEGACY_SEND_ARGS
+
+    model_fields = set(_SendArgs.model_fields.keys())
+    assert model_fields == _KNOWN_LEGACY_SEND_ARGS

--- a/packages/agent-core-discord/tests/test_discord_send_args.py
+++ b/packages/agent-core-discord/tests/test_discord_send_args.py
@@ -8,9 +8,8 @@ existing _ToolError path. No silent drop.
 """
 
 import pytest
-from pydantic import ValidationError
-
 from agent_core_discord.args import _DiscordSendArgs
+from pydantic import ValidationError
 
 
 def test_canonical_minimal_text_send_accepted():

--- a/packages/agent-core-discord/tests/test_discord_send_args.py
+++ b/packages/agent-core-discord/tests/test_discord_send_args.py
@@ -1,0 +1,66 @@
+"""Unit tests for _DiscordSendArgs — the strict canonical args model
+for tool=discord_send (#114).
+
+The model uses extra='forbid' as the second strict layer behind the
+envelope-level shape_validator: a typo on the args side raises
+ValidationError at dispatch, which translates to a yellow Ack via the
+existing _ToolError path. No silent drop.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from agent_core_discord.args import _DiscordSendArgs
+
+
+def test_canonical_minimal_text_send_accepted():
+    """channel_id + text is the smallest valid canonical args."""
+    args = _DiscordSendArgs(channel_id="123", text="hi")
+    assert args.channel_id == "123"
+    assert args.text == "hi"
+    assert args.embeds is None
+    assert args.files is None
+
+
+def test_all_optional_fields_accepted_independently():
+    """Each optional field is accepted on its own. Spot-check the field
+    set rather than enumerating exhaustively."""
+    _DiscordSendArgs(channel_id="1", embeds=[{"title": "x"}])
+    _DiscordSendArgs(channel_id="1", files=["/tmp/a"])
+    _DiscordSendArgs(channel_id="1", reply_to="456")
+    _DiscordSendArgs(channel_id="1", allowed_mentions={"users": []})
+    _DiscordSendArgs(channel_id="1", components=[{"type": 1}])
+    _DiscordSendArgs(channel_id="1", cleanup_inbound_message_id="789")
+
+
+def test_missing_channel_id_raises():
+    with pytest.raises(ValidationError) as exc:
+        _DiscordSendArgs(text="hi")
+    assert "channel_id" in str(exc.value)
+
+
+def test_empty_channel_id_raises():
+    """channel_id is required and must be non-empty."""
+    with pytest.raises(ValidationError):
+        _DiscordSendArgs(channel_id="")
+
+
+def test_extra_field_rejected_by_forbid():
+    """extra='forbid' is the contract: any unknown field at the args
+    level raises ValidationError. The shape_validator should catch this
+    case BEFORE Pydantic, but this is the defense-in-depth layer."""
+    with pytest.raises(ValidationError) as exc:
+        _DiscordSendArgs(channel_id="123", text="hi", mystery_field="X")
+    msg = str(exc.value)
+    assert "mystery_field" in msg or "extra" in msg.lower()
+
+
+def test_canonical_keys_in_sync_with_validator_catalog():
+    """The canonical args field set must stay in lockstep with
+    shape_validator._KNOWN_CANONICAL_SEND_ARGS. A drift between them
+    would surface as a sender being rejected by one layer but accepted
+    by the other."""
+    from agent_core_discord.shape_validator import _KNOWN_CANONICAL_SEND_ARGS
+
+    model_fields = set(_DiscordSendArgs.model_fields.keys())
+    assert model_fields == _KNOWN_CANONICAL_SEND_ARGS

--- a/packages/agent-core-discord/tests/test_discord_send_args.py
+++ b/packages/agent-core-discord/tests/test_discord_send_args.py
@@ -34,7 +34,7 @@ def test_all_optional_fields_accepted_independently():
 
 def test_missing_channel_id_raises():
     with pytest.raises(ValidationError) as exc:
-        _DiscordSendArgs(text="hi")
+        _DiscordSendArgs(text="hi")  # type: ignore[call-arg]
     assert "channel_id" in str(exc.value)
 
 
@@ -49,7 +49,7 @@ def test_extra_field_rejected_by_forbid():
     level raises ValidationError. The shape_validator should catch this
     case BEFORE Pydantic, but this is the defense-in-depth layer."""
     with pytest.raises(ValidationError) as exc:
-        _DiscordSendArgs(channel_id="123", text="hi", mystery_field="X")
+        _DiscordSendArgs(channel_id="123", text="hi", mystery_field="X")  # type: ignore[call-arg]
     msg = str(exc.value)
     assert "mystery_field" in msg or "extra" in msg.lower()
 

--- a/packages/agent-core-discord/tests/test_endpoint_hardening.py
+++ b/packages/agent-core-discord/tests/test_endpoint_hardening.py
@@ -10,10 +10,10 @@ import pytest
 from agent_core_discord import endpoint as endpoint_mod
 from agent_core_discord.args import _DownloadAttachmentsArgs, _FetchArgs
 from agent_core_discord.endpoint import DiscordEndpoint, _check_embeds_within_caps
+from agent_core_discord.testing.fakes import FakeChannel, FakeDiscordClient
 from pydantic import ValidationError
 
 from agent_core.bus.envelope import EndpointInfo, Envelope, ToolInvocationPayload
-from agent_core_discord.testing.fakes import FakeChannel, FakeDiscordClient
 
 
 class _Recording:

--- a/packages/agent-core-discord/tests/test_endpoint_inbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_inbound.py
@@ -724,7 +724,7 @@ async def test_persist_attachment_raises_on_download_failure(monkeypatch, tmp_pa
 
 @pytest.mark.asyncio
 async def test_inbound_autodownloads_and_enriches_metadata(monkeypatch, tmp_path):
-    from agent_core_discord.testing.fakes import FakeChannel, FakeAttachment
+    from agent_core_discord.testing.fakes import FakeAttachment, FakeChannel
 
     ep, handle, fake = await _start_endpoint(monkeypatch)
     ep.attachments_dir = tmp_path
@@ -761,7 +761,7 @@ async def test_inbound_autodownloads_and_enriches_metadata(monkeypatch, tmp_path
 
 @pytest.mark.asyncio
 async def test_inbound_download_failure_degrades_url_only(monkeypatch, tmp_path):
-    from agent_core_discord.testing.fakes import FakeChannel, FakeAttachment
+    from agent_core_discord.testing.fakes import FakeAttachment, FakeChannel
 
     ep, handle, fake = await _start_endpoint(monkeypatch)
     ep.attachments_dir = tmp_path
@@ -794,7 +794,7 @@ async def test_inbound_download_failure_degrades_url_only(monkeypatch, tmp_path)
 
 @pytest.mark.asyncio
 async def test_inbound_multi_attachment_distinct_paths(monkeypatch, tmp_path):
-    from agent_core_discord.testing.fakes import FakeChannel, FakeAttachment
+    from agent_core_discord.testing.fakes import FakeAttachment, FakeChannel
 
     ep, handle, fake = await _start_endpoint(monkeypatch)
     ep.attachments_dir = tmp_path
@@ -813,7 +813,7 @@ async def test_inbound_multi_attachment_distinct_paths(monkeypatch, tmp_path):
 
     atts = [
         FakeAttachment(filename=f"{n}.png", url=u, content_type="image/png", size=len(b))
-        for (u, b), n in zip(payloads.items(), ["one", "two", "three"])
+        for (u, b), n in zip(payloads.items(), ["one", "two", "three"], strict=False)
     ]
     msg = _msg(id="m-multi", attachments=atts)
     msg.channel = fake.get_channel("200")
@@ -831,7 +831,7 @@ async def test_inbound_multi_attachment_distinct_paths(monkeypatch, tmp_path):
 
 @pytest.mark.asyncio
 async def test_inbound_download_error_redacts_signed_cdn_url(monkeypatch, tmp_path):
-    from agent_core_discord.testing.fakes import FakeChannel, FakeAttachment
+    from agent_core_discord.testing.fakes import FakeAttachment, FakeChannel
 
     ep, handle, fake = await _start_endpoint(monkeypatch)
     ep.attachments_dir = tmp_path

--- a/packages/agent-core-discord/tests/test_endpoint_lifecycle.py
+++ b/packages/agent-core-discord/tests/test_endpoint_lifecycle.py
@@ -8,9 +8,9 @@ from datetime import UTC
 
 import pytest
 from agent_core_discord.endpoint import DiscordEndpoint, _active_endpoints
+from agent_core_discord.testing.fakes import FakeBusHandle
 
 from agent_core.bus.protocol import Endpoint
-from agent_core_discord.testing.fakes import FakeBusHandle
 
 
 def test_endpoint_satisfies_endpoint_protocol():

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -42,11 +42,14 @@ from agent_core.bus.envelope import (
 class _Recording:
     def __init__(self):
         self.published: list[Envelope] = []
+        self.acked: set[str] = set()
 
     async def publish(self, envelope: Envelope, to=None) -> None:
         self.published.append(envelope)
 
-    async def ack(self, envelope_id: str) -> None: ...
+    async def ack(self, envelope_id: str) -> None:
+        self.acked.add(envelope_id)
+
     async def nack(self, envelope_id: str, requeue: bool = True) -> None: ...
     def endpoints(self) -> list[EndpointInfo]:
         return []
@@ -2507,5 +2510,60 @@ async def test_discord_send_with_no_payload_raises_explicit_error(monkeypatch):
         assert "text" in last_ack.payload.note
         assert "embeds" in last_ack.payload.note
         assert "files" in last_ack.payload.note
+    finally:
+        await ep.stop()
+
+
+# --- #114 Task 8: deliver() routes unrecognized envelopes to failed-delivery Ack ---
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_field_produces_failed_delivery_ack(monkeypatch):
+    """LOAD-BEARING regression test (spec Testing section). The single
+    test that proves the silent-drop class is closed for this surface.
+
+    A TextMessage envelope with metadata.discord.mystery_field (unknown)
+    must produce a yellow failed-delivery Acknowledgment and NOT reach
+    the Discord API.
+    """
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="123")
+    fake.add_channel(ch)
+
+    env = Envelope(
+        id=uuid.uuid4().hex,
+        correlation_id=uuid.uuid4().hex,
+        from_="agent-test",
+        to="discord-test",
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hi"),
+        metadata={"discord": {
+            "channel_id": "123",
+            "mystery_field": "X",
+        }},
+        created_at=datetime.now(UTC),
+    )
+    original_id = env.id
+
+    try:
+        await ep.deliver(env)
+
+        # (a) No Discord API call.
+        assert ch.sent == [], (
+            "validator failed to gate: dispatch reached the Discord client"
+        )
+
+        # (b) Yellow Ack with right in_reply_to and the unrecognized field
+        # named in the note.
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert acks, "no Acknowledgment was published"
+        ack = acks[-1]
+        assert ack.urgency == "yellow"
+        assert ack.in_reply_to == original_id
+        assert "metadata.discord.mystery_field" in ack.payload.note
+        assert "discord_send" in ack.payload.note
+
+        # (c) The inbound was acked (does not redeliver).
+        assert original_id in handle.acked
     finally:
         await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -2481,3 +2481,31 @@ async def test_dispatch_routes_discord_send_to_internal_send(monkeypatch):
         assert result["status"] == "sent"
     finally:
         await ep.stop()
+
+
+# --- #114 Task 7: _send empty-send guard names 'files' ---
+
+
+@pytest.mark.asyncio
+async def test_discord_send_with_no_payload_raises_explicit_error(monkeypatch):
+    """tool=discord_send with no text, no embeds, no files must produce
+    a clear yellow Ack naming all three options, not just text/embeds.
+    (#114 Task 7 — extends the existing _send guard to mention 'files'.)"""
+    ep, handle, fake = await _started(monkeypatch)
+    try:
+        env = _envelope(
+            "e-empty",
+            "agent-test",
+            "discord-test",
+            _toolcall("discord_send", {"channel_id": "123"}),
+        )
+        await ep.deliver(env)
+
+        # The Acknowledgment fired with a note listing all three payload options.
+        last_ack = [e for e in handle.published if e.kind == "Acknowledgment"][-1]
+        assert last_ack.urgency == "yellow"
+        assert "text" in last_ack.payload.note
+        assert "embeds" in last_ack.payload.note
+        assert "files" in last_ack.payload.note
+    finally:
+        await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -2731,3 +2731,125 @@ async def test_legacy_textmessage_with_embeds_still_delivers_and_logs(
         assert deprecated_logs[0].shape_name == "legacy_textmessage_embeds"
     finally:
         await ep.stop()
+
+
+# --- #114 Task 10: multi-field + canonical + validator-exception integration tests ---
+
+
+@pytest.mark.asyncio
+async def test_multi_field_unrecognized_produces_one_ack_listing_all_fields(
+    monkeypatch,
+):
+    """When two or more unrecognized fields land on the same envelope,
+    ONE failed-delivery Ack lists all of them. Senders see the full
+    failure surface in one delivery, not in N redeliveries."""
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="123")
+    fake.add_channel(ch)
+
+    try:
+        env = Envelope(
+            id="env-multi",
+            correlation_id="corr-multi",
+            to="discord-test",
+            kind="TextMessage",
+            payload=TextMessagePayload(text="hi"),
+            metadata={"discord": {
+                "channel_id": "123",
+                "mystery_one": "X",
+                "mystery_two": "Y",
+            }},
+            created_at=datetime.now(UTC),
+            from_="multi-sender",
+        )
+        await ep.deliver(env)
+
+        # No Discord API call.
+        assert ch.sent == []
+
+        # Exactly ONE Ack with BOTH fields named.
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert len(acks) == 1
+        ack = acks[-1]
+        assert ack.urgency == "yellow"
+        assert "metadata.discord.mystery_one" in ack.payload.note
+        assert "metadata.discord.mystery_two" in ack.payload.note
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_canonical_discord_send_delivers_silently_no_deprecation_log(
+    monkeypatch, caplog
+):
+    """The canonical path: tool=discord_send + canonical args delivers
+    and emits NO deprecation log. The deprecation-readiness telemetry
+    must see clean canonical sends as 'no event recorded'."""
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="123")
+    fake.add_channel(ch)
+
+    try:
+        env = _envelope(
+            "env-canonical",
+            "agent-test",
+            "discord-test",
+            _toolcall("discord_send", {"channel_id": "123", "text": "hi"}),
+        )
+        with caplog.at_level("WARNING"):
+            await ep.deliver(env)
+
+        assert ch.sent, "canonical send should land at the Discord client"
+
+        deprecated_logs = [
+            r for r in caplog.records
+            if getattr(r, "event", None) == "deprecated_shape"
+        ]
+        assert deprecated_logs == [], (
+            f"canonical send must not log deprecation; got {deprecated_logs}"
+        )
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_validator_internal_exception_produces_yellow_ack(
+    monkeypatch
+):
+    """If the validator itself raises (catalog bug, malformed envelope
+    from a test fixture), deliver()'s existing exception handler must
+    catch it and produce a yellow Ack with the error in the note. The
+    inbound must still be acked so no redelivery storm happens."""
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="123")
+    fake.add_channel(ch)
+
+    try:
+        # Force validate_shape() to raise.
+        def _boom(_env):
+            raise RuntimeError("catalog bug for test")
+
+        monkeypatch.setattr(
+            "agent_core_discord.endpoint.validate_shape", _boom
+        )
+
+        env = _envelope(
+            "env-validator-exc",
+            "agent-test",
+            "discord-test",
+            _toolcall("discord_send", {"channel_id": "123", "text": "hi"}),
+        )
+        await ep.deliver(env)
+
+        # _send was NOT reached.
+        assert ch.sent == []
+        # Yellow Ack with "validator failed" in the note.
+        acks = [e for e in handle.published if e.kind == "Acknowledgment"]
+        assert acks, "expected an Acknowledgment after validator exception"
+        ack = acks[-1]
+        assert ack.urgency == "yellow"
+        assert "validator failed" in ack.payload.note.lower()
+        # Inbound was acked.
+        assert env.id in handle.acked
+    finally:
+        await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -2567,3 +2567,167 @@ async def test_unrecognized_field_produces_failed_delivery_ack(monkeypatch):
         assert original_id in handle.acked
     finally:
         await ep.stop()
+
+
+# --- #114 Task 9: back-compat regression suite for the 4 documented legacy shapes ---
+
+
+@pytest.mark.asyncio
+async def test_legacy_textmessage_plain_still_delivers_and_logs_deprecation(
+    monkeypatch, caplog
+):
+    """Back-compat shape #1: TextMessage + metadata.discord.channel_id
+    plain text. Must still deliver. Must emit a structured
+    deprecation_shape log line keyed by shape_name."""
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="123")
+    fake.add_channel(ch)
+
+    env = Envelope(
+        id="env-plain",
+        correlation_id="corr-plain",
+        to="discord-test",
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hi"),
+        metadata={"discord": {"channel_id": "123"}},
+        created_at=datetime.now(UTC),
+        from_="some-sender",
+    )
+
+    try:
+        with caplog.at_level("WARNING"):
+            await ep.deliver(env)
+
+        assert ch.sent, "expected delivery to land at the Discord client"
+        assert ch.sent[0]["content"] == "hi"
+
+        deprecated_logs = [
+            r for r in caplog.records
+            if getattr(r, "event", None) == "deprecated_shape"
+        ]
+        assert len(deprecated_logs) == 1, (
+            f"expected 1 deprecated_shape log, got {len(deprecated_logs)}"
+        )
+        rec = deprecated_logs[0]
+        assert rec.shape_name == "legacy_textmessage_plain"
+        assert rec.sender == "some-sender"
+        assert rec.envelope_id == "env-plain"
+        assert rec.canonical_equivalent == "tool=discord_send"
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_legacy_send_discord_message_with_embeds_still_delivers_and_logs(
+    monkeypatch, caplog
+):
+    """Back-compat shape #2: ToolInvocation + tool=send_discord_message
+    + args.{channel_id, text, embeds}."""
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="123")
+    fake.add_channel(ch)
+
+    env = _envelope(
+        "env-sdm-embeds",
+        "agent-test",
+        "discord-test",
+        _toolcall(
+            "send_discord_message",
+            {"channel_id": "123", "text": "hi", "embeds": [{"title": "x"}]},
+        ),
+    )
+
+    try:
+        with caplog.at_level("WARNING"):
+            await ep.deliver(env)
+
+        assert ch.sent, "expected delivery to land at the Discord client"
+
+        deprecated_logs = [
+            r for r in caplog.records
+            if getattr(r, "event", None) == "deprecated_shape"
+        ]
+        assert len(deprecated_logs) == 1
+        assert deprecated_logs[0].shape_name == "legacy_tool_send_discord_message"
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_legacy_send_discord_message_with_files_still_delivers_and_logs(
+    monkeypatch, caplog, tmp_path
+):
+    """Back-compat shape #3: ToolInvocation + tool=send_discord_message
+    + args.{channel_id, text, files} (verified 2026-05-11)."""
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="123")
+    fake.add_channel(ch)
+
+    fake_file = tmp_path / "qa.zip"
+    fake_file.write_bytes(b"\x00")
+
+    env = _envelope(
+        "env-sdm-files",
+        "agent-test",
+        "discord-test",
+        _toolcall(
+            "send_discord_message",
+            {"channel_id": "123", "text": "ship it", "files": [str(fake_file)]},
+        ),
+    )
+
+    try:
+        with caplog.at_level("WARNING"):
+            await ep.deliver(env)
+
+        assert ch.sent, "expected delivery to land at the Discord client"
+
+        deprecated_logs = [
+            r for r in caplog.records
+            if getattr(r, "event", None) == "deprecated_shape"
+        ]
+        assert len(deprecated_logs) == 1
+        assert deprecated_logs[0].shape_name == "legacy_tool_send_discord_message"
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_legacy_textmessage_with_embeds_still_delivers_and_logs(
+    monkeypatch, caplog
+):
+    """Back-compat shape #4: the poster-child. TextMessage + metadata.
+    discord.embeds was routed by commit a278c68; after #114 it still
+    routes but the deprecation log fires."""
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="123")
+    fake.add_channel(ch)
+
+    env = Envelope(
+        id="env-embeds",
+        correlation_id="corr-embeds",
+        to="discord-test",
+        kind="TextMessage",
+        payload=TextMessagePayload(text=""),
+        metadata={"discord": {
+            "channel_id": "123",
+            "embeds": [{"title": "x"}],
+        }},
+        created_at=datetime.now(UTC),
+        from_="another-sender",
+    )
+
+    try:
+        with caplog.at_level("WARNING"):
+            await ep.deliver(env)
+
+        assert ch.sent, "expected delivery to land at the Discord client"
+
+        deprecated_logs = [
+            r for r in caplog.records
+            if getattr(r, "event", None) == "deprecated_shape"
+        ]
+        assert len(deprecated_logs) == 1
+        assert deprecated_logs[0].shape_name == "legacy_textmessage_embeds"
+    finally:
+        await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_outbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_outbound.py
@@ -2454,3 +2454,30 @@ async def test_existing_clear_pending_ack_via_args_reply_to_path_unchanged(monke
         assert "target-mid" not in ep._awaiting_reply_ids_timestamps
     finally:
         await ep.stop()
+
+
+# --- #114 Task 6: discord_send alias + dispatch wiring ---
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_discord_send_to_internal_send(monkeypatch):
+    """tool=discord_send must reach _send via _dispatch. Verifies the
+    new entry in _TOOL_ALIASES and the _dispatch table (#114 Task 6)."""
+    ep, handle, fake = await _started(monkeypatch)
+    ch = FakeChannel(id="123")
+    fake.add_channel(ch)
+    try:
+        env = _envelope(
+            "e-ds",
+            "agent-test",
+            "discord-test",
+            _toolcall("discord_send", {"channel_id": "123", "text": "hi"}),
+        )
+        await ep.deliver(env)
+        assert len(ch.sent) == 1
+        assert ch.sent[0]["content"] == "hi"
+        ack = [e for e in handle.published if e.kind == "Acknowledgment"][0]
+        result = json.loads(ack.payload.note)
+        assert result["status"] == "sent"
+    finally:
+        await ep.stop()

--- a/packages/agent-core-discord/tests/test_endpoint_pending_acks.py
+++ b/packages/agent-core-discord/tests/test_endpoint_pending_acks.py
@@ -6,9 +6,9 @@ import time
 
 import pytest
 from agent_core_discord.endpoint import DiscordEndpoint
+from agent_core_discord.testing.fakes import FakeChannel, FakeDiscordClient, FakeMessage
 
 from agent_core.bus.envelope import EndpointInfo, Envelope
-from agent_core_discord.testing.fakes import FakeChannel, FakeDiscordClient, FakeMessage
 
 
 class _Recording:

--- a/packages/agent-core-discord/tests/test_endpoint_urgency.py
+++ b/packages/agent-core-discord/tests/test_endpoint_urgency.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import pytest
 from agent_core_discord.endpoint import DiscordEndpoint
+from agent_core_discord.testing.fakes import FakeChannel, FakeDiscordClient, FakeMessage, FakeUser
 
 from agent_core.bus.envelope import EndpointInfo, Envelope
-from agent_core_discord.testing.fakes import FakeChannel, FakeDiscordClient, FakeMessage, FakeUser
 
 
 class _Recording:

--- a/packages/agent-core-discord/tests/test_fakes_attachments.py
+++ b/packages/agent-core-discord/tests/test_fakes_attachments.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import discord
 import pytest
-from agent_core_discord.testing.fakes import FakeChannel
+from agent_core_discord.testing.fakes import FakeAttachment, FakeChannel
 
 
 @pytest.mark.asyncio
@@ -29,9 +29,6 @@ async def test_fake_message_records_attachments_from_send_call(tmp_path):
     finally:
         for df in discord_files:
             df.close()
-
-
-from agent_core_discord.testing.fakes import FakeAttachment
 
 
 def test_fake_attachment_carries_content_type_and_size():

--- a/packages/agent-core-discord/tests/test_recent_inbounds.py
+++ b/packages/agent-core-discord/tests/test_recent_inbounds.py
@@ -7,9 +7,9 @@ from datetime import UTC, datetime
 
 import pytest
 from agent_core_discord.endpoint import DiscordEndpoint
+from agent_core_discord.testing.fakes import FakeDiscordClient
 
 from agent_core.bus.envelope import Envelope, TextMessagePayload
-from agent_core_discord.testing.fakes import FakeDiscordClient
 
 
 async def _make_endpoint(monkeypatch, **kwargs):

--- a/packages/agent-core-discord/tests/test_shape_validator.py
+++ b/packages/agent-core-discord/tests/test_shape_validator.py
@@ -196,18 +196,23 @@ def test_textmessage_ambiguous_discord_meta_returns_legacy_ambiguous():
 
 
 def test_textmessage_inbound_only_key_in_outbound_returns_unrecognized():
-    """Inbound-only keys (message_id, guild_id, etc.) set on an outbound
+    """Pure inbound-only keys (guild_id, author_id, etc.) set on an outbound
     envelope are not in _KNOWN_DISCORD_META_OUTBOUND_KEYS. Task 4
-    closes the silent-drop class on these too — they return Unrecognized
-    so the sender receives a failed-delivery Ack rather than a silent drop."""
+    closes the silent-drop class on these — they return Unrecognized
+    so the sender receives a failed-delivery Ack rather than a silent drop.
+
+    NOTE: message_id is NOT a pure inbound-only key — _deliver_text_message
+    reads metadata.discord.message_id as a legacy reply-to target, so it IS
+    in _KNOWN_DISCORD_META_OUTBOUND_KEYS. guild_id is used here instead as
+    a representative genuinely inbound-only key."""
     env = _make_env(
         kind="TextMessage",
         payload=TextMessagePayload(text="hi"),
-        metadata={"discord": {"message_id": "789"}},
+        metadata={"discord": {"guild_id": "789"}},
     )
     result = validate(env)
     assert isinstance(result, Unrecognized)
-    assert result.fields == ["metadata.discord.message_id"]
+    assert result.fields == ["metadata.discord.guild_id"]
     assert "discord_send" in result.canonical_equivalent
 
 

--- a/packages/agent-core-discord/tests/test_shape_validator.py
+++ b/packages/agent-core-discord/tests/test_shape_validator.py
@@ -9,16 +9,16 @@ returned ShapeValidation value.
 from datetime import UTC, datetime
 
 import pytest
+from agent_core_discord.shape_validator import (
+    Recognized,
+    Unrecognized,
+    validate,
+)
 
 from agent_core.bus.envelope import (
     Envelope,
     TextMessagePayload,
     ToolInvocationPayload,
-)
-from agent_core_discord.shape_validator import (
-    Recognized,
-    Unrecognized,
-    validate,
 )
 
 

--- a/packages/agent-core-discord/tests/test_shape_validator.py
+++ b/packages/agent-core-discord/tests/test_shape_validator.py
@@ -48,9 +48,9 @@ def test_recognized_and_unrecognized_are_frozen_dataclasses():
     r = Recognized(shape_name="x", deprecation_log_line=None)
     u = Unrecognized(fields=["a"], canonical_equivalent="b")
     with pytest.raises(AttributeError):
-        r.shape_name = "y"  # frozen
+        r.shape_name = "y"  # type: ignore[misc]  # frozen
     with pytest.raises(AttributeError):
-        u.fields = ["c"]    # frozen
+        u.fields = ["c"]  # type: ignore[misc]  # frozen
 
 
 def test_canonical_discord_send_returns_recognized_no_deprecation():

--- a/packages/agent-core-discord/tests/test_shape_validator.py
+++ b/packages/agent-core-discord/tests/test_shape_validator.py
@@ -51,3 +51,70 @@ def test_recognized_and_unrecognized_are_frozen_dataclasses():
         r.shape_name = "y"  # frozen
     with pytest.raises(AttributeError):
         u.fields = ["c"]    # frozen
+
+
+def test_canonical_discord_send_returns_recognized_no_deprecation():
+    """The canonical tool=discord_send + canonical args is the new happy
+    path; no deprecation log fires."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="discord_send",
+            args={"channel_id": "123", "text": "hi"},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "canonical_discord_send"
+    assert result.deprecation_log_line is None
+
+
+def test_legacy_tool_send_returns_recognized_with_deprecation():
+    """tool=send is the pre-#114 internal canonical; ships as a legacy
+    alias after #114 with a deprecation-log line."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="send",
+            args={"channel_id": "123", "text": "hi"},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_tool_send"
+    assert result.deprecation_log_line is not None
+    assert "tool=discord_send" in result.deprecation_log_line
+
+
+def test_legacy_tool_send_discord_message_returns_recognized_with_deprecation():
+    """tool=send_discord_message is the existing public alias; ships as a
+    legacy alias after #114 with a deprecation-log line."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="send_discord_message",
+            args={"channel_id": "123", "text": "hi", "embeds": [{"title": "x"}]},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_tool_send_discord_message"
+    assert result.deprecation_log_line is not None
+    assert "tool=discord_send" in result.deprecation_log_line
+
+
+def test_other_tool_invocation_is_non_send_tool():
+    """Non-send tools (edit, react, fetch, etc.) are outside the
+    validator's strict-mode scope. They return Recognized with shape
+    'non_send_tool' so deliver() does not gate on them."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="edit",
+            args={"channel_id": "123", "message_id": "456", "text": "edited"},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "non_send_tool"
+    assert result.deprecation_log_line is None

--- a/packages/agent-core-discord/tests/test_shape_validator.py
+++ b/packages/agent-core-discord/tests/test_shape_validator.py
@@ -179,17 +179,103 @@ def test_textmessage_no_discord_metadata_is_non_discord():
 
 
 def test_textmessage_ambiguous_discord_meta_returns_legacy_ambiguous():
-    """metadata.discord block with no recognized routing-discriminating
-    keys (no channel_id, embeds, or reply_to) is reachable today via
-    inbound-only keys like message_id slipping into an outbound. The
-    branch returns Recognized so deliver() does not silently drop, but
-    flags the shape as ambiguous in the structured log."""
+    """metadata.discord block with no routing-discriminating keys (no
+    channel_id, embeds, or reply_to) and no unrecognized keys returns
+    the ambiguous shape. An empty {} block is the canonical trigger;
+    inbound-only keys (message_id etc.) now produce Unrecognized instead
+    (Task 4 closes the silent-drop class on those too)."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hi"),
+        metadata={"discord": {}},
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_textmessage_ambiguous"
+    assert result.deprecation_log_line is not None
+
+
+def test_textmessage_inbound_only_key_in_outbound_returns_unrecognized():
+    """Inbound-only keys (message_id, guild_id, etc.) set on an outbound
+    envelope are not in _KNOWN_DISCORD_META_OUTBOUND_KEYS. Task 4
+    closes the silent-drop class on these too — they return Unrecognized
+    so the sender receives a failed-delivery Ack rather than a silent drop."""
     env = _make_env(
         kind="TextMessage",
         payload=TextMessagePayload(text="hi"),
         metadata={"discord": {"message_id": "789"}},
     )
     result = validate(env)
-    assert isinstance(result, Recognized)
-    assert result.shape_name == "legacy_textmessage_ambiguous"
-    assert result.deprecation_log_line is not None
+    assert isinstance(result, Unrecognized)
+    assert result.fields == ["metadata.discord.message_id"]
+    assert "discord_send" in result.canonical_equivalent
+
+
+def test_textmessage_with_unrecognized_metadata_field_returns_unrecognized():
+    """The load-bearing case: an outbound carries a metadata.discord.*
+    field the adapter does not route. Validator must flag it so the Ack
+    can be published — silent-drop is what #114 closes."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hi"),
+        metadata={"discord": {"channel_id": "123", "mystery_field": "X"}},
+    )
+    result = validate(env)
+    assert isinstance(result, Unrecognized)
+    assert result.fields == ["metadata.discord.mystery_field"]
+    assert "discord_send" in result.canonical_equivalent
+    assert "mystery_field" in result.canonical_equivalent
+
+
+def test_textmessage_with_multiple_unrecognized_fields_returns_all():
+    """Multi-field case enumerates all unrecognized fields in one Ack
+    rather than fragmenting across N redeliveries."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hi"),
+        metadata={"discord": {
+            "channel_id": "123",
+            "mystery_field": "X",
+            "another_unknown": "Y",
+        }},
+    )
+    result = validate(env)
+    assert isinstance(result, Unrecognized)
+    # Order is sorted for determinism in the Ack note.
+    assert result.fields == [
+        "metadata.discord.another_unknown",
+        "metadata.discord.mystery_field",
+    ]
+
+
+def test_toolinvocation_canonical_with_unrecognized_arg_returns_unrecognized():
+    """args-level strict-mode for the canonical tool. The Pydantic
+    extra='forbid' on _DiscordSendArgs catches this at dispatch too;
+    the validator catches it before dispatch."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="discord_send",
+            args={"channel_id": "123", "text": "hi", "mystery_arg": "X"},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Unrecognized)
+    assert result.fields == ["args.mystery_arg"]
+    assert "discord_send" in result.canonical_equivalent
+
+
+def test_toolinvocation_legacy_with_unrecognized_arg_returns_unrecognized():
+    """Legacy tool with a new field the legacy args model never wired."""
+    env = _make_env(
+        kind="ToolInvocation",
+        payload=ToolInvocationPayload(
+            tool="send_discord_message",
+            args={"channel_id": "123", "text": "hi", "allowed_mentions": {}},
+        ),
+    )
+    result = validate(env)
+    assert isinstance(result, Unrecognized)
+    assert result.fields == ["args.allowed_mentions"]
+    assert "discord_send" in result.canonical_equivalent
+    assert "allowed_mentions" in result.canonical_equivalent

--- a/packages/agent-core-discord/tests/test_shape_validator.py
+++ b/packages/agent-core-discord/tests/test_shape_validator.py
@@ -1,0 +1,47 @@
+"""Unit tests for shape_validator — the pure-function recognized-shape catalog
+for the Discord adapter's strict-mode envelope validation.
+
+The validator is PURE: no I/O, no Discord client, no chrome.* / discord.*
+imports. These tests construct envelopes directly and assert on the
+returned ShapeValidation value.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from agent_core.bus.envelope import (
+    Envelope,
+    TextMessagePayload,
+    ToolInvocationPayload,
+)
+from agent_core_discord.shape_validator import (
+    Recognized,
+    Unrecognized,
+    validate,
+)
+
+
+def _make_env(*, kind, payload, metadata=None, from_="test-sender"):
+    """Helper: build an Envelope with sensible defaults for validator tests."""
+    return Envelope(
+        id="env-abc",
+        correlation_id="corr-1",
+        to="discord-test",
+        kind=kind,
+        payload=payload,
+        metadata=metadata or {},
+        created_at=datetime.now(UTC),
+        from_=from_,
+    )
+
+
+def test_recognized_and_unrecognized_are_frozen_dataclasses():
+    """Both ShapeValidation variants are frozen so test assertions can compare
+    by value and Recognized/Unrecognized can be used as dict keys later."""
+    r = Recognized(shape_name="x", deprecation_log_line=None)
+    u = Unrecognized(fields=["a"], canonical_equivalent="b")
+    with pytest.raises(Exception):
+        r.shape_name = "y"  # frozen
+    with pytest.raises(Exception):
+        u.fields = ["c"]    # frozen

--- a/packages/agent-core-discord/tests/test_shape_validator.py
+++ b/packages/agent-core-discord/tests/test_shape_validator.py
@@ -148,8 +148,8 @@ def test_textmessage_with_embeds_returns_recognized_with_deprecation():
 
 
 def test_textmessage_with_reply_to_returns_recognized_with_deprecation():
-    """reply_to legacy shape. message_id alias also tested via a fallback
-    test below."""
+    """reply_to legacy shape — distinguished by the presence of reply_to
+    in the metadata.discord block."""
     env = _make_env(
         kind="TextMessage",
         payload=TextMessagePayload(text="reply"),
@@ -176,3 +176,20 @@ def test_textmessage_no_discord_metadata_is_non_discord():
     assert isinstance(result, Recognized)
     assert result.shape_name == "non_discord_text_message"
     assert result.deprecation_log_line is None
+
+
+def test_textmessage_ambiguous_discord_meta_returns_legacy_ambiguous():
+    """metadata.discord block with no recognized routing-discriminating
+    keys (no channel_id, embeds, or reply_to) is reachable today via
+    inbound-only keys like message_id slipping into an outbound. The
+    branch returns Recognized so deliver() does not silently drop, but
+    flags the shape as ambiguous in the structured log."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hi"),
+        metadata={"discord": {"message_id": "789"}},
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_textmessage_ambiguous"
+    assert result.deprecation_log_line is not None

--- a/packages/agent-core-discord/tests/test_shape_validator.py
+++ b/packages/agent-core-discord/tests/test_shape_validator.py
@@ -118,3 +118,61 @@ def test_other_tool_invocation_is_non_send_tool():
     assert isinstance(result, Recognized)
     assert result.shape_name == "non_send_tool"
     assert result.deprecation_log_line is None
+
+
+def test_textmessage_plain_text_returns_recognized_with_deprecation():
+    """The most-common legacy shape: TextMessage with channel_id only."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hello"),
+        metadata={"discord": {"channel_id": "123"}},
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_textmessage_plain"
+    assert result.deprecation_log_line is not None
+
+
+def test_textmessage_with_embeds_returns_recognized_with_deprecation():
+    """The poster-child shape from #114 — routed since a278c68 but
+    still legacy. Embed presence determines the shape_name."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text=""),
+        metadata={"discord": {"channel_id": "123", "embeds": [{"title": "x"}]}},
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_textmessage_embeds"
+    assert result.deprecation_log_line is not None
+
+
+def test_textmessage_with_reply_to_returns_recognized_with_deprecation():
+    """reply_to legacy shape. message_id alias also tested via a fallback
+    test below."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="reply"),
+        metadata={
+            "discord": {"channel_id": "123", "reply_to": "456"},
+        },
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "legacy_textmessage_reply"
+    assert result.deprecation_log_line is not None
+
+
+def test_textmessage_no_discord_metadata_is_non_discord():
+    """TextMessage envelopes with no metadata.discord block at all are
+    not discord-bound; validator returns Recognized so deliver() doesn't
+    treat the absence of routing as a failure."""
+    env = _make_env(
+        kind="TextMessage",
+        payload=TextMessagePayload(text="hi"),
+        metadata={},
+    )
+    result = validate(env)
+    assert isinstance(result, Recognized)
+    assert result.shape_name == "non_discord_text_message"
+    assert result.deprecation_log_line is None

--- a/packages/agent-core-discord/tests/test_shape_validator.py
+++ b/packages/agent-core-discord/tests/test_shape_validator.py
@@ -22,7 +22,13 @@ from agent_core_discord.shape_validator import (
 )
 
 
-def _make_env(*, kind, payload, metadata=None, from_="test-sender"):
+def _make_env(
+    *,
+    kind: str,
+    payload: object,
+    metadata: dict[str, object] | None = None,
+    from_: str = "test-sender",
+) -> Envelope:
     """Helper: build an Envelope with sensible defaults for validator tests."""
     return Envelope(
         id="env-abc",
@@ -41,7 +47,7 @@ def test_recognized_and_unrecognized_are_frozen_dataclasses():
     by value and Recognized/Unrecognized can be used as dict keys later."""
     r = Recognized(shape_name="x", deprecation_log_line=None)
     u = Unrecognized(fields=["a"], canonical_equivalent="b")
-    with pytest.raises(Exception):
+    with pytest.raises(AttributeError):
         r.shape_name = "y"  # frozen
-    with pytest.raises(Exception):
+    with pytest.raises(AttributeError):
         u.fields = ["c"]    # frozen


### PR DESCRIPTION
## Summary

Closes #114. Adds one canonical `tool=discord_send` to the Discord adapter and a strict-mode shape validator that publishes failed-delivery `Acknowledgment` envelopes (urgency=yellow) on unrecognized fields. Closes the silent-drop class on the discord-send surface without touching the bus envelope schema.

## Design

See `docs/superpowers/specs/2026-05-23-issue-114-discord-send-unified-envelope-design.md` (commit `eabe993`). Implementation plan at `docs/superpowers/plans/2026-05-23-issue-114-discord-send-unified-envelope.md`.

## What ships

- New `tool=discord_send` with `_DiscordSendArgs(extra="forbid")` (8 fields: `channel_id, text?, embeds?, files?, reply_to?, allowed_mentions?, components?, cleanup_inbound_message_id?`).
- New `shape_validator` pure-function module with recognized-shape catalog.
- `DiscordEndpoint.deliver()` calls the validator at the top; unrecognized envelopes get a yellow failed-delivery Ack with the canonical equivalent named in the note; recognized-but-legacy envelopes get a structured `deprecated_shape` log line and proceed to deliver.
- `_send` empty-payload guard now names `files` alongside `text` and `embeds`.
- Old shapes (`tool=send`, `tool=send_discord_message`, `TextMessage + metadata.discord.{channel_id, embeds, message_id, reply_to}`) continue to deliver. Senders are NOT broken.

## Test plan

- [x] `uv run pytest packages/agent-core-discord/tests/ -v` — 262 passed, 1 skipped (was 253 before this branch).
- [x] Load-bearing test `test_unrecognized_field_produces_failed_delivery_ack` passes — proves the silent-drop class is closed.
- [x] Back-compat regression suite passes for all four documented legacy shapes, with deprecation-log assertions.
- [x] `uv run pytest -q` (full repo) passes — 1205 passed, 5 skipped.
- [x] `uv run ruff check packages/agent-core-discord/` is clean.
- [x] `uv run mypy packages/agent-core-discord/` — no new errors introduced by this branch (2 additional `import-untyped` for new files using the same pre-existing `agent_core.bus.envelope` pattern; all branch-logic errors fixed).
- [x] Canonical lockstep test (`_DiscordSendArgs ↔ _KNOWN_CANONICAL_SEND_ARGS`) and legacy lockstep test (`_SendArgs ↔ _KNOWN_LEGACY_SEND_ARGS`) both pass — guards against future field-drift between the dispatcher and the validator catalog.

## Migration

Pepper will move her own send-paths plus the relevant memory entries to `tool=discord_send` after this lands, so the deprecation-log lines start dropping and the deprecation-readiness telemetry has data for the eventual removal ticket.

## Known-noted (deferred to follow-up tickets)

- **Spec catalog overshoot:** spec lists `legacy_textmessage_files` (`TextMessage + payload.attachments` with no `metadata.discord` block); validator does not implement this branch. Such envelopes still deliver via `_deliver_text_message`'s `outbound_channel_id` fallback but produce no `deprecated_shape` log. Either trim from the spec or add the validator branch when a sender hits the friction.
- **Validator UX nit:** canonical-tool unrecognized-arg `canonical_equivalent` reads `"tool=discord_send accepts [<sorted list>]"`, which is wordy and self-referential when the sender already used `tool=discord_send`. Cosmetic; consider terser phrasing later.
- **Telemetry double-log:** `TextMessage` with `metadata.discord: {}` produces both a `deprecated_shape` log (`legacy_textmessage_ambiguous`) AND a yellow `error: ...` Ack from `_deliver_text_message`'s `_ToolError`. Behavior is correct (no silent drop); just doubly-loud in telemetry.

## Next-ticket triggers

- Removal of deprecated shapes — gated on deprecation-readiness telemetry showing no `deprecated_shape` log lines for a given `shape_name` over N days.
- Generalization to other surfaces (Slack, email) — rule-of-three.
- `allowed_mentions` / `components` wiring through `_send` — earned by named symptom.