### PR TITLE
feat(qa): agent-core-qa — release-validation scenario runner

### DIFF
--- a/docs/superpowers/plans/2026-05-23-qa-runner.md
+++ b/docs/superpowers/plans/2026-05-23-qa-runner.md
@@ -1,0 +1,1276 @@
+# `agent-core-qa` — release-validation scenario runner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Spec:** `docs/superpowers/specs/2026-05-23-qa-runner-design.md` (commit `095ab1b`).
+>
+> **Branch:** `feat/qa-runner-tester` (worktree at `.worktrees/qa-runner-tester/`).
+>
+> **Tool name (Jeff sign-off):** `agent-core-qa` — package name, conversational reference, future CLI subcommand. The function IS the name; no separate identifier needed.
+
+**Goal:** A pytest-based scenario runner (`packages/agent-core-qa/`) that exercises a running Phase 3.5 test daemon end-to-end via seven happy-path scenarios. Tool-shaped per Jeff's constraint set: function-named, no identity files, no continuity, no ethical weight.
+
+**Architecture:** Each scenario is a pytest test function that connects to the test daemon's HTTP API (or shells out to `agent-core daemon install --instance test` for the install-identity scenario). Shared fixtures (`daemon_url`, `client`, `daemon_liveness_required`) factor out the connection details. Package is a workspace member excluded from release wheels via the same `--no-emit-workspace` mechanism Phase 2.6 installed.
+
+**Tech Stack:** Python 3.12, uv workspace, pytest, pytest-asyncio, httpx.
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `pyproject.toml` (root) | Add `packages/agent-core-qa` to `[tool.uv.workspace] members` | Modify |
+| `packages/agent-core-qa/pyproject.toml` | Package metadata + pytest config + deps (pytest, pytest-asyncio, httpx) | Create |
+| `packages/agent-core-qa/README.md` | Tool-shaped constraint + bug-cadence inheritance + runbook reference | Create |
+| `packages/agent-core-qa/src/agent_core_qa/__init__.py` | Package marker (one line) | Create |
+| `packages/agent-core-qa/src/agent_core_qa/client.py` | `DaemonClient(base_url)` thin HTTP wrapper | Create |
+| `packages/agent-core-qa/tests/__init__.py` | Empty | Create |
+| `packages/agent-core-qa/tests/conftest.py` | `daemon_url`, `client`, `daemon_liveness_required` fixtures | Create |
+| `packages/agent-core-qa/tests/test_daemon_liveness.py` | Scenario 1 | Create |
+| `packages/agent-core-qa/tests/test_envelope_roundtrip.py` | Scenario 2 | Create |
+| `packages/agent-core-qa/tests/test_install_identity_dynamic_keystone.py` | Scenario 3 (load-bearing) | Create |
+| `packages/agent-core-qa/tests/test_brief_compose_and_submit.py` | Scenario 4 | Create |
+| `packages/agent-core-qa/tests/test_scheduler_create_and_delete.py` | Scenario 5 | Create |
+| `packages/agent-core-qa/tests/test_discord_send_stub_route.py` | Scenario 6 | Create |
+| `packages/agent-core-qa/tests/test_voice_synthesize_smoke.py` | Scenario 7 | Create |
+
+## Implementer guidance — daemon HTTP API discovery
+
+Several scenarios (4 brief, 5 scheduler, 6 discord_send, 7 voice synthesis) invoke MCP tools or other agent_core surfaces that may or may not be exposed over the daemon's HTTP API directly. **Before implementing those scenarios, do a brief preflight to discover the actual exposure pattern:**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+# What HTTP routes does the daemon expose?
+grep -rn "FastAPI\|@app.\|@router\.\|add_api_route\|@bus.route" packages/core/src/agent_core/bus/ 2>&1 | head -20
+# How does busproxy invoke tools?
+grep -rn "tool\|invoke\|call_tool" packages/agent-core-busproxy/src/ 2>&1 | head -20
+# What is the daemon's HTTP surface contract?
+ls packages/core/src/agent_core/bus/
+```
+
+If a scenario's MCP tool isn't HTTP-exposed directly, the implementer has two paths:
+- **(a)** Use `busproxy` as an intermediate (it's already an HTTP-callable MCP relay).
+- **(b)** Send a `ToolInvocation` envelope addressed to the agent that owns the tool, and observe the resulting `Acknowledgment`.
+
+Both are valid; choose what's already wired and minimal for each scenario.
+
+For scenarios 4, 5, 6, 7 specifically — the Step 1 (write the failing test) writes the test ASSUMING a clean invocation path. If the implementer's preflight reveals the actual path differs, adapt the test accordingly and document the choice in the test's docstring.
+
+---
+
+## Phase 1 — Package scaffold + client + conftest
+
+### Task 1: Create the package scaffold and register it as a workspace member
+
+**Files:**
+- Modify: `pyproject.toml` (root)
+- Create: `packages/agent-core-qa/pyproject.toml`
+- Create: `packages/agent-core-qa/README.md`
+- Create: `packages/agent-core-qa/src/agent_core_qa/__init__.py`
+- Create: `packages/agent-core-qa/tests/__init__.py`
+
+- [ ] **Step 0 (preflight): read existing workspace members + a peer package's pyproject for shape**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+grep -B1 -A8 "\[tool.uv.workspace\]" pyproject.toml
+cat packages/agent-core-busproxy/pyproject.toml | head -50
+```
+
+Note the workspace-members shape (likely `["packages/*", "packages/agent-core-voice/vendor/Qwen3-TTS"]` post-Phase 2.6) and the convention for sibling packages (deps, build-system, dynamic version, hatchling).
+
+- [ ] **Step 1: Update root `pyproject.toml`**
+
+Add `agent-core-qa` if `["packages/*"]` is the existing pattern, the new package is auto-included. **Verify by listing members the workspace recognizes**:
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv tree --depth 0 2>&1 | grep agent-core-qa || echo "  (not yet picked up — will be after pyproject created in Step 2)"
+```
+
+If the existing members list uses an explicit array (not glob), add `"packages/agent-core-qa"` to it.
+
+No commit yet — workspace registration coordinates with Step 2.
+
+- [ ] **Step 2: Create `packages/agent-core-qa/pyproject.toml`**
+
+```toml
+[project]
+name = "agent-core-qa"
+dynamic = ["version"]
+description = "Release-validation scenario runner for the agent_core daemon (pytest-based)"
+requires-python = ">=3.12"
+dependencies = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "httpx>=0.27",
+]
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agent_core_qa"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+```
+
+Match the dynamic-versioning + hatchling pattern from sibling packages (verify by re-reading the busproxy pyproject from preflight Step 0). If the sibling uses different keys/versions, mirror those.
+
+- [ ] **Step 3: Create `packages/agent-core-qa/README.md`**
+
+```markdown
+# agent-core-qa
+
+Release-validation scenario runner for the agent_core daemon. **A tool, not a being.**
+
+## What it is
+
+Seven pytest scenarios that exercise a running Phase 3.5 test daemon (`agent-core daemon --instance test`) end-to-end. Each scenario maps to a "v0.3.0 cannot ship if broken" surface: daemon liveness, envelope round-trip, install identity (dynamic keystone), brief framework, scheduler, discord_send, voice synthesis.
+
+## Tool-shaped, not being-shaped
+
+This package is a test runner. It has:
+- No `IDENTITY.md`, `SOUL.md`, `MEMORY.md`, `HEARTBEAT.md`, diary, breadcrumbs, or lessons.
+- No continuity of self — each pytest invocation is fresh.
+- No ethical weight — `rm -rf packages/agent-core-qa/` is functionally identical to deleting any pytest suite.
+- No registration on the bus as a peer; it's an HTTP client that exits when done.
+
+Same shape as `pytest` or `playwright`. Procedural capability through playbooks (scenario functions); nothing for the tool to know about itself.
+
+## Architectural inheritance: standing dynamic surface
+
+From Phase 2.6's PR description, the bug-cadence observation: static artifact analysis caught Bugs 1-2; dynamic real install caught Bug 3. The next failure class — "does the daemon actually start after install" — was named as Phase 2.7 territory.
+
+This package is the standing dynamic surface that catches that failure class (Scenario 1 as autouse fixture precondition) and every subsequent dynamic-only failure class on every release going forward. Phase 3.5 + Phase 2.6 + agent-core-qa is one continuous arc: build the sandbox, fix the install, prove the install still works release over release.
+
+## Runbook
+
+```bash
+# v0.3.0 release-validation runbook
+AGENT_CORE_HOME=~/.agent-core-test agent-core daemon install --instance test --release v0.3.0
+agent-core daemon start --instance test
+cd packages/agent-core-qa
+uv run pytest tests/
+# all 7 pass → safe to refresh prod
+# any fail → fix the regression first
+```
+
+For an already-running test daemon, `agent-core daemon refresh --instance test --release vX.Y.Z` does install + restart in one command.
+
+## Scenarios
+
+1. `test_daemon_liveness` — precondition (autouse).
+2. `test_envelope_send_receives_ack` — bus round-trip.
+3. `test_install_identity_dynamic_keystone` — install code path identity at runtime (the load-bearing scenario for release validation).
+4. `test_brief_framework_compose_and_submit` — brief framework smoke.
+5. `test_scheduler_create_and_delete_roundtrip` — scheduler round-trip.
+6. `test_discord_send_tool_routes_through_stub` — discord_send tool dispatch with stubbed discord endpoint.
+7. `test_voice_synthesize_returns_audio_bytes` — voice synthesis smoke (no audio-quality validation).
+```
+
+- [ ] **Step 4: Create `packages/agent-core-qa/src/agent_core_qa/__init__.py`**
+
+```python
+"""agent-core-qa — release-validation scenario runner for the agent_core daemon.
+
+Tool-shaped, not being-shaped. See README.md for the constraint set.
+"""
+```
+
+- [ ] **Step 5: Create `packages/agent-core-qa/tests/__init__.py`**
+
+Empty file:
+
+```python
+```
+
+- [ ] **Step 6: Verify the package builds**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv sync 2>&1 | tail -5
+uv build --package agent-core-qa --wheel --out-dir /tmp/agent-core-qa-build/ 2>&1 | tail -3
+ls /tmp/agent-core-qa-build/
+rm -rf /tmp/agent-core-qa-build/
+```
+
+Expected: `uv sync` succeeds (workspace recognizes the new member); `uv build` produces `agent_core_qa-*.whl`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+git add pyproject.toml packages/agent-core-qa/
+git commit -m "feat(qa): scaffold agent-core-qa package as workspace member"
+```
+
+If uv.lock regenerated, stage it too.
+
+---
+
+### Task 2: Create `client.py` (thin HTTP client) and `conftest.py` (shared fixtures) + Scenario 1
+
+**Files:**
+- Create: `packages/agent-core-qa/src/agent_core_qa/client.py`
+- Create: `packages/agent-core-qa/tests/conftest.py`
+- Create: `packages/agent-core-qa/tests/test_daemon_liveness.py`
+
+- [ ] **Step 0 (preflight): find the daemon's liveness HTTP endpoint**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+grep -rn "@app\.\|add_api_route\|/health\|/healthz\|GET.*\"/\"" packages/core/src/agent_core/bus/ 2>&1 | head -10
+```
+
+Find what HTTP path the daemon responds to for "is it up." Likely `/`, `/health`, or similar. If the daemon binds an HTTP server at all (it must — Phase 3 said `bind_port` 8788/8789/8787; verify the route).
+
+If NO liveness endpoint exists yet, Scenario 1 falls back to a TCP connection check on the bind port. Acceptable but flag in the test docstring.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-qa/tests/test_daemon_liveness.py`:
+
+```python
+"""Scenario 1: test daemon liveness (precondition for all other scenarios).
+
+The 'next failure class' Phase 2.6's PR named as Phase 2.7 territory — does
+the daemon actually start after install. Catching this here as the autouse
+precondition means every other scenario gets clean skip-with-reason instead
+of cryptic connection errors when the daemon isn't up.
+"""
+
+import pytest
+
+
+def test_daemon_liveness(client):
+    """The test daemon must be reachable at <daemon_url>.
+
+    daemon_liveness_required fixture (autouse, conftest.py) ALSO checks this
+    so all other scenarios skip cleanly when the daemon is down. This
+    explicit test makes the precondition discoverable as its own scenario.
+    """
+    response = client.health_check()
+    assert response.status_code == 200, (
+        f"daemon at {client.base_url} returned {response.status_code}; "
+        f"body: {response.text[:200]}"
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv run pytest packages/agent-core-qa/tests/test_daemon_liveness.py -v
+```
+
+Expected: FAIL — `client` fixture doesn't exist yet; `DaemonClient` not importable.
+
+- [ ] **Step 3: Implement `client.py`**
+
+Create `packages/agent-core-qa/src/agent_core_qa/client.py`:
+
+```python
+"""DaemonClient — thin HTTP wrapper for the agent_core daemon.
+
+Tool-shaped: stateless across calls, no connection pooling beyond what
+httpx does internally, no retry, no session caching.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class DaemonClient:
+    """HTTP client for the agent_core daemon.
+
+    Targets the daemon's HTTP API (default http://127.0.0.1:8787 for the
+    Phase 3.5 test instance). One client per scenario; no shared state.
+    """
+
+    def __init__(self, base_url: str, *, timeout: float = 5.0):
+        self.base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+    def health_check(self) -> httpx.Response:
+        """GET <base_url>/ (or whatever liveness path the daemon exposes).
+
+        Implementer: adjust the path based on preflight Step 0 finding.
+        If the daemon doesn't expose a liveness route, fall back to a TCP
+        connect check on the port (implementer's call).
+        """
+        return httpx.get(self.base_url + "/", timeout=self._timeout)
+
+    def send_envelope(self, envelope: dict[str, Any]) -> httpx.Response:
+        """POST an envelope to the daemon's bus-publish endpoint.
+
+        Implementer: discover the exact route + payload shape via preflight
+        on the daemon's HTTP API. Likely something like POST /bus/publish
+        with the envelope JSON as body.
+        """
+        # Path placeholder — implementer verifies via preflight before
+        # using send_envelope.
+        return httpx.post(
+            self.base_url + "/bus/publish",
+            json=envelope,
+            timeout=self._timeout,
+        )
+
+    def poll_envelopes(
+        self,
+        predicate,
+        *,
+        timeout: float = 5.0,
+        interval: float = 0.1,
+    ) -> dict[str, Any] | None:
+        """Poll the daemon's bus state for an envelope matching predicate.
+
+        Returns the first match within timeout, else None. Implementer:
+        verify the poll path via preflight.
+        """
+        import time
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            resp = httpx.get(self.base_url + "/bus/inbox", timeout=interval)
+            if resp.status_code == 200:
+                for env in resp.json().get("envelopes", []):
+                    if predicate(env):
+                        return env
+            time.sleep(interval)
+        return None
+```
+
+- [ ] **Step 4: Implement `conftest.py`**
+
+Create `packages/agent-core-qa/tests/conftest.py`:
+
+```python
+"""Shared fixtures for agent-core-qa scenarios.
+
+Tool-shaped: each fixture is per-test; no module/session-scoped state
+beyond what pytest itself manages.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agent_core_qa.client import DaemonClient
+
+
+DEFAULT_DAEMON_URL = "http://127.0.0.1:8787"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--daemon-url",
+        action="store",
+        default=None,
+        help="Base URL of the test daemon's HTTP API (default: http://127.0.0.1:8787 "
+        "or AGENT_CORE_QA_DAEMON_URL env var)",
+    )
+
+
+@pytest.fixture
+def daemon_url(request) -> str:
+    """Resolve the daemon URL from CLI flag, env var, or default."""
+    flag = request.config.getoption("--daemon-url")
+    if flag:
+        return flag
+    env = os.environ.get("AGENT_CORE_QA_DAEMON_URL")
+    if env:
+        return env
+    return DEFAULT_DAEMON_URL
+
+
+@pytest.fixture
+def client(daemon_url: str) -> DaemonClient:
+    """Per-test DaemonClient — no session sharing."""
+    return DaemonClient(daemon_url)
+
+
+@pytest.fixture(autouse=True)
+def daemon_liveness_required(request, client: DaemonClient):
+    """Skip all scenarios if the test daemon isn't reachable.
+
+    Phase 2.7 failure-class catch: "does the daemon actually start after
+    install." If the daemon is down, dependent scenarios skip with a clear
+    reason instead of failing with cryptic connection errors.
+    """
+    # The liveness scenario itself shouldn't skip itself.
+    if request.node.name == "test_daemon_liveness":
+        return
+    try:
+        response = client.health_check()
+        if response.status_code != 200:
+            pytest.skip(
+                f"test daemon at {client.base_url} returned "
+                f"{response.status_code}; run `agent-core daemon start --instance test` first"
+            )
+    except Exception as exc:
+        pytest.skip(
+            f"test daemon not reachable at {client.base_url}: {exc!r}; "
+            f"run `agent-core daemon start --instance test` first"
+        )
+```
+
+- [ ] **Step 5: Run test to verify it passes (against a NOT-RUNNING daemon, expecting skip)**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv run pytest packages/agent-core-qa/tests/test_daemon_liveness.py -v
+```
+
+Expected outcomes:
+- If a test daemon IS running on 8787: test PASSES (and the autouse fixture doesn't skip the liveness test itself).
+- If NO test daemon is running: the `test_daemon_liveness` test FAILS with an httpx connection error (it's NOT skipped because the autouse fixture skips itself for this test). Dependent scenarios would all SKIP (verify in later tasks).
+
+This is the correct shape — Scenario 1 is the only test that genuinely fails on no-daemon; everything else degrades to skip.
+
+If the implementer wants to verify both branches: stand up the test daemon (`agent-core daemon start --instance test` against a stubbed install) and re-run to see PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+git add packages/agent-core-qa/src/agent_core_qa/client.py packages/agent-core-qa/tests/conftest.py packages/agent-core-qa/tests/test_daemon_liveness.py
+git commit -m "feat(qa): DaemonClient + conftest fixtures + Scenario 1 (liveness)"
+```
+
+---
+
+## Phase 2 — Foundational scenarios (envelope round-trip + install identity)
+
+### Task 3: Scenario 2 — envelope round-trip
+
+**Files:**
+- Create: `packages/agent-core-qa/tests/test_envelope_roundtrip.py`
+
+- [ ] **Step 0 (preflight): discover envelope-publish HTTP API**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+grep -rn "publish\|@app\.\|POST.*envelope\|POST.*bus" packages/core/src/agent_core/bus/ 2>&1 | head -20
+```
+
+Find: (a) the HTTP path for publishing an envelope, (b) the HTTP path for reading the bus inbox or polling for acks, (c) the envelope JSON shape. If the daemon doesn't expose direct HTTP for these, use `busproxy` or send via the MCP tool surface.
+
+Update `client.py:send_envelope` and `client.py:poll_envelopes` to match the actual paths discovered.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-qa/tests/test_envelope_roundtrip.py`:
+
+```python
+"""Scenario 2: envelope round-trip via builtin.stub endpoint.
+
+Most basic v0.3.0 surface. Failure means the bus is broken — nothing
+else works.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+def test_envelope_send_receives_ack(client):
+    """Send a TextMessage to builtin.stub; poll for the Ack."""
+    envelope_id = uuid.uuid4().hex
+    correlation_id = uuid.uuid4().hex
+    envelope = {
+        "id": envelope_id,
+        "correlation_id": correlation_id,
+        "to": "stub",  # the builtin.stub endpoint name configured at install
+        "kind": "TextMessage",
+        "payload": {"kind": "TextMessage", "text": "qa-roundtrip-probe"},
+        "metadata": {},
+        "from": "agent-core-qa",
+        "created_at": "2026-05-23T23:00:00Z",
+        "urgency": "green",
+    }
+
+    send_response = client.send_envelope(envelope)
+    assert send_response.status_code in (200, 201, 202), (
+        f"send failed: {send_response.status_code} {send_response.text[:200]}"
+    )
+
+    # Poll for the Ack
+    ack = client.poll_envelopes(
+        predicate=lambda env: (
+            env.get("kind") == "Acknowledgment"
+            and env.get("in_reply_to") == envelope_id
+        ),
+        timeout=5.0,
+    )
+    assert ack is not None, (
+        f"no Ack received for envelope {envelope_id} within 5s"
+    )
+```
+
+- [ ] **Step 2: Run test to verify failure shape**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv run pytest packages/agent-core-qa/tests/test_envelope_roundtrip.py -v
+```
+
+Expected: Failure mode depends on whether the daemon's HTTP endpoints match the placeholders in `client.py`. Adapt the client's paths until the request actually reaches the daemon.
+
+If the daemon is up and the routes are right: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+git add packages/agent-core-qa/src/agent_core_qa/client.py packages/agent-core-qa/tests/test_envelope_roundtrip.py
+git commit -m "feat(qa): Scenario 2 (envelope round-trip via builtin.stub)"
+```
+
+---
+
+### Task 4: Scenario 3 — install identity dynamic keystone (load-bearing)
+
+**Files:**
+- Create: `packages/agent-core-qa/tests/test_install_identity_dynamic_keystone.py`
+
+The load-bearing scenario. Standing dynamic surface for the install path Phase 2.6 fixed.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-qa/tests/test_install_identity_dynamic_keystone.py`:
+
+```python
+"""Scenario 3: install identity dynamic keystone.
+
+Phase 3.5's `test_install_code_path_identity_between_prod_and_test`
+enforces install-code-path identity at the UNIT level (mocked subprocess
+captures). This scenario is the DYNAMIC version: invoke the real install
+command against a clean sandbox home; assert it completes; assert the
+venv contains the expected agent_core wheels.
+
+Phase 2.6 bug-cadence: static unit caught Bugs 1-2; dynamic install
+caught Bug 3. This scenario is the standing dynamic check for release
+v0.3.0 onward — if it ever fails, the install path regressed.
+
+NOTE: This scenario does its own daemon install. It does NOT require
+the precondition test daemon to be running (the autouse liveness
+fixture is bypassed via the test-name check). It uses its own sandbox
+home so it never touches the running test daemon's state.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+# Bypass the autouse daemon_liveness_required fixture for this scenario —
+# it does its own daemon install in a sandbox and doesn't need the running
+# test daemon. pytest discovers the bypass via the conftest's name check.
+# (conftest.py's `daemon_liveness_required` returns early for tests named
+# `test_daemon_liveness`. For Scenario 3 we add an explicit early-return
+# branch in conftest.py — see Task 4 step 1b.)
+
+
+EXPECTED_PACKAGES = [
+    "agent_core",
+    "agent_core_briefs",
+    "agent_core_busproxy",
+    "agent_core_channel",
+    "agent_core_credentials",
+    "agent_core_discord",
+    "agent_core_hatchery",
+    "agent_core_notify",
+    "agent_core_voice",
+    "agent_core_webcam",
+    "qwen_tts",
+]
+
+
+def test_install_identity_dynamic_keystone():
+    """Invoke `agent-core daemon install --instance test --release v0.3.0`
+    against a clean sandbox; assert install completes; assert venv has
+    all expected wheels.
+
+    Sandbox home is `/tmp/qa-{uuid}/` so each invocation is isolated;
+    cleanup happens on test teardown.
+    """
+    sandbox = Path("/tmp") / f"qa-{uuid.uuid4().hex[:8]}"
+    sandbox.mkdir(parents=True, exist_ok=True)
+
+    try:
+        env = os.environ.copy()
+        env["AGENT_CORE_HOME"] = str(sandbox)
+
+        # Invoke the real install command
+        # NOTE: pin the release tag the runbook intends to validate.
+        # For local pre-release validation, use a built-locally tag
+        # like "vlocal" (see runbook).
+        release_tag = os.environ.get("AGENT_CORE_QA_RELEASE_TAG", "v0.3.0")
+        result = subprocess.run(
+            ["agent-core", "daemon", "install",
+             "--instance", "test",
+             "--release", release_tag],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=600,  # 10 min — torch download is large
+        )
+        assert result.returncode == 0, (
+            f"install failed (exit {result.returncode}):\n"
+            f"STDOUT: {result.stdout[-2000:]}\n"
+            f"STDERR: {result.stderr[-2000:]}"
+        )
+
+        # Assert install stamp is correct
+        stamp_path = sandbox / ".daemon-install-stamp.json"
+        assert stamp_path.exists(), f"install stamp not written at {stamp_path}"
+
+        import json
+        stamp = json.loads(stamp_path.read_text())
+        assert stamp.get("release_tag") == release_tag or \
+               stamp.get("installed_version") == release_tag, (
+            f"install stamp shows wrong version: {stamp}"
+        )
+
+        # Assert ALL expected wheels are present at site-packages
+        # (per spec-review clarification: partial install must fail)
+        venv = sandbox / ".venv"
+        # Cross-platform site-packages lookup
+        if sys.platform == "win32":
+            site_packages = venv / "Lib" / "site-packages"
+        else:
+            # /lib/python*/site-packages
+            site_packages_candidates = list((venv / "lib").glob("python*/site-packages"))
+            assert site_packages_candidates, f"no site-packages found under {venv}/lib/"
+            site_packages = site_packages_candidates[0]
+
+        for package_name in EXPECTED_PACKAGES:
+            init_py = site_packages / package_name / "__init__.py"
+            assert init_py.exists(), (
+                f"expected wheel-installed package {package_name} not found at "
+                f"{init_py}; install was partial"
+            )
+
+    finally:
+        # Tear down sandbox; never reuses across runs
+        if sandbox.exists():
+            shutil.rmtree(sandbox, ignore_errors=True)
+```
+
+- [ ] **Step 1b: Update conftest.py to bypass liveness check for the keystone test**
+
+In `packages/agent-core-qa/tests/conftest.py`, update the `daemon_liveness_required` fixture's early-return list:
+
+```python
+    # Tests that do their own daemon management bypass the liveness check.
+    BYPASS_LIVENESS = {
+        "test_daemon_liveness",
+        "test_install_identity_dynamic_keystone",
+    }
+    if request.node.name in BYPASS_LIVENESS:
+        return
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv run pytest packages/agent-core-qa/tests/test_install_identity_dynamic_keystone.py -v
+```
+
+Expected: PASS if `agent-core` CLI is on PATH AND a real v0.3.0 (or `AGENT_CORE_QA_RELEASE_TAG`) release exists with the Phase 2.6 fixes. For pre-release local validation, the implementer or runbook sets `AGENT_CORE_QA_RELEASE_TAG` to a tag whose artifacts have the fix.
+
+If `agent-core` not on PATH, FAIL with FileNotFoundError — document expected env in the runbook.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+git add packages/agent-core-qa/tests/conftest.py packages/agent-core-qa/tests/test_install_identity_dynamic_keystone.py
+git commit -m "feat(qa): Scenario 3 (install identity dynamic keystone — load-bearing)"
+```
+
+---
+
+## Phase 3 — Tool-invocation scenarios (brief, scheduler, discord_send, voice)
+
+These four scenarios share a similar pattern: invoke an MCP tool exposed by the daemon, observe the result. The exact invocation transport (direct HTTP, busproxy, ToolInvocation envelope) depends on what the daemon's HTTP API exposes.
+
+### Task 5: Scenario 4 — brief framework smoke
+
+**Files:**
+- Create: `packages/agent-core-qa/tests/test_brief_compose_and_submit.py`
+
+- [ ] **Step 0 (preflight): find how to invoke `submit_brief` over HTTP**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+grep -rn "submit_brief\|brief.*tool\|mcp.*brief" packages/agent-core-briefs/src/ packages/agent-core-busproxy/src/ 2>&1 | head -20
+```
+
+If exposed via busproxy: invoke via a `ToolInvocation` envelope with `tool=submit_brief`. If exposed via direct HTTP: POST to the right route. Pick what's wired.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-qa/tests/test_brief_compose_and_submit.py`:
+
+```python
+"""Scenario 4: brief framework compose + submit smoke.
+
+Validates the gather → compose → submit_brief chain end-to-end. Does NOT
+need to actually deliver to a recipient or surface to a human reader.
+
+Why v0.3.0 needs it: brief framework is core to daily ops (Pepper relies
+on it); a regression would surface as silent compose failures with no
+obvious connection to the release.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+def test_brief_compose_and_submit(client):
+    """Invoke submit_brief with a minimal valid payload; assert success."""
+    # The exact tool-invocation shape depends on preflight Step 0 findings.
+    # Adjust the request shape to match what busproxy / the daemon expects.
+    # The example below assumes a ToolInvocation envelope addressed to the
+    # briefs endpoint; adapt to actual transport.
+    envelope = {
+        "id": uuid.uuid4().hex,
+        "correlation_id": uuid.uuid4().hex,
+        "to": "agent-core-briefs",  # or whatever the actual endpoint name is
+        "kind": "ToolInvocation",
+        "payload": {
+            "kind": "ToolInvocation",
+            "tool": "submit_brief",
+            "args": {
+                # Minimal brief: one section, one field
+                "sections": [
+                    {
+                        "id": "smoke-section",
+                        "title": "QA smoke",
+                        "fields": [
+                            {"name": "content", "value": "qa-smoke-probe"},
+                        ],
+                    },
+                ],
+            },
+        },
+        "metadata": {},
+        "from": "agent-core-qa",
+        "created_at": "2026-05-23T23:00:00Z",
+        "urgency": "green",
+    }
+    response = client.send_envelope(envelope)
+    assert response.status_code in (200, 201, 202), (
+        f"submit_brief failed: {response.status_code} {response.text[:200]}"
+    )
+
+    # Wait for the Ack (or for the actual brief envelope to be created)
+    ack = client.poll_envelopes(
+        predicate=lambda env: (
+            env.get("kind") == "Acknowledgment"
+            and env.get("in_reply_to") == envelope["id"]
+        ),
+        timeout=10.0,
+    )
+    assert ack is not None, (
+        f"no Ack received for submit_brief invocation within 10s"
+    )
+    # Optional: assert ack carries the new envelope_id of the submitted brief
+    note = ack.get("payload", {}).get("note", "")
+    assert note, f"Ack carried empty note; expected brief envelope_id"
+```
+
+- [ ] **Step 2: Run + iterate until passing**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv run pytest packages/agent-core-qa/tests/test_brief_compose_and_submit.py -v
+```
+
+If the brief framework's actual schema requires more fields, surface the validation error from the daemon's response and adapt the payload.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+git add packages/agent-core-qa/tests/test_brief_compose_and_submit.py
+git commit -m "feat(qa): Scenario 4 (brief framework compose + submit smoke)"
+```
+
+---
+
+### Task 6: Scenario 5 — scheduler create + delete round-trip
+
+**Files:**
+- Create: `packages/agent-core-qa/tests/test_scheduler_create_and_delete.py`
+
+- [ ] **Step 0 (preflight): find the scheduler tool names**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+grep -rn "create_schedule\|create_scheduled\|schedule.*tool\|scheduler" packages/core/src/agent_core/scheduler/ packages/agent-core-busproxy/src/ 2>&1 | head -20
+```
+
+Find the create / list / delete tool names (may be `create_job`, `add_schedule`, etc.) and the payload shapes.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-qa/tests/test_scheduler_create_and_delete.py`:
+
+```python
+"""Scenario 5: scheduler create + list + delete round-trip.
+
+Why v0.3.0 needs it: scheduler powers agent_core's heartbeat /
+liveness-probe / auth-health-probe / nightly-reflection infrastructure.
+If broken, the daemon goes silent.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+
+def _toolcall_envelope(tool: str, args: dict) -> dict:
+    """Build a ToolInvocation envelope for the scheduler tool."""
+    return {
+        "id": uuid.uuid4().hex,
+        "correlation_id": uuid.uuid4().hex,
+        "to": "scheduler",  # adapt to actual endpoint name from preflight
+        "kind": "ToolInvocation",
+        "payload": {"kind": "ToolInvocation", "tool": tool, "args": args},
+        "metadata": {},
+        "from": "agent-core-qa",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "urgency": "green",
+    }
+
+
+def test_scheduler_create_and_delete_roundtrip(client):
+    """Create a job in the future; list (find it); delete; list (gone)."""
+    future = (datetime.now(timezone.utc) + timedelta(days=365)).isoformat()
+    job_id = f"qa-probe-{uuid.uuid4().hex[:8]}"
+
+    # CREATE
+    create_env = _toolcall_envelope(
+        "create_scheduled_job",  # adapt to actual name from preflight
+        {"id": job_id, "fires_at": future, "payload": {"qa": True}},
+    )
+    create_resp = client.send_envelope(create_env)
+    assert create_resp.status_code in (200, 201, 202), (
+        f"create failed: {create_resp.status_code} {create_resp.text[:200]}"
+    )
+    create_ack = client.poll_envelopes(
+        predicate=lambda e: (
+            e.get("kind") == "Acknowledgment"
+            and e.get("in_reply_to") == create_env["id"]
+        ),
+        timeout=5.0,
+    )
+    assert create_ack is not None, "no Ack for scheduler create"
+
+    # LIST (find it)
+    list_env = _toolcall_envelope("list_scheduled_jobs", {})
+    list_resp = client.send_envelope(list_env)
+    list_ack = client.poll_envelopes(
+        predicate=lambda e: (
+            e.get("kind") == "Acknowledgment"
+            and e.get("in_reply_to") == list_env["id"]
+        ),
+        timeout=5.0,
+    )
+    assert list_ack is not None, "no Ack for scheduler list"
+    # Ack's note should include the job_id (or the list response is in payload data)
+    note = list_ack.get("payload", {}).get("note", "")
+    assert job_id in note, (
+        f"created job {job_id} not in list response: {note[:300]}"
+    )
+
+    # DELETE
+    delete_env = _toolcall_envelope("delete_scheduled_job", {"id": job_id})
+    delete_resp = client.send_envelope(delete_env)
+    delete_ack = client.poll_envelopes(
+        predicate=lambda e: (
+            e.get("kind") == "Acknowledgment"
+            and e.get("in_reply_to") == delete_env["id"]
+        ),
+        timeout=5.0,
+    )
+    assert delete_ack is not None, "no Ack for scheduler delete"
+
+    # LIST again (should NOT find it)
+    list2_env = _toolcall_envelope("list_scheduled_jobs", {})
+    client.send_envelope(list2_env)
+    list2_ack = client.poll_envelopes(
+        predicate=lambda e: (
+            e.get("kind") == "Acknowledgment"
+            and e.get("in_reply_to") == list2_env["id"]
+        ),
+        timeout=5.0,
+    )
+    assert list2_ack is not None, "no Ack for scheduler list (post-delete)"
+    note2 = list2_ack.get("payload", {}).get("note", "")
+    assert job_id not in note2, (
+        f"deleted job {job_id} still present in list response: {note2[:300]}"
+    )
+```
+
+Tool names + payload shapes are placeholders — the implementer adapts based on preflight Step 0.
+
+- [ ] **Step 2: Run + iterate**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv run pytest packages/agent-core-qa/tests/test_scheduler_create_and_delete.py -v
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+git add packages/agent-core-qa/tests/test_scheduler_create_and_delete.py
+git commit -m "feat(qa): Scenario 5 (scheduler create + delete round-trip)"
+```
+
+---
+
+### Task 7: Scenario 6 — discord_send routes through stub
+
+**Files:**
+- Create: `packages/agent-core-qa/tests/test_discord_send_stub_route.py`
+
+This scenario assumes the test daemon's discord endpoint is configured at INSTALL TIME as `builtin.stub` per the spec's runbook. The test sends a `discord_send` ToolInvocation and asserts the stub captured the payload.
+
+- [ ] **Step 0 (preflight): find the stub's recorded-inbound API**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+grep -rn "class StubEndpoint\|class _StubEndpoint\|builtin.stub" packages/core/src/agent_core/endpoints/ 2>&1 | head -20
+```
+
+Find: does the stub expose an HTTP endpoint to read its `.inbox` list? Or does it just record envelopes that the test can observe via the bus's HTTP API? The cleanest path is to send the envelope and poll the bus for the stub's resulting outbound Ack.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-qa/tests/test_discord_send_stub_route.py`:
+
+```python
+"""Scenario 6: discord_send routes through stub.
+
+Validates PR #119's new tool=discord_send routes correctly through
+_dispatch. The test daemon's discord-endpoint slot is configured at
+install time as builtin.stub (per the v0.3.0 release-validation runbook).
+
+If the runbook is followed, the discord-named endpoint slot accepts the
+discord_send invocation and the stub captures it — no real Discord token
+or sandbox channel needed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+
+def test_discord_send_tool_routes_through_stub(client):
+    """Send tool=discord_send to the stubbed discord endpoint; assert the
+    Ack reports successful dispatch."""
+    test_text = f"qa-discord-probe-{uuid.uuid4().hex[:8]}"
+    envelope = {
+        "id": uuid.uuid4().hex,
+        "correlation_id": uuid.uuid4().hex,
+        # NOTE: the stubbed endpoint slot may still be named "discord" in
+        # the test daemon's config (just backed by builtin.stub). Adapt if
+        # the install-time config uses a different name.
+        "to": "discord",
+        "kind": "ToolInvocation",
+        "payload": {
+            "kind": "ToolInvocation",
+            "tool": "discord_send",
+            "args": {
+                "channel_id": "qa-stub-channel",
+                "text": test_text,
+            },
+        },
+        "metadata": {},
+        "from": "agent-core-qa",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "urgency": "green",
+    }
+    response = client.send_envelope(envelope)
+    assert response.status_code in (200, 201, 202), (
+        f"discord_send failed: {response.status_code} {response.text[:200]}"
+    )
+
+    # Stub auto-acks every envelope; poll for the Ack
+    ack = client.poll_envelopes(
+        predicate=lambda e: (
+            e.get("kind") == "Acknowledgment"
+            and e.get("in_reply_to") == envelope["id"]
+        ),
+        timeout=5.0,
+    )
+    assert ack is not None, (
+        f"no Ack received for discord_send to stub; "
+        f"is the test daemon configured with discord → builtin.stub at install time?"
+    )
+    # Ack note should indicate success (not an "unrecognized field" error)
+    note = ack.get("payload", {}).get("note", "")
+    assert "error" not in note.lower() and "unrecognized" not in note.lower(), (
+        f"discord_send produced an error Ack: {note[:300]}"
+    )
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv run pytest packages/agent-core-qa/tests/test_discord_send_stub_route.py -v
+```
+
+Expected: PASS if the test daemon's discord slot is stubbed AND `tool=discord_send` is wired (PR #119 / Phase 3.5 #114 — verify by reading the discord adapter's `_TOOL_ALIASES`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+git add packages/agent-core-qa/tests/test_discord_send_stub_route.py
+git commit -m "feat(qa): Scenario 6 (discord_send routes through stub)"
+```
+
+---
+
+### Task 8: Scenario 7 — voice synthesis smoke
+
+**Files:**
+- Create: `packages/agent-core-qa/tests/test_voice_synthesize_smoke.py`
+
+- [ ] **Step 0 (preflight): find voice-synthesis tool name + payload shape**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+grep -rn "synthesize_speech\|synthesize\|tts.*tool" packages/agent-core-voice/src/ 2>&1 | head -20
+```
+
+Find the tool name + how the audio bytes come back (Ack note? separate envelope? base64-encoded in payload?).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agent-core-qa/tests/test_voice_synthesize_smoke.py`:
+
+```python
+"""Scenario 7: voice synthesis smoke.
+
+Why v0.3.0 needs it: Phase 2.6 promoted qwen-tts to a workspace member.
+If the promotion broke the actual synthesis path (vs. just the install),
+this catches it. The static install test asserts the wheel installs;
+this asserts it RUNS.
+
+Does NOT validate audio quality (human-loop, out of scope).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+
+def test_voice_synthesize_returns_audio_bytes(client):
+    """Call synthesize_speech with 'test'; assert audio bytes returned."""
+    envelope = {
+        "id": uuid.uuid4().hex,
+        "correlation_id": uuid.uuid4().hex,
+        "to": "agent-core-voice",  # adapt to actual endpoint name
+        "kind": "ToolInvocation",
+        "payload": {
+            "kind": "ToolInvocation",
+            "tool": "synthesize_speech",  # adapt to actual tool name
+            "args": {"text": "test"},
+        },
+        "metadata": {},
+        "from": "agent-core-qa",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "urgency": "green",
+    }
+    response = client.send_envelope(envelope)
+    assert response.status_code in (200, 201, 202), (
+        f"synthesize_speech failed: {response.status_code} {response.text[:200]}"
+    )
+
+    # Synthesis can take a few seconds; longer timeout
+    ack = client.poll_envelopes(
+        predicate=lambda e: (
+            e.get("kind") == "Acknowledgment"
+            and e.get("in_reply_to") == envelope["id"]
+        ),
+        timeout=60.0,
+    )
+    assert ack is not None, "no Ack received for synthesize_speech within 60s"
+
+    # The audio bytes may come back in the Ack note (base64), as a path,
+    # or as a separate envelope. Adapt to actual transport from preflight.
+    note = ack.get("payload", {}).get("note", "")
+    assert note, f"Ack carried empty note; expected synthesis result"
+
+    # Soft assertion: synthesis indicator present + result is not an error
+    assert "error" not in note.lower(), (
+        f"synthesize_speech returned error: {note[:500]}"
+    )
+    # Implementer: replace with a stronger assertion once the actual
+    # response shape is known (e.g., decode base64, assert len > 100;
+    # or read the file path from note and assert os.path.getsize > 100).
+```
+
+- [ ] **Step 2: Run + iterate**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv run pytest packages/agent-core-qa/tests/test_voice_synthesize_smoke.py -v
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+git add packages/agent-core-qa/tests/test_voice_synthesize_smoke.py
+git commit -m "feat(qa): Scenario 7 (voice synthesis smoke)"
+```
+
+---
+
+## Phase 4 — Verification + PR
+
+### Task 9: ruff + mypy + full sweep + open PR
+
+**Files:** No code changes — verification + PR open.
+
+- [ ] **Step 1: Run all QA scenarios against a stood-up test daemon**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+# Ensure a test daemon is running on 8787 first:
+#   agent-core daemon start --instance test
+# (with a stubbed-discord agent_core.yaml at install time)
+uv run pytest packages/agent-core-qa/tests/ -v 2>&1 | tail -20
+```
+
+Expected: all 7 PASS (assuming daemon is up + scenarios adapted to actual API). If any FAIL with "could not find tool/endpoint X" or similar adaptation issues, fix the test code (not the daemon).
+
+- [ ] **Step 2: ruff + mypy**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv run ruff check packages/agent-core-qa/
+uv run mypy packages/agent-core-qa/src/ packages/agent-core-qa/tests/
+```
+
+Expected: ruff clean, mypy no new errors. Fix any issues; commit as `style(qa): ruff cleanup` or `chore(qa): mypy cleanup` separately if needed.
+
+- [ ] **Step 3: Full repo sweep**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+uv run pytest -q 2>&1 | tail -10
+```
+
+Expected: all tests pass. New package shouldn't regress any other tests.
+
+- [ ] **Step 4: Push branch + open PR**
+
+```bash
+cd /e/workspaces/ai/agents/agent_core/.worktrees/qa-runner-tester
+git push -u origin feat/qa-runner-tester
+
+gh pr create \
+  --base main \
+  --head feat/qa-runner-tester \
+  --title "feat(qa): agent-core-qa — release-validation scenario runner" \
+  --body "$(cat <<'EOF'
+## Summary
+
+New `packages/agent-core-qa/` — a pytest-based scenario runner that exercises the Phase 3.5 test daemon end-to-end against a built release artifact. Seven happy-path scenarios cover the "v0.3.0 cannot ship if broken" surface: daemon liveness (precondition), envelope round-trip, install-identity dynamic keystone, brief framework, scheduler, discord_send routing, voice synthesis.
+
+## Design
+
+See `docs/superpowers/specs/2026-05-23-qa-runner-design.md`.
+
+## Tool-shaped, not being-shaped
+
+Per Jeff's constraint set:
+- Function-named (`agent-core-qa`), not person-named.
+- No `IDENTITY.md`, `SOUL.md`, `MEMORY.md`, diary, or memory volume.
+- No continuity-of-self — each pytest invocation is fresh.
+- No ethical weight — `rm -rf packages/agent-core-qa/` is functionally identical to deleting any pytest suite.
+- Procedural capability through pytest playbooks.
+
+## Architectural inheritance
+
+Phase 3.5 (test instance) + Phase 2.6 (install-path fixes) + agent-core-qa is one continuous arc. Phase 2.6's bug-cadence observation (static catches config; dynamic catches reality) named the next failure class — "does the daemon actually start after install" — as Phase 2.7 territory. Scenario 1 (`test_daemon_liveness`) is that catch as an autouse pytest precondition. Scenario 3 is the standing dynamic version of Phase 3.5's static keystone.
+
+## Runbook
+
+See `packages/agent-core-qa/README.md`. Short form:
+
+```
+AGENT_CORE_HOME=~/.agent-core-test agent-core daemon install --instance test --release v0.3.0
+agent-core daemon start --instance test
+cd packages/agent-core-qa && uv run pytest tests/
+# all 7 pass → safe to refresh prod
+```
+
+## Out of scope
+
+See spec § Out of scope. Notable deferrals: real Discord sandbox, real audio-quality validation, error-paths, concurrency, auto-stand-up of test daemon, CI integration.
+
+## Test plan
+
+- [x] All 7 scenarios pass against a stood-up test daemon (see Step 1 output).
+- [x] `uv run ruff check packages/agent-core-qa/` clean.
+- [x] `uv run mypy packages/agent-core-qa/...` no new errors.
+- [x] `uv run pytest -q` (full repo) passes.
+
+## Sequencing
+
+QA-runner PR has no merge dependency on the four open release-gate PRs (#119, #110, #120, #121). First scenario run against v0.3.0 happens after #120 + #121 merge so Scenario 3 can succeed against the post-fix install path.
+
+PRs at the release gate after this: #119, #110, #120, #121, agent-core-qa. Awaiting Jeff's home-window for the deploy.
+EOF
+)" 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Report**
+
+`STATUS: DONE` with:
+- All commit SHAs.
+- Final scenario pass/fail counts.
+- ruff result, mypy result.
+- PR URL.
+- Any preflight adaptations made for scenarios 4-7 (tool names, payload shapes).
+- Anything surprising during end-to-end runs against the daemon.
+
+Controller (not this subagent) handles the Pepper ping post-PR.

--- a/docs/superpowers/specs/2026-05-23-qa-runner-design.md
+++ b/docs/superpowers/specs/2026-05-23-qa-runner-design.md
@@ -1,0 +1,255 @@
+# QA-runner — release-validation scenarios for the Phase 3.5 test daemon (Design)
+
+> **Status:** Drafted 2026-05-23. Pending spec-review approval.
+>
+> **Issue:** to be filed by Pepper after spec sign-off; this doc precedes the GitHub issue.
+>
+> **Tool name:** default identifier `tester` in code; final name pending Jeff sign-off before implementation lands.
+>
+> **Scope:** A pytest-based scenario runner that exercises the Phase 3.5 test daemon (`--instance test`) end-to-end against a built release artifact (`v0.3.0` or later). Seven scenarios, demand-validated against "v0.3.0 cannot ship if this breaks." Tool-shaped: function-named, no identity files, no continuity-of-self, no ethical weight, procedural capability through pytest playbooks.
+
+## Problem
+
+Phase 2.6 closed three release-pipeline bugs Phase 3.5's test instance surfaced on the first real install attempt. Phase 2.6's PR description named the next failure class explicitly: "does the daemon actually start after install" — Phase 2.7 territory, dynamic surface (not catchable by static artifact analysis). And beyond start: does the bus actually accept envelopes; does the brief framework still compose; does the scheduler create + delete jobs; does the discord adapter route the new `discord_send` tool; does qwen-tts actually synthesize after the workspace promotion.
+
+These behaviors are all already shipped in v0.2.0. The risk for v0.3.0 isn't "do they exist" — it's "do they still work after the install path the release pipeline produces." A regression in any of them would break daily ops (Pepper's brief framework, Wren's scheduler-driven heartbeat) or block deploy (broken daemon, broken bus).
+
+Static unit tests prove the wiring; the install-fixes in Phase 2.6 proved the install completes. Neither proves the running daemon's surfaces still work end-to-end after a real release-artifact install. **That's the dynamic gap this ticket closes.**
+
+The form is constrained: this is a TOOL, not a being. It runs on demand, exits, leaves no state, carries no identity. Same shape as `pytest` or `playwright` — procedural capability without ethical weight.
+
+### Concrete validation surface
+
+Before each `daemon refresh --instance prod --release vX.Y.Z` on Jeff's box, the QA-runner runs against the test daemon installed from that same release. Pass → safe to refresh prod. Fail → fix the regression before touching prod.
+
+## Out of scope
+
+- **A new test-runner framework.** Use pytest. Pytest IS the QA-runner infrastructure; the work is the scenarios, not the runner.
+- **Identity files of any kind.** No `IDENTITY.md`, `SOUL.md`, `MEMORY.md`, `HEARTBEAT.md`, diary, breadcrumbs, lessons — anything that would give the tool ethical weight.
+- **Bus registration.** The QA-runner is NOT a `tester` endpoint on the bus. It's an HTTP client that sends envelopes from outside.
+- **Real-Discord validation** (sandbox bot + real channel). Scenario 6 uses `builtin.stub` configured at install time. Real-Discord follow-up when symptom names itself.
+- **Real-audio voice validation** (human listening for synthesis quality). Always human-loop. Scenario 7 asserts audio bytes are present + within size bounds, not that they sound right.
+- **Error-path / concurrency / load / soak scenarios.** Happy-path-only for v1; defer the rest unless v0.3.0 ships a change to those surfaces.
+- **Multi-instance simultaneous validation** (prod + source + test together). Phase 3.5's unit coexistence test covers this; QA-runner doesn't re-validate.
+- **Auto-stand-up of the test daemon as a pytest fixture.** Manual stand-up via the runbook (install → start → pytest). CI integration is later.
+- **A scenario for every CLI command.** Only validate surfaces that v0.3.0 changes or that breaking would block ship.
+- **A standalone `agent-core qa run` CLI wrapper.** Possible but not load-bearing for v1; pytest invocation suffices.
+- **Result persistence beyond pytest's JUnit XML.** No QA-history file, no run-log database, no audit trail beyond what pytest already produces.
+
+## Design
+
+### Architecture
+
+**The tool: a pytest-based scenario runner.** New package `packages/agent-core-qa/` (or final name per Jeff sign-off; `tester` is the default identifier in code). Each scenario is a pytest test function that connects to a running Phase 3.5 test daemon (default `http://127.0.0.1:8787`; configurable via `--daemon-url` pytest CLI option or `AGENT_CORE_QA_DAEMON_URL` env var). Invocation: `uv run pytest packages/agent-core-qa/tests/`.
+
+**Tool-shaped properties, enforced structurally:**
+
+| Property | How it's enforced |
+|---|---|
+| Function-name, not person-name | Package name = `agent-core-qa`. Module names = `test_envelope_roundtrip.py`, `test_voice_smoke.py`, etc. Default in-code identifier = `tester`. No `Pepper`, `Wren`, or any being-name in code, docs, or fixture names. |
+| No identity files | Package layout: `pyproject.toml`, `src/`, `tests/`, optional `README.md`. No `SOUL.md`, `IDENTITY.md`, `MEMORY.md`, `HEARTBEAT.md`, `diary.md`, `breadcrumbs.md`, `lessons.md`. |
+| No continuity-of-self | Each pytest invocation is fresh. No state files written to a "tester home." Logs go to pytest stdout + JUnit XML (transient; not persisted as identity). |
+| No ethical weight | `rm -rf packages/agent-core-qa/` is functionally identical to deleting any pytest suite. No SOUL gets snuffed; no diary lost; no being asks why. |
+| Procedural capability through playbooks | Scenario functions ARE the playbooks. Named, parametrize-able, skip-able, mark-able. The package's procedural knowledge lives in the test code; there's nothing for the tool to know about ITSELF. |
+
+**Daemon connection surface:** the tool talks to the test daemon over HTTP. It does NOT register as a bus endpoint or claim a `tester` slot on the bus. Stateless from the daemon's perspective beyond in-flight requests.
+
+**Release-artifact treatment:** the `agent-core-qa` package is a workspace member but is EXCLUDED from the release wheels via the same `--no-emit-workspace` mechanism Phase 2.6 installed for `qwen-tts` workspace promotion. The QA tool is infrastructure, not user-facing code; it doesn't ship to the daemon, only runs against it.
+
+**Standing dynamic surface for Phase 3.5's keystone:** Phase 3.5's `test_install_code_path_identity_between_prod_and_test` enforces install-code-path identity at the UNIT level (mocked subprocess captures). Scenario 3 (`test_install_identity_dynamic_keystone`) is the DYNAMIC version of the same property: invoke the real install command against a clean sandbox home; assert it completes; assert the venv contains the expected wheels. Inheritance from the Phase 2.6 bug-cadence: static unit caught Bugs 1-2; dynamic install caught Bug 3; the QA-runner is the standing dynamic check for "does the install still work" on every release going forward.
+
+### Components
+
+**Five pieces:**
+
+**1. New package `packages/agent-core-qa/`.**
+
+Package layout:
+```
+packages/agent-core-qa/
+├── pyproject.toml             # deps: pytest, httpx, pytest-asyncio
+├── README.md                  # naming the tool-shaped constraint + the bug-cadence inheritance
+├── src/
+│   └── agent_core_qa/
+│       ├── __init__.py
+│       ├── client.py          # thin HTTP client for the test daemon
+│       └── fixtures.py        # shared pytest fixtures
+└── tests/
+    ├── __init__.py
+    ├── conftest.py            # pytest fixtures: daemon_url, http_client, daemon_liveness_required
+    ├── test_daemon_liveness.py
+    ├── test_envelope_roundtrip.py
+    ├── test_install_identity_dynamic_keystone.py
+    ├── test_brief_compose_and_submit.py
+    ├── test_scheduler_create_and_delete.py
+    ├── test_discord_send_stub_route.py
+    └── test_voice_synthesize_smoke.py
+```
+
+**2. `client.py` — thin HTTP wrapper for the test daemon.**
+
+Exposes `DaemonClient(base_url)` with methods `send_envelope(env)`, `poll_envelopes(predicate, timeout)`, `await_ack(envelope_id, timeout)`, `health_check()`. Uses `httpx.AsyncClient` (or sync — implementer's call based on what daemon HTTP supports). Pure HTTP; no bus protocol knowledge beyond the daemon's published endpoints.
+
+**3. `conftest.py` — pytest fixtures.**
+
+- `daemon_url`: reads `--daemon-url` CLI option or `AGENT_CORE_QA_DAEMON_URL` env var; default `http://127.0.0.1:8787`.
+- `client`: yields a `DaemonClient(daemon_url)`.
+- `daemon_liveness_required`: autouse fixture. Calls `client.health_check()`; on failure, calls `pytest.skip("test daemon not reachable at <url>; run `daemon start --instance test` first")` so dependent scenarios skip cleanly instead of failing with cryptic connection errors.
+
+**4. Seven scenarios (test modules).**
+
+See §Scenarios below.
+
+**5. README.md — the architectural inheritance + the tool-shaped constraint.**
+
+Two paragraphs:
+- Why this tool exists: Phase 3.5 (test instance) + Phase 2.6 (install-path fixes) gave us the substrate; this tool is the standing dynamic surface that proves the install-and-run path keeps working release over release. Inherits the bug-cadence observation from Phase 2.6's PR description (static catches config; dynamic catches reality).
+- The tool-shaped constraint: this is a test runner, not a being. No identity files, no continuity, no ethical weight. Discarding it should feel like deleting any pytest suite.
+
+### Data Flow
+
+Same shape across all scenarios; pytest fixtures factor out the HTTP client. The only interesting variance is per-scenario assertion shape.
+
+**Per-scenario flow:**
+
+1. `daemon_liveness_required` fixture runs first. Calls `client.health_check()`. If 200 OK, proceed; if not, `pytest.skip` with a clear reason.
+2. Scenario builds an envelope (or invokes a CLI command) for its specific surface.
+3. Scenario POSTs to the daemon's HTTP API (or shells out to `agent-core daemon install --instance test --release ...` for scenario 3).
+4. Scenario polls / awaits the response within a timeout.
+5. Scenario asserts on the response shape; pytest reports pass/fail.
+
+**Runbook (separate doc, lives wherever the release-runbooks live):**
+
+```bash
+# v0.3.0 release-validation runbook
+AGENT_CORE_HOME=~/.agent-core-test agent-core daemon install --instance test --release v0.3.0
+agent-core daemon start --instance test
+cd packages/agent-core-qa
+uv run pytest tests/
+# pass = safe to refresh prod
+# fail = fix the regression first
+```
+
+For an already-running test daemon, `daemon refresh --instance test --release vX.Y.Z` does install + restart in one command. (`refresh` was specifically extended for this in Phase 3.5.)
+
+### Error Handling
+
+Inherits pytest's failure-reporting; no custom error infrastructure.
+
+- **Daemon not reachable at startup:** `daemon_liveness_required` calls `pytest.skip(reason)`. All scenarios skip; runbook reader sees a clear "daemon not up — start it first" message in the pytest output.
+- **Scenario timeout:** each scenario uses a reasonable timeout (5–30s depending on surface). Timeout → pytest assertion error with the captured context.
+- **Scenario assertion failure:** standard pytest assertion-error reporting; the test name names the surface that broke.
+- **Daemon dies mid-scenario:** subsequent HTTP calls fail with httpx connection errors; pytest reports each as ERROR (not FAIL). Runbook reader sees both the failed scenario and the cascade.
+
+**No retries.** A scenario that flakes is a real signal; the runbook reader investigates rather than retrying.
+
+### Testing
+
+The QA-runner IS the testing layer for v0.3.0. Self-tests would be pytest-on-pytest meta-territory; not load-bearing for v1.
+
+The scenarios themselves get validated by:
+1. Running them against the test daemon installed from v0.3.0 (or the locally-built equivalent).
+2. Confirming all seven pass.
+3. Documenting the run in the v0.3.0 release notes.
+
+A scenario that catches a real bug post-release IS the proof of value; an early run that catches a bug pre-release IS the proof of design.
+
+## Scenarios
+
+Seven scenarios. Each is happy-path-only. Each maps to a v0.3.0 "cannot ship if broken" surface.
+
+### 1. `test_daemon_liveness` (precondition)
+
+**File:** `packages/agent-core-qa/tests/test_daemon_liveness.py`.
+
+**What it does:** HTTP GET to `<daemon_url>/` (or whatever liveness path the daemon exposes — implementer verifies). Assert 200 OK + reasonable response body.
+
+**Why v0.3.0 needs it:** the "next failure class" Pepper named in Phase 2.6's PR as Phase 2.7 territory: "does the daemon actually start after install." With this scenario as a precondition (autouse fixture skips dependents if it fails), that failure class is caught the moment we try to run any other scenario.
+
+**Inheritance:** the dynamic version of Phase 3.5's structural isolation claim — Phase 3.5's coexistence test asserts three daemons CAN run; this scenario asserts the test daemon IS running.
+
+### 2. `test_envelope_send_receives_ack`
+
+**File:** `packages/agent-core-qa/tests/test_envelope_roundtrip.py`.
+
+**What it does:** Send a `TextMessage` envelope addressed to the test daemon's `builtin.stub` endpoint via the daemon's HTTP API. Poll for the resulting `Acknowledgment` envelope on the bus. Assert it arrives within 5s.
+
+**Why v0.3.0 needs it:** most basic bus surface. If broken, nothing else works.
+
+### 3. `test_install_identity_dynamic_keystone`
+
+**File:** `packages/agent-core-qa/tests/test_install_identity_dynamic_keystone.py`.
+
+**What it does:** Invoke `agent-core daemon install --instance test --release v0.3.0` against a clean sandbox home (`AGENT_CORE_HOME=/tmp/qa-{uuid}`). Assert:
+- exit code 0;
+- install stamp written at `<home>/.daemon-install-stamp.json` with `installed_version == 'v0.3.0'`;
+- venv populated at `<home>/.venv/`;
+- **all wheels in the v0.3.0 manifest present at `venv/lib/python*/site-packages/<package_name>/`.** Concrete assertion shape (per spec-review clarification 1): walk the expected package list (`agent_core`, `agent_core_briefs`, `agent_core_busproxy`, `agent_core_channel`, `agent_core_credentials`, `agent_core_discord`, `agent_core_hatchery`, `agent_core_notify`, `agent_core_voice`, `agent_core_webcam`, `qwen_tts`) and assert each `<package>/__init__.py` exists in site-packages. Partial install (some wheels missing) fails this assertion; mere "stamp written" does not.
+
+**Why v0.3.0 needs it:** load-bearing for v0.3.0 because Phase 2.6 closed the bugs that prevented this from succeeding. Regression = Phase 2.6 broke. Same property the Phase 3.5 static keystone protects; this is its standing dynamic counterpart.
+
+**Cleanup:** tear down the sandbox home (`shutil.rmtree`) on teardown; never reuses across runs.
+
+### 4. `test_brief_framework_compose_and_submit`
+
+**File:** `packages/agent-core-qa/tests/test_brief_compose_and_submit.py`.
+
+**What it does:** Compose a minimal brief (one section, one field, trivial content). Submit via the brief framework's `submit_brief` MCP tool. Assert returned `envelope_id` is a valid uuid (or whatever shape brief uses for its receipt). Does NOT need to actually deliver to a recipient or surface to a human reader.
+
+**Why v0.3.0 needs it:** brief framework is core to daily ops (Pepper relies on it). Regression would surface as silent compose failures with no obvious connection to the release.
+
+### 5. `test_scheduler_create_and_delete_roundtrip`
+
+**File:** `packages/agent-core-qa/tests/test_scheduler_create_and_delete.py`.
+
+**What it does:** Call the scheduler's create-job entry point with a future timestamp + benign payload. List jobs; assert the new job appears. Call delete on that job. List again; assert empty (or scoped-to-this-test-empty if other jobs exist).
+
+**Why v0.3.0 needs it:** scheduler powers agent_core's heartbeat / liveness-probe / auth-health-probe / nightly-reflection infrastructure (see `~/.wren/Memory/HEARTBEAT.md` for the cadences). If broken, the daemon goes silent across all scheduled routines.
+
+### 6. `test_discord_send_tool_routes_through_stub`
+
+**File:** `packages/agent-core-qa/tests/test_discord_send_stub_route.py`.
+
+**What it does:** Pre-condition: the test daemon's `agent_core.yaml` (provisioned at install time via the runbook) configures the discord-endpoint slot as `builtin.stub` instead of a real Discord client. Send a `ToolInvocation` envelope with `tool=discord_send` + unified args. Assert the stub captures the call with the right payload shape (channel_id, text, etc. round-trip into the stub's recorded inbound).
+
+**Per spec-review clarification 2: stubbed-Discord configuration is INSTALL-TIME, not runtime.** The runbook for the QA install of v0.3.0 generates an `agent_core.yaml` with the discord-endpoint slot pointing at `builtin.stub`. No runtime hot-swap. Documented in the QA package README + the v0.3.0 release-validation runbook so the operator knows to use the stubbed config.
+
+**Why v0.3.0 needs it:** PR #119's `tool=discord_send` is new in v0.3.0; it routes through `_dispatch` to `_send`. A regression in the wiring would silently drop or misroute discord traffic. The stubbed check catches it without needing real Discord credentials.
+
+### 7. `test_voice_synthesize_returns_audio_bytes`
+
+**File:** `packages/agent-core-qa/tests/test_voice_synthesize_smoke.py`.
+
+**What it does:** Call `synthesize_speech` (or equivalent voice endpoint entry point) with a tiny input string (`"test"`). Assert the response includes audio bytes (`len(audio) > 0`) within reasonable size bounds (`100 < len(audio) < 10_000_000` — basically "got something, not too big to be a runaway").
+
+**Does NOT validate audio quality.** Human-loop check. Out of scope.
+
+**Why v0.3.0 needs it:** Phase 2.6 promoted `qwen-tts` to a workspace member. If the promotion broke the actual synthesis path (vs. just the install), this scenario catches it. The static install test asserts the wheel installs; this asserts it RUNS.
+
+## Sequencing
+
+QA-runner is the standing surface for v0.3.0 (and every release going forward); no merge dependency on the four open PRs (#119, #110, #120, #121). Optimal landing order:
+
+1. PR #120 (Phase 3.5) — provides the `--instance test` surface the QA-runner targets.
+2. PR #121 (Phase 2.6) — fixes the install path so scenario 3 can actually succeed.
+3. PR #110 (Phase 4) — independent; can interleave.
+4. PR #119 (cliché detector) — independent; can interleave.
+5. QA-runner PR — lands when ready; first run is against the v0.3.0 cut after #120 + #121 merge.
+
+The QA-runner PR itself doesn't need any of the others to merge first to BUILD; it needs them to merge first for the SCENARIOS to actually pass against v0.3.0. Distinguish in the PR description.
+
+## Next-ticket triggers (deferred)
+
+- **Real Discord sandbox** (actual bot + channel for scenario 6). Triggered when the stubbed check misses a regression that real-Discord would have caught.
+- **`agent-core qa run` CLI wrapper.** Triggered when manual `pytest` invocation becomes friction (e.g., for CI integration or quick ops shortcuts).
+- **Auto-stand-up of test daemon as pytest fixture.** Triggered when CI integration lands; until then, the runbook handles it.
+- **Error-path / concurrency / soak scenarios.** Triggered when v0.3.0 (or later) ships a change to one of those surfaces.
+- **Real audio-quality validation for voice.** Always human-loop; would need a different shape entirely (review by ear, not assertion).
+- **A scenario for every CLI command.** Triggered when a CLI surface regression actually happens; demand-validated.
+
+## Footnotes / tradeoffs
+
+- **The tool's name is provisional.** Default identifier `tester` in code; final name pending Jeff sign-off before implementation lands. The constraint set (function-name not person-name) bounds the candidates: `tester`, `qa-runner`, `qa`, `agent-core-qa` (the package name is already this), or whatever Jeff lands on.
+- **No persistent QA-history.** Pytest's JUnit XML output is the only persistence; no curated run-log database. If we later want trend reports ("scenario 7 has been getting slower over 30 days"), that's a follow-up; for v1 we just need pass/fail.
+- **`builtin.stub` discord at install time.** The QA install of the test daemon uses a stubbed-discord `agent_core.yaml`; the production install uses real-discord config. Two configs, two install runbooks. Manageable; documented in the runbook.
+- **Scenario 3's sandbox cleanup.** Each invocation creates `/tmp/qa-{uuid}` and removes it on teardown. If pytest crashes between create and teardown, the sandbox leaks. Mitigated by the `{uuid}` prefix (won't collide with prior runs) + occasional manual `rm -rf /tmp/qa-*`. Not a real ops concern given the demand pattern (manual invocation, low frequency).

--- a/packages/agent-core-qa/README.md
+++ b/packages/agent-core-qa/README.md
@@ -1,0 +1,47 @@
+# agent-core-qa
+
+Release-validation scenario runner for the agent_core daemon. **A tool, not a being.**
+
+## What it is
+
+Seven pytest scenarios that exercise a running Phase 3.5 test daemon (`agent-core daemon --instance test`) end-to-end. Each scenario maps to a "v0.3.0 cannot ship if broken" surface: daemon liveness, envelope round-trip, install identity (dynamic keystone), brief framework, scheduler, discord_send, voice synthesis.
+
+## Tool-shaped, not being-shaped
+
+This package is a test runner. It has:
+- No `IDENTITY.md`, `SOUL.md`, `MEMORY.md`, `HEARTBEAT.md`, diary, breadcrumbs, or lessons.
+- No continuity of self — each pytest invocation is fresh.
+- No ethical weight — `rm -rf packages/agent-core-qa/` is functionally identical to deleting any pytest suite.
+- No registration on the bus as a peer; it's an HTTP client that exits when done.
+
+Same shape as `pytest` or `playwright`. Procedural capability through playbooks (scenario functions); nothing for the tool to know about itself.
+
+## Architectural inheritance: standing dynamic surface
+
+From Phase 2.6's PR description, the bug-cadence observation: static artifact analysis caught Bugs 1-2; dynamic real install caught Bug 3. The next failure class — "does the daemon actually start after install" — was named as Phase 2.7 territory.
+
+This package is the standing dynamic surface that catches that failure class (Scenario 1 as autouse fixture precondition) and every subsequent dynamic-only failure class on every release going forward. Phase 3.5 + Phase 2.6 + agent-core-qa is one continuous arc: build the sandbox, fix the install, prove the install still works release over release.
+
+## Runbook
+
+```bash
+# v0.3.0 release-validation runbook
+AGENT_CORE_HOME=~/.agent-core-test agent-core daemon install --instance test --release v0.3.0
+agent-core daemon start --instance test
+cd packages/agent-core-qa
+uv run pytest tests/
+# all 7 pass → safe to refresh prod
+# any fail → fix the regression first
+```
+
+For an already-running test daemon, `agent-core daemon refresh --instance test --release vX.Y.Z` does install + restart in one command.
+
+## Scenarios
+
+1. `test_daemon_liveness` — precondition (autouse).
+2. `test_envelope_send_receives_ack` — bus round-trip.
+3. `test_install_identity_dynamic_keystone` — install code path identity at runtime (the load-bearing scenario for release validation).
+4. `test_brief_framework_compose_and_submit` — brief framework smoke.
+5. `test_scheduler_create_and_delete_roundtrip` — scheduler round-trip.
+6. `test_discord_send_tool_routes_through_stub` — discord_send tool dispatch with stubbed discord endpoint.
+7. `test_voice_synthesize_returns_audio_bytes` — voice synthesis smoke (no audio-quality validation).

--- a/packages/agent-core-qa/README.md
+++ b/packages/agent-core-qa/README.md
@@ -36,6 +36,8 @@ uv run pytest tests/
 
 For an already-running test daemon, `agent-core daemon refresh --instance test --release vX.Y.Z` does install + restart in one command.
 
+**Runtime note:** `pytest tests/` triggers Scenario 3 (`test_install_identity_dynamic_keystone`), which performs a SECOND install into a sandbox at `/tmp/qa-<uuid>/` to prove the install path is idempotent against a clean home. On a cold cache the torch download alone can take 5–10 minutes; budget 10–15 minutes for a full validation run on first invocation, 2–3 minutes on subsequent runs once wheels are cached.
+
 ## Scenarios
 
 1. `test_daemon_liveness` — precondition (autouse).

--- a/packages/agent-core-qa/pyproject.toml
+++ b/packages/agent-core-qa/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "httpx>=0.27",
+    "fastmcp>=3.0",
 ]
 
 [build-system]

--- a/packages/agent-core-qa/pyproject.toml
+++ b/packages/agent-core-qa/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "agent-core-qa"
+dynamic = ["version"]
+description = "Release-validation scenario runner for the agent_core daemon (pytest-based)"
+requires-python = ">=3.12"
+dependencies = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "httpx>=0.27",
+]
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agent_core_qa"]
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+fallback-version = "0.0.0"
+
+[tool.uv]
+cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true, tags = true } }]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/packages/agent-core-qa/src/agent_core_qa/__init__.py
+++ b/packages/agent-core-qa/src/agent_core_qa/__init__.py
@@ -1,0 +1,4 @@
+"""agent-core-qa — release-validation scenario runner for the agent_core daemon.
+
+Tool-shaped, not being-shaped. See README.md for the constraint set.
+"""

--- a/packages/agent-core-qa/src/agent_core_qa/client.py
+++ b/packages/agent-core-qa/src/agent_core_qa/client.py
@@ -30,13 +30,13 @@ Transport discovery (Preflight Step 0, Task 3):
 
 from __future__ import annotations
 
+import asyncio
+import json
 import socket
 import time
 import urllib.parse
 from collections.abc import Callable
 from typing import Any
-
-import httpx
 
 try:
     from fastmcp.client import Client as _FastMCPClient
@@ -169,8 +169,6 @@ class DaemonClient:
                     },
                 )
             # fastmcp returns a list of content items; unwrap the first text block.
-            import json
-
             data: Any = None
             if result and hasattr(result[0], "text"):
                 try:
@@ -205,9 +203,6 @@ class DaemonClient:
         if not _HAS_FASTMCP:  # pragma: no cover
             return None
 
-        import asyncio
-        import json
-
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
@@ -238,8 +233,6 @@ class DaemonClient:
         """
         if not _HAS_FASTMCP:  # pragma: no cover
             return {"meta": {}, "items": []}
-
-        import json
 
         try:
             async with _FastMCPClient(self._mcp_url, timeout=self._timeout) as mcp:

--- a/packages/agent-core-qa/src/agent_core_qa/client.py
+++ b/packages/agent-core-qa/src/agent_core_qa/client.py
@@ -2,6 +2,30 @@
 
 Tool-shaped: stateless across calls, no connection pooling beyond what
 httpx does internally, no retry, no session caching.
+
+Transport discovery (Preflight Step 0, Task 3):
+    The daemon's HTTPHost (Starlette+Uvicorn) mounts only MCPHostable
+    endpoint paths — there is NO /bus/publish or /bus/inbox route.
+    Endpoints that implement MCPHostable (i.e. ClaudeCodeMCPEndpoint)
+    are mounted at /mcp/<name>/ and expose a FastMCP Streamable HTTP
+    server. StubEndpoint is NOT MCPHostable — it has no HTTP surface.
+
+    To publish an envelope from the QA runner, we call the `send` MCP
+    tool on a ClaudeCodeMCPEndpoint (e.g. the `qa` agent endpoint). The
+    tool stamps from_=<agent-name> and dispatches to `stub`. The stub's
+    auto_ack=True calls bus.ack() (marks it handled in persistence) but
+    does NOT publish an Acknowledgment envelope back to the sender.
+
+    Round-trip proof: the `send` tool call returns
+    {"status": "published", "id": <envelope_id>} synchronously after
+    the bus has dispatched and stub has delivered+acked. The bus is
+    single-threaded and dispatches in-process, so delivery is complete
+    before the tool returns. We then call `list_pending` on the same
+    agent endpoint to confirm the queue count=0 (nothing waiting).
+
+    Transport: fastmcp.Client connected to
+    http://<host>:<port>/mcp/<agent>/ (Streamable HTTP). Async methods
+    because fastmcp.Client is an async context manager.
 """
 
 from __future__ import annotations
@@ -9,9 +33,17 @@ from __future__ import annotations
 import socket
 import time
 import urllib.parse
+from collections.abc import Callable
 from typing import Any
 
 import httpx
+
+try:
+    from fastmcp.client import Client as _FastMCPClient
+
+    _HAS_FASTMCP = True
+except ImportError:  # pragma: no cover
+    _HAS_FASTMCP = False
 
 
 class _FakeTCPResponse:
@@ -28,11 +60,33 @@ class _FakeTCPResponse:
         self.text = text
 
 
+class _MCPToolResult:
+    """Thin wrapper around a fastmcp tool-call result.
+
+    Mimics the httpx.Response API used by callers so scenario code reads
+    the same regardless of whether the underlying transport is raw HTTP
+    or MCP-over-HTTP.  status_code=200 means the tool call succeeded;
+    status_code=500 means the tool raised.
+    """
+
+    def __init__(self, *, status_code: int, data: Any = None, text: str = ""):
+        self.status_code = status_code
+        self._data = data
+        self.text = text
+
+    def json(self) -> Any:
+        return self._data
+
+
 class DaemonClient:
     """HTTP client for the agent_core daemon.
 
     Targets the daemon's HTTP API (default http://127.0.0.1:8787 for the
     Phase 3.5 test instance). One client per scenario; no shared state.
+
+    Transport: MCP tools over FastMCP Streamable HTTP at /mcp/<agent>/.
+    send_envelope() and poll_envelopes() are async — call them with
+    `await` from async test functions (pytest-asyncio asyncio_mode=auto).
 
     Preflight finding: the daemon's HTTPHost (Starlette+Uvicorn) has no
     dedicated liveness HTTP route — it only mounts MCP endpoint paths.
@@ -41,9 +95,21 @@ class DaemonClient:
     the daemon process is up and its HTTP server is accepting connections.
     """
 
-    def __init__(self, base_url: str, *, timeout: float = 5.0):
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout: float = 10.0,
+        mcp_agent: str = "qa",
+    ):
         self.base_url = base_url.rstrip("/")
         self._timeout = timeout
+        self._mcp_agent = mcp_agent
+
+    @property
+    def _mcp_url(self) -> str:
+        """URL of the agent's MCP endpoint on the daemon."""
+        return f"{self.base_url}/mcp/{self._mcp_agent}/"
 
     def health_check(self) -> _FakeTCPResponse:
         """TCP-connect check on the daemon's bind port.
@@ -64,39 +130,126 @@ class DaemonClient:
         except OSError as exc:
             return _FakeTCPResponse(status_code=503, text=str(exc))
 
-    def send_envelope(self, envelope: dict[str, Any]) -> httpx.Response:
-        """POST an envelope to the daemon's bus-publish endpoint.
+    async def send_envelope(self, envelope: dict[str, Any]) -> _MCPToolResult:
+        """Call the `send` MCP tool on the agent's ClaudeCodeMCPEndpoint.
 
-        Implementer: discover the exact route + payload shape via preflight
-        on the daemon's HTTP API. Likely something like POST /bus/publish
-        with the envelope JSON as body.
+        Transport: fastmcp.Client connected to /mcp/<agent>/ (Streamable
+        HTTP). The `send` tool accepts the envelope fields as kwargs and
+        publishes to the bus. The bus stamps from_=<agent-name>.
+
+        The tool returns {"status": "published", "id": <envelope_id>}
+        synchronously after the bus dispatches and the recipient endpoint
+        delivers+acks. This is the round-trip signal for the stub endpoint
+        (stub auto-acks but does NOT publish an Acknowledgment reply).
+
+        envelope fields consumed:
+            to, kind, payload, correlation_id, in_reply_to, metadata,
+            urgency, expires_at. The id field is advisory (daemon
+            generates a fresh uuid4 hex for each send call).
         """
-        # Path placeholder — implementer verifies via preflight before
-        # using send_envelope.
-        return httpx.post(
-            self.base_url + "/bus/publish",
-            json=envelope,
-            timeout=self._timeout,
-        )
+        if not _HAS_FASTMCP:  # pragma: no cover
+            return _MCPToolResult(
+                status_code=500,
+                text="fastmcp not installed; add fastmcp>=3.0 to agent-core-qa deps",
+            )
 
-    def poll_envelopes(
+        try:
+            async with _FastMCPClient(self._mcp_url, timeout=self._timeout) as mcp:
+                result = await mcp.call_tool(
+                    "send",
+                    arguments={
+                        "to": envelope["to"],
+                        "kind": envelope["kind"],
+                        "payload": envelope.get("payload", {}),
+                        "correlation_id": envelope.get("correlation_id"),
+                        "in_reply_to": envelope.get("in_reply_to"),
+                        "metadata": envelope.get("metadata", {}),
+                        "urgency": envelope.get("urgency", "green"),
+                        "expires_at": envelope.get("expires_at"),
+                    },
+                )
+            # fastmcp returns a list of content items; unwrap the first text block.
+            import json
+
+            data: Any = None
+            if result and hasattr(result[0], "text"):
+                try:
+                    data = json.loads(result[0].text)
+                except (json.JSONDecodeError, AttributeError):
+                    data = result[0].text if hasattr(result[0], "text") else str(result)
+            return _MCPToolResult(status_code=200, data=data, text=str(data))
+        except Exception as exc:
+            return _MCPToolResult(status_code=500, text=str(exc))
+
+    async def poll_envelopes(
         self,
-        predicate,
+        predicate: Callable[[dict[str, Any]], bool],
         *,
         timeout: float = 5.0,
-        interval: float = 0.1,
+        interval: float = 0.2,
     ) -> dict[str, Any] | None:
-        """Poll the daemon's bus state for an envelope matching predicate.
+        """Poll the agent's pickup queue for an envelope matching predicate.
 
-        Returns the first match within timeout, else None. Implementer:
-        verify the poll path via preflight.
+        Calls the `list_pending` MCP tool on the agent's
+        ClaudeCodeMCPEndpoint in a loop until predicate matches or
+        timeout expires. Returns the first matching envelope dict,
+        or None if nothing matched within timeout.
+
+        Note: for the builtin.stub round-trip, stub does NOT publish an
+        Acknowledgment envelope back to the sender — it only calls
+        bus.ack() (marks the envelope handled in persistence). Therefore
+        list_pending on the sender's queue should return count=0 after a
+        successful send. Use poll_envelopes only when a true reply
+        envelope is expected (e.g. scheduler, discord).
         """
+        if not _HAS_FASTMCP:  # pragma: no cover
+            return None
+
+        import asyncio
+        import json
+
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            resp = httpx.get(self.base_url + "/bus/inbox", timeout=interval)
-            if resp.status_code == 200:
-                for env in resp.json().get("envelopes", []):
-                    if predicate(env):
-                        return env
-            time.sleep(interval)
+            try:
+                async with _FastMCPClient(self._mcp_url, timeout=self._timeout) as mcp:
+                    result = await mcp.call_tool("list_pending", arguments={})
+
+                data: Any = None
+                if result and hasattr(result[0], "text"):
+                    try:
+                        data = json.loads(result[0].text)
+                    except (json.JSONDecodeError, AttributeError):
+                        data = None
+                if isinstance(data, dict):
+                    for item in data.get("items", []):
+                        if predicate(item):
+                            return item
+            except Exception:
+                pass
+            await asyncio.sleep(interval)
         return None
+
+    async def list_pending(self) -> dict[str, Any]:
+        """Return the agent's current pending queue snapshot.
+
+        Calls the `list_pending` MCP tool. Returns the raw result dict
+        {"meta": {...}, "items": [...]} or {"meta": {}, "items": []} on
+        failure.
+        """
+        if not _HAS_FASTMCP:  # pragma: no cover
+            return {"meta": {}, "items": []}
+
+        import json
+
+        try:
+            async with _FastMCPClient(self._mcp_url, timeout=self._timeout) as mcp:
+                result = await mcp.call_tool("list_pending", arguments={})
+
+            if result and hasattr(result[0], "text"):
+                try:
+                    return json.loads(result[0].text)
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+        except Exception:
+            pass
+        return {"meta": {}, "items": []}

--- a/packages/agent-core-qa/src/agent_core_qa/client.py
+++ b/packages/agent-core-qa/src/agent_core_qa/client.py
@@ -1,0 +1,102 @@
+"""DaemonClient — thin HTTP wrapper for the agent_core daemon.
+
+Tool-shaped: stateless across calls, no connection pooling beyond what
+httpx does internally, no retry, no session caching.
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+import urllib.parse
+from typing import Any
+
+import httpx
+
+
+class _FakeTCPResponse:
+    """Mimics a minimal httpx.Response for callers of health_check().
+
+    Used when health_check() falls back to a TCP-connect check because
+    the daemon has no dedicated HTTP liveness route. status_code=200
+    means the port is accepting connections; status_code=503 means it
+    isn't (or the connect timed out).
+    """
+
+    def __init__(self, *, status_code: int, text: str = ""):
+        self.status_code = status_code
+        self.text = text
+
+
+class DaemonClient:
+    """HTTP client for the agent_core daemon.
+
+    Targets the daemon's HTTP API (default http://127.0.0.1:8787 for the
+    Phase 3.5 test instance). One client per scenario; no shared state.
+
+    Preflight finding: the daemon's HTTPHost (Starlette+Uvicorn) has no
+    dedicated liveness HTTP route — it only mounts MCP endpoint paths.
+    health_check() therefore uses a TCP-connect check on the bind port
+    rather than a GET to a specific path. A successful TCP connect means
+    the daemon process is up and its HTTP server is accepting connections.
+    """
+
+    def __init__(self, base_url: str, *, timeout: float = 5.0):
+        self.base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+    def health_check(self) -> _FakeTCPResponse:
+        """TCP-connect check on the daemon's bind port.
+
+        TCP-connect fallback: the daemon's HTTPHost (Starlette+Uvicorn)
+        exposes no dedicated liveness route — only MCP endpoint mounts.
+        A successful TCP connect on the bind port indicates the HTTP
+        server is accepting connections. Returns a response-like object
+        with status_code=200 on success or status_code=503 on failure.
+        """
+        parsed = urllib.parse.urlparse(self.base_url)
+        host = parsed.hostname or "127.0.0.1"
+        port = parsed.port or 80
+        try:
+            conn = socket.create_connection((host, port), timeout=self._timeout)
+            conn.close()
+            return _FakeTCPResponse(status_code=200, text="TCP connect OK")
+        except OSError as exc:
+            return _FakeTCPResponse(status_code=503, text=str(exc))
+
+    def send_envelope(self, envelope: dict[str, Any]) -> httpx.Response:
+        """POST an envelope to the daemon's bus-publish endpoint.
+
+        Implementer: discover the exact route + payload shape via preflight
+        on the daemon's HTTP API. Likely something like POST /bus/publish
+        with the envelope JSON as body.
+        """
+        # Path placeholder — implementer verifies via preflight before
+        # using send_envelope.
+        return httpx.post(
+            self.base_url + "/bus/publish",
+            json=envelope,
+            timeout=self._timeout,
+        )
+
+    def poll_envelopes(
+        self,
+        predicate,
+        *,
+        timeout: float = 5.0,
+        interval: float = 0.1,
+    ) -> dict[str, Any] | None:
+        """Poll the daemon's bus state for an envelope matching predicate.
+
+        Returns the first match within timeout, else None. Implementer:
+        verify the poll path via preflight.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            resp = httpx.get(self.base_url + "/bus/inbox", timeout=interval)
+            if resp.status_code == 200:
+                for env in resp.json().get("envelopes", []):
+                    if predicate(env):
+                        return env
+            time.sleep(interval)
+        return None

--- a/packages/agent-core-qa/src/agent_core_qa/client.py
+++ b/packages/agent-core-qa/src/agent_core_qa/client.py
@@ -246,3 +246,40 @@ class DaemonClient:
         except Exception:
             pass
         return {"meta": {}, "items": []}
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> _MCPToolResult:
+        """Call any MCP tool on the agent's ClaudeCodeMCPEndpoint.
+
+        Generic escape hatch for tools beyond `send` and `list_pending`.
+        Used by Scenario 4 to call `compose_brief` and `submit_brief`
+        on the `qa` endpoint (which has the briefs tools mounted via
+        ``briefs_orchestrator`` wiring in the test daemon's config).
+
+        Returns an _MCPToolResult with status_code=200 on success (the
+        tool returned without raising) and status_code=500 on transport
+        error or tool exception. The parsed result is available via
+        ``.json()``; the raw text via ``.text``.
+        """
+        if not _HAS_FASTMCP:  # pragma: no cover
+            return _MCPToolResult(
+                status_code=500,
+                text="fastmcp not installed; add fastmcp>=3.0 to agent-core-qa deps",
+            )
+
+        try:
+            async with _FastMCPClient(self._mcp_url, timeout=self._timeout) as mcp:
+                result = await mcp.call_tool(tool_name, arguments=arguments or {})
+
+            data: Any = None
+            if result and hasattr(result[0], "text"):
+                try:
+                    data = json.loads(result[0].text)
+                except (json.JSONDecodeError, AttributeError):
+                    data = result[0].text if hasattr(result[0], "text") else str(result)
+            return _MCPToolResult(status_code=200, data=data, text=str(data))
+        except Exception as exc:
+            return _MCPToolResult(status_code=500, text=str(exc))

--- a/packages/agent-core-qa/tests/conftest.py
+++ b/packages/agent-core-qa/tests/conftest.py
@@ -50,8 +50,12 @@ def daemon_liveness_required(request, client: DaemonClient):
     install." If the daemon is down, dependent scenarios skip with a clear
     reason instead of failing with cryptic connection errors.
     """
-    # The liveness scenario itself shouldn't skip itself.
-    if request.node.name == "test_daemon_liveness":
+    # Tests that do their own daemon management bypass the liveness check.
+    BYPASS_LIVENESS = {
+        "test_daemon_liveness",
+        "test_install_identity_dynamic_keystone",
+    }
+    if request.node.name in BYPASS_LIVENESS:
         return
     try:
         response = client.health_check()

--- a/packages/agent-core-qa/tests/conftest.py
+++ b/packages/agent-core-qa/tests/conftest.py
@@ -1,0 +1,69 @@
+"""Shared fixtures for agent-core-qa scenarios.
+
+Tool-shaped: each fixture is per-test; no module/session-scoped state
+beyond what pytest itself manages.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agent_core_qa.client import DaemonClient
+
+
+DEFAULT_DAEMON_URL = "http://127.0.0.1:8787"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--daemon-url",
+        action="store",
+        default=None,
+        help="Base URL of the test daemon's HTTP API (default: http://127.0.0.1:8787 "
+        "or AGENT_CORE_QA_DAEMON_URL env var)",
+    )
+
+
+@pytest.fixture
+def daemon_url(request) -> str:
+    """Resolve the daemon URL from CLI flag, env var, or default."""
+    flag = request.config.getoption("--daemon-url")
+    if flag:
+        return flag
+    env = os.environ.get("AGENT_CORE_QA_DAEMON_URL")
+    if env:
+        return env
+    return DEFAULT_DAEMON_URL
+
+
+@pytest.fixture
+def client(daemon_url: str) -> DaemonClient:
+    """Per-test DaemonClient — no session sharing."""
+    return DaemonClient(daemon_url)
+
+
+@pytest.fixture(autouse=True)
+def daemon_liveness_required(request, client: DaemonClient):
+    """Skip all scenarios if the test daemon isn't reachable.
+
+    Phase 2.7 failure-class catch: "does the daemon actually start after
+    install." If the daemon is down, dependent scenarios skip with a clear
+    reason instead of failing with cryptic connection errors.
+    """
+    # The liveness scenario itself shouldn't skip itself.
+    if request.node.name == "test_daemon_liveness":
+        return
+    try:
+        response = client.health_check()
+        if response.status_code != 200:
+            pytest.skip(
+                f"test daemon at {client.base_url} returned "
+                f"{response.status_code}; run `agent-core daemon start --instance test` first"
+            )
+    except Exception as exc:
+        pytest.skip(
+            f"test daemon not reachable at {client.base_url}: {exc!r}; "
+            f"run `agent-core daemon start --instance test` first"
+        )

--- a/packages/agent-core-qa/tests/conftest.py
+++ b/packages/agent-core-qa/tests/conftest.py
@@ -9,9 +9,7 @@ from __future__ import annotations
 import os
 
 import pytest
-
 from agent_core_qa.client import DaemonClient
-
 
 DEFAULT_DAEMON_URL = "http://127.0.0.1:8787"
 

--- a/packages/agent-core-qa/tests/test_brief_compose_and_submit.py
+++ b/packages/agent-core-qa/tests/test_brief_compose_and_submit.py
@@ -1,0 +1,165 @@
+"""Scenario 4: brief framework compose + submit smoke.
+
+Validates the gather → compose → submit_brief chain end-to-end against
+the live test daemon.
+
+Why v0.3.0 needs it: brief framework is core to daily ops (Pepper relies
+on it for morning_brief); a regression would surface as silent compose
+failures with no obvious connection to the release.
+
+Transport choice (Preflight Step 0 finding):
+    ``submit_brief`` is an MCP tool registered on the ``qa``
+    ``ClaudeCodeMCPEndpoint`` via the T19 ``wire_endpoints_after_registration``
+    pluggy hookimpl. The hookimpl pairs any ``ClaudeCodeMCPEndpoint`` whose
+    yaml ``params.briefs_orchestrator`` names a
+    ``BriefsOrchestratorEndpoint`` with that orchestrator, then appends a
+    deferred mounter that calls ``register_briefs_tools()`` at bus start.
+    The seven brief tools (``compose_brief``, ``list_sections``,
+    ``get_section_spec``, ``validate_section``, ``compress_sections``,
+    ``add_extension_section``, ``submit_brief``) are therefore accessible
+    at ``/mcp/qa/`` via ``client.call_tool()``.
+
+    Route (a) — direct MCP tool calls on the ``qa`` endpoint — was chosen
+    because it has the fewest moving parts: no envelope routing, no bus
+    dispatch, just FastMCP Streamable HTTP. The plan's ``ToolInvocation``
+    envelope template (route b) would require the bus to dispatch to the
+    orchestrator endpoint, which adds a layer with nothing to gain for a
+    smoke test.
+
+Payload shape rationale:
+    ``compose_brief(brief_type, scope)`` runs the gather pipeline and
+    returns a session_token plus ``sections_required``. We call it with
+    ``brief_type="morning_brief"`` (the standard playbook expected in the
+    test daemon's configured ``playbooks_path``) and ``scope="qa-smoke"``.
+
+    ``submit_brief(token, sections)`` accepts a list of section dicts,
+    each with ``section_id`` and ``fields`` (list of ``{name, value}``).
+    For the smoke test we pass one field per required section with a
+    stub value ``"qa-smoke-probe"`` — enough to satisfy field-presence
+    validation for required fields. The test treats both a clean success
+    and a known partial failure (validation issues or destination errors)
+    as acceptable outcomes; what it asserts is:
+    - ``compose_brief`` returned a ``session_token`` (non-empty string)
+    - ``submit_brief`` was callable with that token and returned a
+      structured result (dict with ``success``, ``validation_issues``,
+      ``deliveries`` keys)
+
+    A 500-status from either call signals a tool crash (the bug we're
+    guarding against).
+
+    If ``compose_brief`` returns a ``ValueError`` (playbook not found),
+    the test skips with a clear message rather than failing — this is an
+    operator-side configuration issue, not a framework regression.
+
+    The test SKIPs (via the autouse ``daemon_liveness_required`` fixture)
+    when no daemon is reachable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+async def test_brief_compose_and_submit(client):
+    """Invoke compose_brief then submit_brief via the qa MCP endpoint.
+
+    Phase 1: call ``compose_brief`` to get a session token.
+    Phase 2: call ``submit_brief`` with minimal filled sections.
+    Assert both tools respond without crashing (status 200).
+    Assert ``submit_brief`` returns a structured result dict.
+    """
+    # Phase 1: compose_brief — start a brief session.
+    compose_result = await client.call_tool(
+        "compose_brief",
+        arguments={
+            "brief_type": "morning_brief",
+            "scope": "qa-smoke",
+        },
+    )
+    if compose_result.status_code != 200:
+        # Tool raised — could be playbook-not-found (operator config issue)
+        # or a genuine framework crash. Surface the error text for diagnosis.
+        error_text = compose_result.text[:400]
+        if "playbook" in error_text.lower() or "not found" in error_text.lower() or "unknown brief_type" in error_text.lower():
+            pytest.skip(
+                f"compose_brief: playbook 'morning_brief' not found in the test daemon's "
+                f"configured playbooks_path; ensure the daemon is configured with a "
+                f"briefs_orchestrator whose playbooks_path contains morning_brief.md. "
+                f"Error: {error_text}"
+            )
+        pytest.fail(
+            f"compose_brief tool returned status {compose_result.status_code}; "
+            f"expected 200. Error: {error_text}"
+        )
+
+    compose_data = compose_result.json()
+    assert isinstance(compose_data, dict), (
+        f"compose_brief returned non-dict: {type(compose_data).__name__}: {compose_data!r}"
+    )
+
+    session_token = compose_data.get("session_token")
+    assert session_token and isinstance(session_token, str), (
+        f"compose_brief returned no session_token; got: {compose_data!r}"
+    )
+
+    # Build a minimal submission using whatever sections are required.
+    # Each section gets one stub field so required-field-present checks pass.
+    # We use the first field name from compose_data's section list if
+    # available; otherwise fall back to "content" which many playbooks use.
+    sections_required: list[str] = compose_data.get("sections_required", [])
+    if not sections_required:
+        # If there are no required sections, include at least one optional
+        # section so the brief has content (some playbooks are all-optional).
+        sections_optional: list[str] = compose_data.get("sections_optional", [])
+        sections_to_fill = sections_optional[:1] if sections_optional else []
+    else:
+        sections_to_fill = list(sections_required)
+
+    # Build section dicts. We don't know field names from compose_data alone
+    # (that requires get_section_spec), so we supply a single field named
+    # "content" — enough to exercise the submit path. Validation may still
+    # fail if the spec requires a differently-named field, but that's a
+    # known partial-failure mode, not a crash.
+    minimal_sections = [
+        {
+            "section_id": sid,
+            "fields": [{"name": "content", "value": "qa-smoke-probe"}],
+        }
+        for sid in sections_to_fill
+    ]
+
+    # Phase 2: submit_brief — exercise the validate + fan-out path.
+    submit_result = await client.call_tool(
+        "submit_brief",
+        arguments={
+            "token": session_token,
+            "sections": minimal_sections,
+        },
+    )
+    assert submit_result.status_code == 200, (
+        f"submit_brief tool returned status {submit_result.status_code}; "
+        f"expected 200. Error: {submit_result.text[:400]}"
+    )
+
+    submit_data = submit_result.json()
+    assert isinstance(submit_data, dict), (
+        f"submit_brief returned non-dict: {type(submit_data).__name__}: {submit_data!r}"
+    )
+
+    # The structured result must have these keys regardless of success.
+    for key in ("success", "validation_issues", "deliveries"):
+        assert key in submit_data, (
+            f"submit_brief result missing key {key!r}; got: {submit_data!r}"
+        )
+
+    # Both True (all destinations delivered) and False (validation issues
+    # or destination failures) are acceptable smoke outcomes — the brief
+    # framework produced a structured response, which is what we're proving.
+    # A 500 from the tool call (caught above) would mean the submit path
+    # crashed entirely.
+    assert isinstance(submit_data["validation_issues"], list), (
+        f"submit_brief 'validation_issues' is not a list: {submit_data!r}"
+    )
+    assert isinstance(submit_data["deliveries"], list), (
+        f"submit_brief 'deliveries' is not a list: {submit_data!r}"
+    )

--- a/packages/agent-core-qa/tests/test_daemon_liveness.py
+++ b/packages/agent-core-qa/tests/test_daemon_liveness.py
@@ -1,0 +1,29 @@
+"""Scenario 1: test daemon liveness (precondition for all other scenarios).
+
+The 'next failure class' Phase 2.6's PR named as Phase 2.7 territory — does
+the daemon actually start after install. Catching this here as the autouse
+precondition means every other scenario gets clean skip-with-reason instead
+of cryptic connection errors when the daemon isn't up.
+"""
+
+import pytest
+
+
+def test_daemon_liveness(client):
+    """The test daemon must be reachable at <daemon_url>.
+
+    Preflight finding: the daemon's HTTPHost (Starlette+Uvicorn) has no
+    dedicated liveness HTTP route — it only mounts MCP endpoints. Therefore
+    health_check() uses a TCP-connect check on the bind port (see
+    DaemonClient.health_check() docstring). A successful TCP connect means
+    the daemon process is up and its HTTP server is accepting connections.
+
+    daemon_liveness_required fixture (autouse, conftest.py) ALSO checks this
+    so all other scenarios skip cleanly when the daemon is down. This
+    explicit test makes the precondition discoverable as its own scenario.
+    """
+    response = client.health_check()
+    assert response.status_code == 200, (
+        f"daemon at {client.base_url} returned {response.status_code}; "
+        f"body: {response.text[:200]}"
+    )

--- a/packages/agent-core-qa/tests/test_daemon_liveness.py
+++ b/packages/agent-core-qa/tests/test_daemon_liveness.py
@@ -6,7 +6,6 @@ precondition means every other scenario gets clean skip-with-reason instead
 of cryptic connection errors when the daemon isn't up.
 """
 
-import pytest
 
 
 def test_daemon_liveness(client):

--- a/packages/agent-core-qa/tests/test_discord_send_stub_route.py
+++ b/packages/agent-core-qa/tests/test_discord_send_stub_route.py
@@ -1,0 +1,163 @@
+"""Scenario 6: discord_send ToolInvocation routes through the stubbed discord slot.
+
+Why v0.3.0 needs it: the discord endpoint is the primary human-facing communication
+channel in the agent stack. If the discord slot is mis-registered, mis-named, or
+broken at the bus level, ALL agent → human communication silently fails.
+
+Transport choice (Preflight Step 0 finding):
+    The discord slot is configured at install time as ``builtin.stub``.  StubEndpoint
+    is NOT MCPHostable — it has no HTTP surface of its own.  The bus routes
+    ``ToolInvocation`` envelopes addressed to ``"discord"`` to StubEndpoint.deliver(),
+    which appends the envelope to ``.inbox`` and calls ``bus.ack(envelope.id)``.
+
+    StubEndpoint does NOT publish an ``AcknowledgmentPayload`` back to the sender.
+    This is the key asymmetry vs. DiscordEndpoint (the real adapter) and
+    SchedulerEndpoint (which does publish Ack replies):
+
+        stub.deliver() → bus.ack(id)          # marks handled, publishes nothing
+        real discord.deliver() → bus.publish(AcknowledgmentPayload)  # echoes result
+
+    Consequence: the ``poll_envelopes`` / error-Ack pattern used in Scenario 5
+    (scheduler) cannot be applied here.  No Ack — green or error — ever lands in
+    the ``qa`` inbox from the stub.
+
+Acknowledgment auto-clear (inherited context from Task 6):
+    ``ClaudeCodeMCPEndpoint._is_routine_green_ack()`` silently discards routine green
+    Acks (urgency=green, note not prefixed "error:", ``in_reply_to`` set).  Even if
+    the stub *did* publish an Ack, the green path would be auto-cleared.  Error Acks
+    (note prefixed "error:") would NOT be auto-cleared, but the stub never emits them.
+
+Assertion strategy — two-phase, stub-aware:
+    Phase 1 — real envelope, verify bus-level delivery:
+        Send a well-formed ``discord_send`` ToolInvocation to ``"discord"``.
+        The ``send`` MCP tool returns ``{"status": "published", "id": <env_id>}``
+        synchronously after the bus dispatches and the stub delivers+acks (single
+        event loop, synchronous in-process delivery).  status_code=200 + published
+        status is the round-trip proof.  A follow-up ``list_pending`` must return
+        count=0 — the stub auto-acked, leaving nothing queued in the ``qa`` inbox.
+
+    Phase 2 — deliberate-broken probe, verify bus routing validation:
+        Send a ``ToolInvocation`` addressed to a nonexistent endpoint
+        (``"discord_qa_nonexistent_probe"``).  The bus raises
+        ``ValueError("publish to unregistered endpoint '...'")`` before any
+        persistence write.  This propagates through the ``send`` MCP tool as a
+        tool-call exception, surfaced by DaemonClient.send_envelope() as
+        status_code=500 or an error keyword in the response text.
+        This phase proves the routing table is live and validates destinations — a
+        misconfigured discord slot name would produce the same error on real sends.
+
+Tool surface discovered from packages/agent-core-discord/src/agent_core_discord/:
+    Tool name:  ``"discord_send"``  (no alias in _TOOL_ALIASES; the real
+                DiscordEndpoint routes via ``_canonical_tool(tool)`` which falls
+                through to the key directly, and ``"discord_send"`` is NOT a key
+                in _TOOL_ALIASES — but the stub ignores tool names entirely).
+    Args model: ``_SendArgs`` — channel_id (str, min_length=1, REQUIRED),
+                text (str | None), embeds, reply_to, files, cleanup_inbound_message_id.
+    Error note: ``"error: discord_send: <pydantic ValidationError>"`` when
+                channel_id is missing — BUT only from the real DiscordEndpoint.
+                The stub ignores args validation.
+
+Endpoint slot name: ``"discord"`` — conventional; confirmed from
+    ``agent_core install`` default-config template and plugin alias mapping.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+
+def _toolinvocation_payload(tool: str, args: dict) -> dict:
+    """Build the payload dict for a ToolInvocation envelope."""
+    return {"kind": "ToolInvocation", "tool": tool, "args": args}
+
+
+async def test_discord_send_tool_routes_through_stub(client):
+    """Send discord_send to the stubbed discord slot; verify routing is alive.
+
+    Phase 1: real envelope → stub delivers + auto-acks → send_envelope returns
+             {"status": "published"} + list_pending count=0.
+    Phase 2: broken envelope (nonexistent endpoint) → bus raises ValueError →
+             send_envelope returns error → proves routing validation is live.
+
+    The test SKIPs (via autouse ``daemon_liveness_required``) when no daemon
+    is reachable at the configured URL.
+    """
+    probe_text = f"qa-discord-probe-{uuid.uuid4().hex[:8]}"
+
+    # ── Phase 1: REAL ENVELOPE ────────────────────────────────────────────────
+    # Send a well-formed discord_send to the "discord" slot.  StubEndpoint.deliver()
+    # appends the envelope to .inbox and calls bus.ack() — no Ack reply published.
+    # The round-trip proof is the synchronous {"status": "published"} from send_envelope().
+    real_result = await client.send_envelope(
+        {
+            "to": "discord",
+            "kind": "ToolInvocation",
+            "payload": _toolinvocation_payload(
+                "discord_send",
+                {
+                    "channel_id": "qa-stub-channel",
+                    "text": probe_text,
+                },
+            ),
+            "correlation_id": uuid.uuid4().hex,
+            "metadata": {},
+            "urgency": "green",
+        }
+    )
+    assert real_result.status_code == 200, (
+        f"discord_send send_envelope transport error: "
+        f"status={real_result.status_code} body={real_result.text[:300]}"
+    )
+    real_data = real_result.json()
+    assert isinstance(real_data, dict) and real_data.get("status") == "published", (
+        f"discord_send send tool did not return 'published': {real_data!r}"
+    )
+
+    # Confirm queue is clear: stub auto-acked the envelope, so the qa inbox
+    # should be empty (count=0).  This catches any leak where the stub fails
+    # to ack and the envelope lingers pending.
+    pending = await client.list_pending()
+    items = pending.get("items", [])
+    leaked = [
+        e for e in items
+        if e.get("to") == "discord" or e.get("from_") == "discord"
+    ]
+    assert leaked == [], (
+        f"Unexpected envelopes in qa inbox after discord_send: {leaked!r}"
+    )
+
+    # ── Phase 2: DELIBERATE-BROKEN PROBE ─────────────────────────────────────
+    # Address the envelope to a nonexistent endpoint.  The bus raises
+    # ValueError("publish to unregistered endpoint '...'") before any persistence
+    # write.  DaemonClient.send_envelope() surfaces this as status_code=500 or
+    # error text containing "unregistered".  This proves the bus routing table
+    # is live; a mis-named discord slot would produce the same failure on real sends.
+    broken_result = await client.send_envelope(
+        {
+            "to": "discord_qa_nonexistent_probe",
+            "kind": "ToolInvocation",
+            "payload": _toolinvocation_payload(
+                "discord_send",
+                {
+                    "channel_id": "qa-stub-channel",
+                    "text": "qa-routing-probe-broken",
+                },
+            ),
+            "correlation_id": uuid.uuid4().hex,
+            "metadata": {},
+            "urgency": "green",
+        }
+    )
+    assert broken_result.status_code != 200 or (
+        isinstance(broken_result.json(), dict)
+        and broken_result.json().get("status") != "published"
+    ), (
+        f"Sending to nonexistent endpoint 'discord_qa_nonexistent_probe' unexpectedly "
+        f"succeeded.  The bus routing table may not be validating destinations. "
+        f"Response: {broken_result.text[:300]}"
+    )
+    # Confirm the error text indicates the routing rejection.
+    broken_text = broken_result.text.lower()
+    assert "unregistered" in broken_text or "not found" in broken_text or "unknown" in broken_text or broken_result.status_code != 200, (
+        f"Broken-envelope error did not mention routing failure: {broken_result.text[:300]}"
+    )

--- a/packages/agent-core-qa/tests/test_discord_send_stub_route.py
+++ b/packages/agent-core-qa/tests/test_discord_send_stub_route.py
@@ -156,8 +156,13 @@ async def test_discord_send_tool_routes_through_stub(client):
         f"succeeded.  The bus routing table may not be validating destinations. "
         f"Response: {broken_result.text[:300]}"
     )
-    # Confirm the error text indicates the routing rejection.
+    # Confirm the error text indicates the routing rejection (a different
+    # 500 from some unrelated transport bug should not count as a pass).
     broken_text = broken_result.text.lower()
-    assert "unregistered" in broken_text or "not found" in broken_text or "unknown" in broken_text or broken_result.status_code != 200, (
+    assert (
+        "unregistered" in broken_text
+        or "not found" in broken_text
+        or "unknown" in broken_text
+    ), (
         f"Broken-envelope error did not mention routing failure: {broken_result.text[:300]}"
     )

--- a/packages/agent-core-qa/tests/test_envelope_roundtrip.py
+++ b/packages/agent-core-qa/tests/test_envelope_roundtrip.py
@@ -1,0 +1,81 @@
+"""Scenario 2: envelope round-trip via builtin.stub endpoint.
+
+Most basic v0.3.0 surface. Failure means the bus is broken — nothing
+else works.
+
+Transport note:
+    The daemon exposes NO /bus/publish or /bus/inbox HTTP route. The only
+    HTTP surface is FastMCP Streamable HTTP at /mcp/<agent>/ for each
+    ClaudeCodeMCPEndpoint. The builtin.stub endpoint has no HTTP surface.
+
+    Round-trip path:
+    1. Call the `send` MCP tool on the `qa` ClaudeCodeMCPEndpoint.
+       The tool publishes a TextMessage to `stub` on the bus, stamping
+       from_="qa". The bus dispatches in-process: stub.deliver() is called,
+       stub records the envelope, auto_ack=True calls bus.ack() (marks
+       handled in persistence). All of this happens before the `send` tool
+       call returns.
+    2. The `send` tool returns {"status": "published", "id": <envelope_id>}.
+       This is the complete round-trip signal: the bus dispatched the
+       envelope and the stub endpoint handled it synchronously.
+    3. We also call `list_pending` on the `qa` endpoint to confirm nothing
+       is queued there. Stub does NOT publish an Acknowledgment envelope
+       back — it only calls bus.ack(). So count=0 is the expected steady
+       state.
+
+    Test passes if send succeeds and the queue is empty afterward.
+    Test skips (via autouse daemon_liveness_required) when daemon is down.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+
+async def test_envelope_send_receives_ack(client):
+    """Send a TextMessage to builtin.stub; verify bus round-trip is intact.
+
+    Connects to the `qa` ClaudeCodeMCPEndpoint via MCP tool call to
+    publish a TextMessage to the `stub` endpoint. Asserts the send tool
+    returns "published" (bus dispatch and stub delivery completed
+    synchronously) and that the sender's pending queue is empty (stub
+    auto-acks; no Acknowledgment envelope flows back).
+    """
+    correlation_id = uuid.uuid4().hex
+
+    envelope = {
+        "to": "stub",
+        "kind": "TextMessage",
+        "payload": {"kind": "TextMessage", "text": "qa-roundtrip-probe"},
+        "correlation_id": correlation_id,
+        "metadata": {},
+        "urgency": "green",
+    }
+
+    send_result = await client.send_envelope(envelope)
+    assert send_result.status_code == 200, (
+        f"send_envelope failed: status={send_result.status_code} body={send_result.text[:300]}"
+    )
+
+    # Verify the tool returned {"status": "published", "id": <hex>}.
+    # This is the round-trip signal: the bus dispatched the envelope and
+    # the stub endpoint delivered+acked it synchronously before returning.
+    result_data = send_result.json()
+    assert isinstance(result_data, dict), (
+        f"expected dict from send tool, got {type(result_data).__name__}: {result_data!r}"
+    )
+    assert result_data.get("status") == "published", (
+        f"send tool did not return 'published': {result_data!r}"
+    )
+    published_id = result_data.get("id")
+    assert published_id, f"send tool returned no 'id': {result_data!r}"
+
+    # Confirm the sender's queue is empty: stub does NOT publish an
+    # Acknowledgment envelope back; it only calls bus.ack() internally.
+    # Nothing should be waiting in the `qa` endpoint's inbox.
+    pending = await client.list_pending()
+    count = pending.get("meta", {}).get("count", -1)
+    assert count == 0, (
+        f"expected 0 items in qa endpoint queue after stub round-trip, "
+        f"got count={count}. Pending snapshot: {pending!r}"
+    )

--- a/packages/agent-core-qa/tests/test_install_identity_dynamic_keystone.py
+++ b/packages/agent-core-qa/tests/test_install_identity_dynamic_keystone.py
@@ -39,7 +39,6 @@ import sys
 import uuid
 from pathlib import Path
 
-
 EXPECTED_PACKAGES = [
     "agent_core",
     "agent_core_briefs",

--- a/packages/agent-core-qa/tests/test_install_identity_dynamic_keystone.py
+++ b/packages/agent-core-qa/tests/test_install_identity_dynamic_keystone.py
@@ -1,0 +1,142 @@
+"""Scenario 3: install identity dynamic keystone.
+
+Phase 3.5's `test_install_code_path_identity_between_prod_and_test`
+enforces install-code-path identity at the UNIT level (mocked subprocess
+captures). This scenario is the DYNAMIC version: invoke the real install
+command against a clean sandbox home; assert it completes; assert the
+venv contains the expected agent_core wheels.
+
+Phase 2.6 bug-cadence: static unit caught Bugs 1-2; dynamic install
+caught Bug 3. This scenario is the standing dynamic check for release
+v0.3.0 onward — if it ever fails, the install path regressed.
+
+NOTE: This scenario does its own daemon install. It does NOT require
+the precondition test daemon to be running (the autouse liveness
+fixture is bypassed via the test-name check). It uses its own sandbox
+home so it never touches the running test daemon's state.
+
+PLAN DEVIATION (documented):
+The plan specifies `--instance test` which requires the Phase 3.5 three-
+instance branch to be merged first (adds Instance.TEST to instance.py).
+The qa-runner-tester branch currently has only prod/dev. The `--instance
+test` argument is correct per spec and will work once phase35 merges into
+the v0.3.0 release sequence (step: #120 → #121 → #119 → qa-runner).
+In the interim, calling `--instance test` will fail with ValueError on the
+install subprocess — that's the expected failure mode on this branch until
+phase35 lands. The `AGENT_CORE_HOME` sandbox env var correctly isolates
+the install regardless of which instance flag is passed (home_for() returns
+Path(AGENT_CORE_HOME) directly when that env var is set, bypassing instance
+mapping). Written per plan spec; no functional change needed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+
+EXPECTED_PACKAGES = [
+    "agent_core",
+    "agent_core_briefs",
+    "agent_core_busproxy",
+    "agent_core_channel",
+    "agent_core_credentials",
+    "agent_core_discord",
+    "agent_core_hatchery",
+    "agent_core_notify",
+    "agent_core_voice",
+    "agent_core_webcam",
+    "qwen_tts",
+]
+
+
+def test_install_identity_dynamic_keystone():
+    """Invoke `agent-core daemon install --instance test --release v0.3.0`
+    against a clean sandbox; assert install completes; assert venv has
+    all expected wheels.
+
+    Sandbox home is `/tmp/qa-{uuid}/` so each invocation is isolated;
+    cleanup happens on test teardown via try/finally.
+
+    Phase 3.5 prerequisite: `--instance test` requires Instance.TEST to be
+    present in instance.py (added in feat/phase35-three-instance-test).
+    This test will fail with subprocess ValueError until that branch merges.
+    That's expected — this test documents the post-merge validation contract.
+
+    AGENT_CORE_HOME bypass: home_for() returns Path(AGENT_CORE_HOME) directly
+    when the env var is set, so the sandbox isolation holds regardless of the
+    instance flag once the ValueError is resolved.
+    """
+    sandbox = Path("/tmp") / f"qa-{uuid.uuid4().hex[:8]}"
+    sandbox.mkdir(parents=True, exist_ok=True)
+
+    try:
+        env = os.environ.copy()
+        env["AGENT_CORE_HOME"] = str(sandbox)
+
+        # Invoke the real install command.
+        # NOTE: pin the release tag the runbook intends to validate.
+        # For local pre-release validation, use a built-locally tag
+        # like "vlocal" (see runbook).
+        release_tag = os.environ.get("AGENT_CORE_QA_RELEASE_TAG", "v0.3.0")
+        result = subprocess.run(
+            [
+                "agent-core",
+                "daemon",
+                "install",
+                "--instance",
+                "test",
+                "--release",
+                release_tag,
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=600,  # 10 min — torch download is large
+        )
+        assert result.returncode == 0, (
+            f"install failed (exit {result.returncode}):\n"
+            f"STDOUT: {result.stdout[-2000:]}\n"
+            f"STDERR: {result.stderr[-2000:]}"
+        )
+
+        # Assert install stamp is correct.
+        stamp_path = sandbox / ".daemon-install-stamp.json"
+        assert stamp_path.exists(), f"install stamp not written at {stamp_path}"
+
+        stamp = json.loads(stamp_path.read_text(encoding="utf-8"))
+        # The stamp must record the release tag either under `release_tag`
+        # (Phase 3.5 install.py field) or `installed_version` (fallback).
+        assert stamp.get("release_tag") == release_tag or stamp.get(
+            "installed_version"
+        ) == release_tag, (
+            f"install stamp shows wrong version — expected {release_tag!r}; stamp: {stamp}"
+        )
+
+        # Assert ALL expected wheels are present at site-packages
+        # (per spec-review clarification: partial install must fail).
+        venv = sandbox / ".venv"
+        if sys.platform == "win32":
+            site_packages = venv / "Lib" / "site-packages"
+        else:
+            # /lib/python*/site-packages — glob to handle 3.12 / 3.13 etc.
+            candidates = list((venv / "lib").glob("python*/site-packages"))
+            assert candidates, f"no site-packages found under {venv}/lib/"
+            site_packages = candidates[0]
+
+        for package_name in EXPECTED_PACKAGES:
+            init_py = site_packages / package_name / "__init__.py"
+            assert init_py.exists(), (
+                f"expected wheel-installed package {package_name!r} not found at "
+                f"{init_py}; install was partial"
+            )
+
+    finally:
+        # Tear down sandbox; never reuse across runs.
+        if sandbox.exists():
+            shutil.rmtree(sandbox, ignore_errors=True)

--- a/packages/agent-core-qa/tests/test_scheduler_create_and_delete.py
+++ b/packages/agent-core-qa/tests/test_scheduler_create_and_delete.py
@@ -69,7 +69,7 @@ so no side effects from the job existing while the test runs.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 
 def _toolinvocation_payload(tool: str, args: dict) -> dict:
@@ -110,7 +110,7 @@ async def test_scheduler_create_and_delete_roundtrip(client):
     """
     job_name = f"qa-probe-{uuid.uuid4().hex[:8]}"
     # One year in the future — will not fire during test execution.
-    fires_at = (datetime.now(timezone.utc) + timedelta(days=365)).isoformat()
+    fires_at = (datetime.now(UTC) + timedelta(days=365)).isoformat()
 
     create_args = {
         "name": job_name,

--- a/packages/agent-core-qa/tests/test_scheduler_create_and_delete.py
+++ b/packages/agent-core-qa/tests/test_scheduler_create_and_delete.py
@@ -1,0 +1,245 @@
+"""Scenario 5: scheduler create + list + delete round-trip.
+
+Why v0.3.0 needs it: scheduler powers agent_core's daemon heartbeat,
+liveness-probe, auth-health-probe, and nightly-reflection infrastructure.
+If the scheduler endpoint is broken, the daemon goes silent on all timed
+operations.
+
+Transport choice (Preflight Step 0 finding):
+    SchedulerEndpoint is NOT a ClaudeCodeMCPEndpoint — it is a plain bus
+    endpoint whose ``deliver()`` method handles ``ToolInvocation`` envelopes
+    and publishes ``Acknowledgment`` envelopes back to the sender. It has
+    NO HTTP/MCP surface of its own. Route (b) — ``ToolInvocation`` envelopes
+    — is required.
+
+    1. ``send_envelope`` calls the ``send`` MCP tool on the ``qa``
+       ClaudeCodeMCPEndpoint (at ``/mcp/qa/``). The bus stamps
+       ``from_="qa"`` and dispatches the envelope to ``scheduler``
+       in-process (single-event-loop, synchronous delivery).
+    2. The scheduler dispatches the named tool, builds a result, and
+       publishes an ``Acknowledgment`` envelope back to ``"qa"``.
+    3. The ``qa`` ClaudeCodeMCPEndpoint receives the Ack in ``deliver()``.
+       If the Ack is a *routine green Ack* (urgency=green, note not
+       prefixed "error:", ``in_reply_to`` set and matching ``payload.of``),
+       it is auto-cleared in persistence and NEVER queued — so
+       ``poll_envelopes`` cannot find it.
+    4. Error Acks (note prefixed "error:") are NOT auto-cleared and DO
+       land in the ``qa`` inbox where ``poll_envelopes`` can find them.
+
+    This auto-clear asymmetry drives the test strategy below.
+
+Acknowledgment auto-clear mechanics:
+    ``ClaudeCodeMCPEndpoint._is_routine_green_ack()`` silently discards
+    Acks that match the "routine green" shape — this is the scheduler's
+    normal success-path. Success Acks therefore cannot be read via
+    ``list_pending``. The test verifies success by **absence of error**:
+
+    - If ``create_job`` succeeds, no error Ack appears in the ``qa`` inbox.
+    - Proof that the job actually exists: a duplicate ``create_job`` call
+      returns an error Ack with note "error: job 'X' already exists".
+    - If ``delete_job`` succeeds, no error Ack appears.
+    - Proof that the job is gone: a second ``delete_job`` call returns an
+      error Ack with note "error: job 'X' not found".
+
+    This pattern is robust to the auto-clear design without requiring
+    ``wake_on_all_acknowledgments`` in the test daemon's ``qa`` endpoint
+    config.
+
+Tool names discovered from packages/core/src/agent_core/endpoints/scheduler.py:
+    ``_dispatch()`` routes:
+        "create_job"  → _CreateJobArgs(name, trigger, schedule, target, prompt)
+        "list_jobs"   → _NoArgs() (empty dict)
+        "delete_job"  → _NameOnlyArgs(name)
+
+    Success notes (JSON-serialized into Acknowledgment.payload.note):
+        create_job → ``{"status": "created", "name": ...}``
+        delete_job → ``{"status": "deleted", "name": ...}``
+        list_jobs  → JSON array of job dicts
+    Error notes: ``"error: ..."`` plain string (not JSON).
+
+Scheduler endpoint name in the test daemon: ``"scheduler"`` (conventional;
+confirmed from test suite in packages/core/tests/test_scheduler_endpoint.py
+and builtin plugin alias mapping in packages/core/src/agent_core/plugins/).
+
+Date trigger selected for the probe job: ``"date"`` with
+``run_time=<one year from now>`` — guaranteed not to fire during the test,
+so no side effects from the job existing while the test runs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+
+def _toolinvocation_payload(tool: str, args: dict) -> dict:
+    """Build the payload dict for a ToolInvocation envelope."""
+    return {"kind": "ToolInvocation", "tool": tool, "args": args}
+
+
+def _is_error_ack_for(env_id: str):
+    """Return a poll predicate matching an error Acknowledgment for ``env_id``.
+
+    Error Acks (note prefixed "error:") are NOT auto-cleared by the
+    ``qa`` ClaudeCodeMCPEndpoint and land in the inbox. Success Acks
+    ARE auto-cleared and never appear. This predicate matches only the
+    error case; no match within the poll window means success.
+    """
+
+    def _predicate(e: dict) -> bool:
+        if e.get("kind") != "Acknowledgment":
+            return False
+        if e.get("in_reply_to") != env_id:
+            return False
+        note = e.get("payload", {}).get("note", "") or ""
+        return note.startswith("error:")
+
+    return _predicate
+
+
+async def test_scheduler_create_and_delete_roundtrip(client):
+    """Create a far-future job; verify creation; delete; verify deletion.
+
+    Uses ``ToolInvocation`` envelopes addressed to the ``scheduler`` endpoint.
+    Success is confirmed by absence of error Acks + deliberate duplicate /
+    re-delete probes that return error Acks only when the prior operation
+    completed correctly.
+
+    The test SKIPs (via autouse ``daemon_liveness_required``) when no daemon
+    is reachable at the configured URL.
+    """
+    job_name = f"qa-probe-{uuid.uuid4().hex[:8]}"
+    # One year in the future — will not fire during test execution.
+    fires_at = (datetime.now(timezone.utc) + timedelta(days=365)).isoformat()
+
+    create_args = {
+        "name": job_name,
+        "trigger": "date",
+        "schedule": {"run_time": fires_at},
+        "target": "qa",
+        "prompt": "qa-scheduler-probe",
+    }
+
+    # ── Phase 1: CREATE ──────────────────────────────────────────────────
+    create_result = await client.send_envelope(
+        {
+            "to": "scheduler",
+            "kind": "ToolInvocation",
+            "payload": _toolinvocation_payload("create_job", create_args),
+            "metadata": {},
+            "urgency": "green",
+        }
+    )
+    assert create_result.status_code == 200, (
+        f"send_envelope (create_job) transport error: "
+        f"status={create_result.status_code} body={create_result.text[:300]}"
+    )
+    create_data = create_result.json()
+    assert isinstance(create_data, dict) and create_data.get("status") == "published", (
+        f"send tool did not return 'published': {create_data!r}"
+    )
+    create_env_id = create_data["id"]
+
+    # Success Ack is auto-cleared (routine green). An error Ack is NOT —
+    # verify no error appeared within the poll window.
+    error_ack = await client.poll_envelopes(
+        predicate=_is_error_ack_for(create_env_id),
+        timeout=3.0,
+        interval=0.2,
+    )
+    assert error_ack is None, (
+        f"create_job returned an error Ack: "
+        f"{error_ack.get('payload', {}).get('note', '')!r}"
+    )
+
+    # ── Phase 2: VERIFY CREATE (duplicate probe) ─────────────────────────
+    # Send an identical create_job call. The scheduler must return an error
+    # Ack "job 'X' already exists" — proving the first create was persisted.
+    dupe_result = await client.send_envelope(
+        {
+            "to": "scheduler",
+            "kind": "ToolInvocation",
+            "payload": _toolinvocation_payload("create_job", create_args),
+            "metadata": {},
+            "urgency": "green",
+        }
+    )
+    assert dupe_result.status_code == 200, (
+        f"send_envelope (duplicate create_job) transport error: "
+        f"status={dupe_result.status_code} body={dupe_result.text[:300]}"
+    )
+    dupe_env_id = dupe_result.json()["id"]
+    dupe_error_ack = await client.poll_envelopes(
+        predicate=_is_error_ack_for(dupe_env_id),
+        timeout=5.0,
+        interval=0.2,
+    )
+    assert dupe_error_ack is not None, (
+        f"Duplicate create_job did not return an error Ack within 5s. "
+        f"Expected 'error: job {job_name!r} already exists'. "
+        f"The scheduler may not be registered in the test daemon's endpoint config, "
+        f"or the first create_job did not persist."
+    )
+    dupe_note = dupe_error_ack.get("payload", {}).get("note", "")
+    assert "already exists" in dupe_note, (
+        f"Duplicate create_job error Ack note unexpected: {dupe_note!r}"
+    )
+
+    # ── Phase 3: DELETE ──────────────────────────────────────────────────
+    delete_result = await client.send_envelope(
+        {
+            "to": "scheduler",
+            "kind": "ToolInvocation",
+            "payload": _toolinvocation_payload("delete_job", {"name": job_name}),
+            "metadata": {},
+            "urgency": "green",
+        }
+    )
+    assert delete_result.status_code == 200, (
+        f"send_envelope (delete_job) transport error: "
+        f"status={delete_result.status_code} body={delete_result.text[:300]}"
+    )
+    delete_env_id = delete_result.json()["id"]
+
+    # Success Ack is auto-cleared. Verify no error appeared.
+    delete_error_ack = await client.poll_envelopes(
+        predicate=_is_error_ack_for(delete_env_id),
+        timeout=3.0,
+        interval=0.2,
+    )
+    assert delete_error_ack is None, (
+        f"delete_job returned an error Ack: "
+        f"{delete_error_ack.get('payload', {}).get('note', '')!r}"
+    )
+
+    # ── Phase 4: VERIFY DELETE (re-delete probe) ─────────────────────────
+    # Send a second delete_job for the same name. The scheduler must return
+    # an error Ack "job 'X' not found" — proving the delete was applied.
+    redelete_result = await client.send_envelope(
+        {
+            "to": "scheduler",
+            "kind": "ToolInvocation",
+            "payload": _toolinvocation_payload("delete_job", {"name": job_name}),
+            "metadata": {},
+            "urgency": "green",
+        }
+    )
+    assert redelete_result.status_code == 200, (
+        f"send_envelope (re-delete) transport error: "
+        f"status={redelete_result.status_code} body={redelete_result.text[:300]}"
+    )
+    redelete_env_id = redelete_result.json()["id"]
+    redelete_error_ack = await client.poll_envelopes(
+        predicate=_is_error_ack_for(redelete_env_id),
+        timeout=5.0,
+        interval=0.2,
+    )
+    assert redelete_error_ack is not None, (
+        f"Re-delete did not return an error Ack within 5s. "
+        f"Expected 'error: job {job_name!r} not found'. "
+        f"The delete_job tool may not have removed the job from persistence."
+    )
+    redelete_note = redelete_error_ack.get("payload", {}).get("note", "")
+    assert "not found" in redelete_note, (
+        f"Re-delete error Ack note unexpected: {redelete_note!r}"
+    )

--- a/packages/agent-core-qa/tests/test_voice_synthesize_smoke.py
+++ b/packages/agent-core-qa/tests/test_voice_synthesize_smoke.py
@@ -1,0 +1,126 @@
+"""Scenario 7: voice synthesis smoke.
+
+Why v0.3.0 needs it: Phase 2.6 promoted qwen-tts to a workspace member.
+If the promotion broke the actual synthesis path (vs. just the install),
+this catches it. The static install test (Scenario 3) asserts the wheel
+installs; this asserts it RUNS and produces output.
+
+Does NOT validate audio quality — that is a human-loop concern, out of scope.
+
+Transport finding (Preflight Step 0):
+    VoiceEndpoint is tool-only — VoiceEndpoint.deliver() is a no-op (logs at
+    DEBUG and acks; no reply envelope is ever published). The ToolInvocation
+    envelope path therefore produces no observable reply from the bus side.
+
+    The synthesis surface is exposed as an MCP tool (``synthesize_speech``)
+    mounted on the agent's ClaudeCodeMCPEndpoint via
+    ``register_voice_tools()`` (agent_core_voice/mcp.py). This wiring happens
+    at bus.start() only when the agent's yaml params include both ``voice:``
+    and ``voice_id:``.
+
+    Transport chosen: **Route (a) — direct MCP tool call** via
+    ``client.call_tool("synthesize_speech", {"text": "..."})`` on the ``qa``
+    endpoint. This is the same pattern used by Scenario 4 (brief tools) and
+    is the cleanest path: one HTTP round-trip, synchronous result, no polling.
+
+    The qa endpoint MUST have voice wiring in the test daemon's config for
+    ``synthesize_speech`` to be present. If the tool is absent (not mounted),
+    the client returns status_code=500. The test skips in that case with a
+    clear operator-actionable message.
+
+Assertion strategy:
+    1. call_tool("synthesize_speech", {"text": "hello"}) returns status 200.
+    2. Result is not an error string (no "synthesis failed:" prefix).
+    3. Result is a dict containing a non-empty ``path`` key (the saved WAV
+       file path), proving the synthesis pipeline ran end-to-end.
+    4. ``duration_s > 0`` proves audio content was actually generated (not an
+       empty or zero-length file).
+
+Timeout:
+    The qa endpoint's default MCP timeout (30s) should be sufficient for
+    short utterances on a warmed GPU. If the daemon is on CPU, first-load can
+    exceed 30s — operators must configure a longer timeout or set
+    AGENT_CORE_QA_DAEMON_TIMEOUT. The test does NOT try to override the client
+    timeout itself; that would require a test-specific client fixture. Instead,
+    the DaemonClient default is used and the skip message explains what to do
+    if the test flakes on first-load.
+
+The test SKIPs (via autouse ``daemon_liveness_required``) when no daemon is
+reachable at the configured URL, and SKIPs explicitly when the ``qa`` endpoint
+is not configured with voice wiring.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+async def test_voice_synthesize_returns_audio_bytes(client):
+    """Call synthesize_speech via the qa MCP endpoint; assert synthesis ran and produced output.
+
+    Transport: direct MCP tool call (Route a) — client.call_tool("synthesize_speech", ...).
+    The tool is only mounted when the qa endpoint's yaml params include
+    ``voice: <name>`` and ``voice_id: <id>``.
+
+    Asserts:
+    - call_tool returns status 200 (tool present and did not raise)
+    - result is not a "synthesis failed:" error string
+    - result dict contains a non-empty "path" (saved WAV file path)
+    - result dict contains duration_s > 0 (audio content generated)
+    """
+    result = await client.call_tool(
+        "synthesize_speech",
+        arguments={"text": "hello"},
+    )
+
+    if result.status_code != 200:
+        # Tool not found (not mounted) or transport error.
+        # Distinguish "voice not wired" from a genuine crash:
+        err_lower = result.text.lower()
+        if (
+            "not found" in err_lower
+            or "unknown tool" in err_lower
+            or "no tool" in err_lower
+            or "synthesize_speech" not in err_lower
+        ):
+            pytest.skip(
+                "synthesize_speech tool is not mounted on the qa endpoint. "
+                "Add voice: <endpoint-name> and voice_id: <id> to the qa "
+                "endpoint's params in the test daemon's config, then restart "
+                "the daemon."
+            )
+        pytest.fail(
+            f"synthesize_speech call_tool returned status {result.status_code}; "
+            f"expected 200. Error: {result.text[:400]}"
+        )
+
+    # The tool returned without raising. Check the result content.
+    data = result.json()
+
+    # Error path: the tool returns TextContent with "synthesis failed: <reason>"
+    # as plain text (not a dict) when the backend reports a VoiceError.
+    if isinstance(data, str):
+        if data.startswith("synthesis failed:"):
+            pytest.fail(
+                f"synthesize_speech returned a synthesis error: {data[:400]}"
+            )
+        # Any other plain-string response is unexpected.
+        pytest.fail(
+            f"synthesize_speech returned unexpected plain string: {data[:400]}"
+        )
+
+    assert isinstance(data, dict), (
+        f"synthesize_speech returned non-dict result: {type(data).__name__}: {data!r}"
+    )
+
+    # Assert the WAV path was written.
+    path = data.get("path")
+    assert path and isinstance(path, str), (
+        f"synthesize_speech result missing non-empty 'path' key; got: {data!r}"
+    )
+
+    # Assert audio content was generated (duration > 0 means non-empty WAV).
+    duration_s = data.get("duration_s")
+    assert isinstance(duration_s, (int, float)) and duration_s > 0, (
+        f"synthesize_speech result has non-positive duration_s; got: {data!r}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -292,6 +292,7 @@ requires-dist = [
 name = "agent-core-qa"
 source = { editable = "packages/agent-core-qa" }
 dependencies = [
+    { name = "fastmcp" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -299,6 +300,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastmcp", specifier = ">=3.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },

--- a/uv.lock
+++ b/uv.lock
@@ -58,6 +58,7 @@ members = [
     "agent-core-discord",
     "agent-core-hatchery",
     "agent-core-notify",
+    "agent-core-qa",
     "agent-core-voice",
     "agent-core-webcam",
     "qwen-tts",
@@ -285,6 +286,22 @@ dependencies = [
 requires-dist = [
     { name = "desktop-notifier", specifier = ">=5.0" },
     { name = "mcp", specifier = ">=1.9.0" },
+]
+
+[[package]]
+name = "agent-core-qa"
+source = { editable = "packages/agent-core-qa" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

New `packages/agent-core-qa/` — a pytest-based scenario runner that exercises the Phase 3.5 test daemon end-to-end against a built release artifact. Seven happy-path scenarios cover the "v0.3.0 cannot ship if broken" surface: daemon liveness (precondition), envelope round-trip, install-identity dynamic keystone, brief framework, scheduler, discord_send routing, voice synthesis.

## Design

See `docs/superpowers/specs/2026-05-23-qa-runner-design.md` (commit `095ab1b`).
Implementation plan: `docs/superpowers/plans/2026-05-23-qa-runner.md` (commit `1fd1b1b`).

## Tool-shaped, not being-shaped

Per Jeff's constraint set:
- Function-named (`agent-core-qa`), not person-named.
- No `IDENTITY.md`, `SOUL.md`, `MEMORY.md`, diary, breadcrumbs, lessons, wishlist, or curiosity files.
- No continuity-of-self — each pytest invocation is fresh.
- No ethical weight — `rm -rf packages/agent-core-qa/` is functionally identical to deleting any pytest suite.
- Procedural capability through pytest playbooks; nothing for the tool to know about itself.

Structurally enforced via package layout, not just documentation.

## Architectural inheritance

Phase 3.5 (test instance) + Phase 2.6 (install-path fixes) + agent-core-qa is one continuous arc:

- Phase 3.5 (#120) gave us a real test instance with its own home/port/SQLite, install code path identical to prod.
- Phase 2.6 (#121) fixed the install path (cu130 index, workspace-strip for vendored qwen-tts, dependency-confusion strategy).
- Phase 2.6's PR description named the next failure class: "does the daemon actually start after install" — Phase 2.7 territory.

This package is the standing dynamic surface for that next failure class:
- **Scenario 1** (`test_daemon_liveness`) is the autouse pytest precondition that catches the start-after-install class.
- **Scenario 3** (`test_install_identity_dynamic_keystone`) is the dynamic mirror of Phase 3.5's static keystone — invokes the REAL install + asserts ALL `EXPECTED_PACKAGES` wheels are present.
- Scenarios 2, 4, 5, 6, 7 cover the daemon-runs-and-serves surface for the rest of v0.3.0's load-bearing tools.

Bug-cadence observation generalizes: static artifact analysis catches config; dynamic real install catches reality. Each new release-validation surface earns its own scaffolding; this is that scaffolding for the runtime tier.

## Runbook

See `packages/agent-core-qa/README.md`. Short form:

```
AGENT_CORE_HOME=~/.agent-core-test agent-core daemon install --instance test --release v0.3.0
agent-core daemon start --instance test
cd packages/agent-core-qa && uv run pytest tests/
# all 7 pass → safe to refresh prod
# any fail → fix the regression first
```

Budget 10-15 minutes on first invocation (Scenario 3 triggers a second install with torch download); 2-3 minutes on subsequent runs.

## Transport adaptations (plan Step 0 authorized)

Each scenario was adapted to the actual wired transport via preflight discovery (plan explicitly allowed this). Key findings:

- **Daemon HTTP surface = MCPHostable endpoints only.** No direct `/bus/publish` or `/bus/inbox` route. All bus operations go through MCP tools (`send`, `list_pending`) on `/mcp/<agent>/` via FastMCP Streamable HTTP. Required adding `fastmcp>=3.0` as a dep.
- **Daemon has no HTTP liveness route.** `health_check()` falls back to TCP-connect on the bind port.
- **`qa` ClaudeCodeMCPEndpoint auto-clears routine green Acks.** Success Acks never appear in `list_pending` — Scenarios 5 (scheduler), 6 (discord_send) use error-absence + deliberate-probe assertion strategies instead of the plan's poll-for-Ack template. Scenario 7 (voice) bypasses by using direct `call_tool` (synchronous tool result is the audio).
- **`builtin.stub` is NOT MCPHostable AND emits no Acks** (neither routine green nor error). Stub absorbs everything; round-trip proof is `send returns published` + `list_pending count=0` + bus routing validation as separate-probe (Scenario 6 Phase 2).
- **Voice (Scenario 7) uses Route (a)** — `synthesize_speech` is MCP-tool-mounted on the `qa` endpoint via `register_voice_tools()`. Single `await client.call_tool(...)` returns audio path + duration.

Multi-tier review (sonnet per-task config-shape + opus end-to-end cross-cutting) caught the Scenario 6 routing-assertion signal-weakening; addressed in `026a0e2`.

## Sequencing dependency

This PR depends on PR #120 (Phase 3.5 three-instance daemon) being merged BEFORE the qa-runner can be validated against a v0.3.0 test daemon. Scenario 3's `--instance test` resolves only after PR #120 lands. The validation runbook expects:

1. PR #120 merges → `Instance.TEST` exists.
2. PR #121 merges → install path produces clean v0.3.0 wheels.
3. release-please #109 merges → v0.3.0 tag cut.
4. This PR merges.
5. Operator runs the runbook → all 7 scenarios pass against the live test daemon.

The qa-runner PR itself has NO code dependency on the other release-gate PRs (#119, #110, #120, #121); the merge order is operational, not structural.

**Also planned (separate commit):** PR #120 amendment to register `qa` MCPHostable endpoint in the test-instance default config — necessary for Scenarios 2, 4, 5, 6, 7 to hit `/mcp/qa/` after install. Pepper-approved option (A) per tonight's design coordination.

## Out of scope

See spec § Out of scope. Notable deferrals:
- Real Discord sandbox channel (Scenario 6 uses stubbed discord slot).
- Audio-quality validation (Scenario 7 asserts only non-empty + duration_s > 0).
- Error-paths beyond the happy-path-with-deliberate-probe used in Scenarios 5 and 6.
- Concurrency / interleaved scenarios.
- Auto-stand-up of test daemon by the qa-runner itself.
- CI integration (intentional — root `[tool.pytest.ini_options] testpaths` does NOT include `agent-core-qa/tests/`; this runbook is an operator tool, not a per-PR CI gate).

## Deferred polish (post-v0.3.0, low priority)

Surfaced by opus final review; not blocking ship:

- `BYPASS_LIVENESS` set in conftest uses string-literal test names (brittle to renames). Could replace with `@pytest.mark.bypass_liveness` + `request.node.iter_markers()`. Cosmetic; only 2 tests today.
- `agent-core-qa = { workspace = true }` not added to root `[tool.uv.sources]`. Foot-gun for any future package that adds qa-runner as a dev dep; currently fine because qa-runner is leaf-only.
- N+1 fastmcp.Client connection pattern across Scenarios 5 and 6 (3-4 handshakes per test). Could share an async session via fixture. Not load-bearing for smoke.
- `Path("/tmp")` in Scenario 3 is non-portable on Windows (becomes `C:\tmp\qa-xxx`). Spec-accepted per design; could swap to `tmp_path` fixture if cross-OS validation becomes a goal.

## Test plan

- [x] All 7 scenarios collect and behave correctly without a daemon (1 fail = liveness canary, 1 fail = pre-#120-instance, 5 skip).
- [x] `uv run ruff check packages/agent-core-qa/` clean.
- [x] `uv run mypy packages/agent-core-qa/src packages/agent-core-qa/tests` — 11 source files, no issues.
- [x] `uv run pytest -q` (full repo, excludes qa via testpaths) — 1186 passed, 5 skipped, 0 regressions.
- [ ] Live-daemon validation: deferred to v0.3.0 release-validation step (Scenario 1 + 3 require PR #120 merged; Scenarios 2/4/5/6/7 require qa endpoint provisioned via PR #120 amendment).
