### PR TITLE
chore: add MIT LICENSE + license field to all packages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jeff Richley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agent-core-briefs/pyproject.toml
+++ b/packages/agent-core-briefs/pyproject.toml
@@ -2,6 +2,7 @@
 name = "agent-core-briefs"
 dynamic = ["version"]
 description = "Brief framework — structured-composition pattern for agent_core"
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "agent-core",

--- a/packages/agent-core-busproxy/pyproject.toml
+++ b/packages/agent-core-busproxy/pyproject.toml
@@ -2,6 +2,7 @@
 name = "agent-core-busproxy"
 dynamic = ["version"]
 description = "Stdio MCP proxy — bridges Claude Code to the agent-core daemon bus tool surface with per-request backend sessions so a daemon bounce never strands the session."
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "fastmcp>=3.2",

--- a/packages/agent-core-channel/pyproject.toml
+++ b/packages/agent-core-channel/pyproject.toml
@@ -2,6 +2,7 @@
 name = "agent-core-channel"
 dynamic = ["version"]
 description = "Stdio MCP channel relay — bridges agent-core daemon notifications to Claude Code's wake mechanism."
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "mcp>=1.0",

--- a/packages/agent-core-discord/pyproject.toml
+++ b/packages/agent-core-discord/pyproject.toml
@@ -2,6 +2,7 @@
 name = "agent-core-discord"
 dynamic = ["version"]
 description = "Discord bot adapter for the agent-core bus — one bot per agent (1:1)."
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "agent-core",

--- a/packages/agent-core-hatchery/pyproject.toml
+++ b/packages/agent-core-hatchery/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "agent-core-hatchery"
 dynamic = ["version"]
 description = "Bootstrap system for hatching new agent-core beings"
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "jinja2>=3.1",

--- a/packages/agent-core-voice/pyproject.toml
+++ b/packages/agent-core-voice/pyproject.toml
@@ -2,6 +2,7 @@
 name = "agent-core-voice"
 dynamic = ["version"]
 description = "Voice synthesis endpoint for agent_core — per-agent Qwen3-TTS via ICL voice cloning"
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "agent-core",

--- a/packages/agent-core-webcam/pyproject.toml
+++ b/packages/agent-core-webcam/pyproject.toml
@@ -2,6 +2,7 @@
 name = "agent-core-webcam"
 dynamic = ["version"]
 description = "Webcam endpoint for agent_core — agent-driven on-demand frame capture"
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "agent-core",

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -2,6 +2,7 @@
 name = "agent-core"
 dynamic = ["version"]
 description = "Core infrastructure for AI agents - memory, knowledge compilation, and tooling"
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "claude-agent-sdk>=0.1.29",

--- a/packages/credentials/pyproject.toml
+++ b/packages/credentials/pyproject.toml
@@ -2,6 +2,7 @@
 name = "agent-core-credentials"
 dynamic = ["version"]
 description = "KeePass-backed credential vault for agent-core agents"
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "pykeepass>=4.1.1.post1",

--- a/packages/notify/pyproject.toml
+++ b/packages/notify/pyproject.toml
@@ -2,6 +2,7 @@
 name = "agent-core-notify"
 dynamic = ["version"]
 description = "Desktop notification MCP server for agent-core agents"
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "desktop-notifier>=5.0",


### PR DESCRIPTION
## Summary

Retroactively fills in OSS basics:

- Root-level `LICENSE` file (MIT, matching voice repo's text)
- `license = "MIT"` added to all 10 member packages' pyproject.toml

Aligns metadata with the project's implicit MIT intent and ensures built wheels carry license info.

## Packages updated

`core`, `notify`, `credentials`, `agent-core-briefs`, `agent-core-busproxy`, `agent-core-channel`, `agent-core-discord`, `agent-core-hatchery`, `agent-core-voice`, `agent-core-webcam`

## Test plan

- [x] Pre-push hook ran full suite locally: 1173 passed, 5 skipped, 7 deselected
- [ ] CI green
- [ ] Title-lint passes