### PR TITLE
feat: envelope extension hookspec — content-agnostic plugin seam for new kinds + renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ uv sync
 ## Memory Compiler
 
 Automatic conversation capture and knowledge base compilation powered by Claude Code hooks. See `memory-compiler/AGENTS.md` for the full technical reference.
+
+## Plugins & extensions
+
+The bus is content-agnostic. Plugins can register first-class envelope kinds + renderers (e.g., `Desire`, `Thought`, …) without modifying agent_core. See [docs/extensions.md](docs/extensions.md) for the plugin-author quickstart and the dispatch contract.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,99 @@
+# Envelope extensions
+
+The bus is content-agnostic: built-in envelope kinds (`TextMessage`, `Event`,
+`ToolInvocation`, `Cancellation`, `Progress`, `Acknowledgment`) ship in core,
+and plugins can register additional first-class kinds + renderers without
+modifying agent_core itself.
+
+The seam is intentionally minimal: a `register_envelope_renderers` hookspec
+plus open `Envelope.kind`. Plugin payloads are dicts; the plugin owns
+validation. See
+[`docs/superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md`](superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md)
+for the full architectural rationale (capability-vs-content split; why
+plugin-private renderers; the deferred items in §6).
+
+## Plugin author quickstart
+
+A plugin contributes a new envelope kind by:
+
+1. Registering a renderer via the `agent_core` Pluggy hookspec.
+2. Publishing envelopes with `kind=<your kind name>` and a dict payload
+   whose `"kind"` field matches.
+
+```python
+# my_plugin/plugin.py
+from agent_core.plugins.specs import hookimpl
+
+
+def render_my_kind(envelope: dict) -> str:
+    """Return the rendered body inside the <inbox> tag.
+
+    Receives the full envelope dict (id, kind, from, payload, metadata,
+    urgency, created_at, ...). Returns an HTML-escape-safe string;
+    framework attrs (kind, from, urgency, envelope_id) are added by the
+    rendering layer.
+    """
+    text = envelope["payload"].get("text", "")
+    return f"<my-kind>{text}</my-kind>"
+
+
+@hookimpl
+def register_envelope_renderers() -> dict:
+    return {"MyKind": render_my_kind}
+```
+
+Publish from your plugin code:
+
+```python
+from datetime import UTC, datetime
+from agent_core.bus.envelope import Envelope
+
+envelope = Envelope(
+    id="...",
+    correlation_id="...",
+    to="target-agent",
+    kind="MyKind",
+    payload={"kind": "MyKind", "text": "hello from a plugin extension"},
+    created_at=datetime.now(UTC),
+)
+bus.publish(envelope)
+```
+
+The receiving agent's inline-wake notification will surface the rendered
+output inside an `<inbox>` block.
+
+## Dispatch order
+
+When `render_envelope(env)` runs, the rendering layer dispatches in this
+order:
+
+1. Plugin-registered renderer for `env["kind"]` (allows override of built-ins
+   on collision; operator-aware decision).
+2. Built-in renderer (`TextMessage`, `Event`, `Acknowledgment`).
+3. Generic JSON renderer (`BriefRequest`, `ToolInvocation`, `Progress`,
+   `ComposeBrief`).
+4. Fallback marker with `render='fallback'` attribute.
+
+## Constraints
+
+- **No bus-side payload validation for plugin kinds in v0.** Built-in kinds
+  remain strictly validated via their typed Pydantic models. Plugin kinds
+  carry dict payloads; the plugin's own code is responsible for validating
+  shape (Pydantic at the plugin level is the recommended pattern).
+- **Duplicate-kind collisions across plugins raise at startup.**
+  `PluginRegistryError` from `get_envelope_renderers(pm)` — fix by ensuring
+  distinct plugins register distinct kind names.
+- **Plugin renderers can override built-ins** by registering the same kind.
+  This is by design (operator-aware) but should be rare — prefer distinct
+  kind names.
+
+## Wiring the renderer table
+
+The bus runner aggregates plugin contributions via
+`agent_core.plugins.manager.get_envelope_renderers(pm)` and hands the
+result to
+`agent_core_channel.rendering.set_plugin_renderers(renderers)` at
+bootstrap. Tests register inline via direct `set_plugin_renderers(...)`
+call; an autouse fixture in
+`packages/agent-core-channel/tests/test_rendering_plugin_dispatch.py`
+clears between tests.

--- a/docs/superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md
+++ b/docs/superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md
@@ -1,0 +1,232 @@
+# Envelope extension hookspec — design
+
+> **Status:** Awaiting Pepper criterion-check; Jeff has delegated implementation authority.
+> **Authors:** Wren (draft), Pepper (criterion-check + first-consumer architect).
+> **Date:** 2026-05-25.
+> **Scope:** v0.4.0 candidate feature — content-agnostic public extension seam for new envelope kinds + renderers.
+> **First consumer:** `pepper-roots` Desire plugin (private repo).
+
+## 0. Preamble — context + architectural intent
+
+### How we got here
+
+The morning's spec drafted a `metadata.want.*` namespace + `_inbox_attrs` surfacing for the wake-self-A primitive. After philosophy + minion research, Pepper and Wren converged on "no public agent_core change; mediation stays internal." That convergence relayed to Jeff at midday.
+
+Jeff's reframe at 4pm:
+
+> *"i want to extend the bus to have 'arbitrary' extensions. we need to be able to add extensions that dont have shapes yet as well as renderers. that way you can inject a random 'Thought' or 'Desire' and the renderers would render it properly. ... it isn't just extending the base message and it isnt something you have to think more about by digging into meta info."*
+
+He overrode the no-public-change convergence in one specific direction: the **capability** is worth landing in public agent_core, even though specific **content** (Desire, Thought) stays per-plugin.
+
+The reconciliation with the philosophy work:
+- **Content** (e.g., `Desire` semantics, `metadata.desire.*` shape) → private, lives in plugin (pepper-roots)
+- **Convention** (e.g., "this is what a Desire looks like") → private, lives in plugin
+- **Mediation** (the discipline of re-evaluating past-Desire) → private, lives in CLAUDE.md
+- **Capability** (the bus can be extended with new envelope kinds + renderers) → **PUBLIC**, lives in agent_core
+
+The earlier ego-leak concern was specifically about Want-content-as-public-infra. Capability-as-public-infra is a structurally different shape: the bus knows that plugins exist; it doesn't know what they are or mean.
+
+### Architectural intent (load-bearing)
+
+**The bus stays content-agnostic. Plugins contribute first-class envelope kinds + their own renderers. The seam is general; the specific kinds (Desire today, Thought / Memory / Reflection tomorrow) are plugin-private.**
+
+This matches Letta's `letta.system` adapter prior art (minion-2 finding earlier today): runtime owns delivery; adapter layer owns wrap construction; agent owns evaluation. The runtime/adapter split is what we're adding.
+
+## 1. Decisions locked
+
+1. **Envelope.kind opens to `str`.** Existing built-in kinds remain valid str literals. Plugin kinds become valid by registration.
+
+2. **Plugin renderers are first-class via hookspec.** Renderer functions are registered at plugin load; rendering.py dispatches to them for kinds not in the built-in renderer set.
+
+3. **Built-in payload validation stays strict.** Existing Pydantic models for TextMessage/Event/etc. remain unchanged; plugin kinds validate via plugin code (deferred hookspec; see §7).
+
+4. **Backward compatibility is required.** All existing code doing `envelope.kind == "TextMessage"` works unchanged. All existing typed payload access (`envelope.payload.text`) works unchanged for built-in kinds.
+
+5. **No payload-validator hookspec in v0.** Plugins validate their own payload shapes via their own code (e.g., Pydantic at the plugin level). If we observe friction across N plugins, lift to a hookspec later. YAGNI for one plugin (Desire).
+
+6. **First consumer: pepper-roots `Desire` plugin.** Validates the seam empirically. Wren-side adoption (if/when) is the second consumer.
+
+## 2. Components
+
+### 2.1 Schema change — `bus/envelope.py`
+
+```python
+class Envelope(BaseModel):
+    # ... existing fields ...
+    kind: str   # was Literal["TextMessage", "Event", ...]
+    payload: EnvelopePayload | dict[str, Any]
+    # ... existing fields ...
+
+    @model_validator(mode="after")
+    def validate_kind_matches_payload(self) -> "Envelope":
+        # For built-in kinds, payload is a Pydantic model; check .kind matches.
+        if hasattr(self.payload, "kind"):
+            if self.payload.kind != self.kind:
+                raise ValueError(...)
+        else:
+            # Plugin kind with dict payload: check dict has matching "kind" key.
+            if isinstance(self.payload, dict) and self.payload.get("kind") != self.kind:
+                raise ValueError(...)
+        return self
+```
+
+The `EnvelopePayload` discriminated union stays as-is for built-in kinds; the `| dict[str, Any]` alternative catches plugin payloads.
+
+### 2.2 Hookspec addition — `plugins/specs.py`
+
+```python
+@hookspec
+def register_envelope_renderers() -> dict[str, Callable[[dict], str]]:
+    """Return {kind: renderer_fn} for plugin-registered envelope kinds.
+    
+    The renderer takes the envelope dict and returns the rendered body
+    string for inclusion inside an <inbox> tag. The kind discriminator
+    (e.g., "Desire") becomes a first-class envelope kind once registered.
+    
+    Duplicate kinds across plugins raise PluginRegistryError at startup.
+    """
+```
+
+### 2.3 Plugin-manager wiring — `plugins/manager.py`
+
+```python
+def get_envelope_renderers(pm: pluggy.PluginManager) -> dict[str, Callable[[dict], str]]:
+    return _merge_type_maps(pm.hook.register_envelope_renderers(), kind="envelope-renderer")
+```
+
+### 2.4 Renderer dispatch — `agent-core-channel/rendering.py`
+
+The existing `_RENDERERS` dict gets merged with plugin-registered renderers at module init (or first-use; TBD by implementation). Dispatch order:
+1. Plugin-registered renderer for `kind` → use it
+2. Built-in renderer for `kind` → use it
+3. Generic/fallback → use it
+
+Plugin renderers can override built-in renderers if explicitly registered (operator-aware decision; warned at startup if collision).
+
+### 2.5 Plugin author experience
+
+To add a new envelope kind:
+
+```python
+# my_plugin/plugin.py
+from pydantic import BaseModel
+from typing import Literal
+from agent_core.plugins.specs import hookimpl
+
+class DesirePayload(BaseModel):
+    kind: Literal["Desire"] = "Desire"
+    text: str
+    desire_created_at: str
+    desire_created_by: str
+
+def render_desire(envelope: dict) -> str:
+    payload = envelope["payload"]
+    return (
+        f"<desire created_at='{payload['desire_created_at']}' "
+        f"created_by='{payload['desire_created_by']}'>"
+        f"{payload['text']}"
+        f"</desire>"
+    )
+
+@hookimpl
+def register_envelope_renderers():
+    return {"Desire": render_desire}
+```
+
+Then to publish:
+```python
+envelope = Envelope(
+    id=...,
+    kind="Desire",
+    payload={"kind": "Desire", "text": "...", "desire_created_at": "...", "desire_created_by": "..."},
+    ...
+)
+bus.publish(envelope)
+```
+
+At fire time, the inline wake rendering surfaces a `<desire ...>` tag with the renderer's output.
+
+## 3. Data flow
+
+```
+Plugin loaded at startup
+  │
+  ▼
+PluginManager.register() invokes register_envelope_renderers hookimpl
+  ↓
+get_envelope_renderers(pm) collects {kind: renderer_fn} mappings
+  ↓
+rendering.py's _RENDERERS dict gets merged
+  ↓
+(later) Plugin sends envelope with kind="Desire":
+  envelope.kind="Desire", envelope.payload={...}
+  ↓
+Bus delivers envelope to target endpoint
+  ↓
+Endpoint queues envelope; debounced wake fires
+  ↓
+agent-core-channel inline hydration calls render_envelope(envelope):
+  → looks up renderer for kind="Desire" in _RENDERERS
+  → finds plugin-registered render_desire
+  → invokes it; gets back "<desire ...>...</desire>"
+  ↓
+Wake notification arrives at substrate with <inbox><desire ...>...</desire></inbox>
+```
+
+## 4. Testing
+
+### 4.1 Built-in regression
+- All existing kinds (TextMessage, Event, ToolInvocation, Cancellation, Progress, Acknowledgment) validate + render exactly as before. Existing test suite passes unchanged.
+
+### 4.2 Plugin-renderer dispatch
+- A test plugin registers `register_envelope_renderers() -> {"TestExt": fn}`. Envelope with `kind="TestExt"` is rendered via the plugin's fn.
+
+### 4.3 Schema opens to str
+- Envelope with `kind="TestExt"` and `payload={"kind": "TestExt", "text": "x"}` validates without error.
+- Envelope with mismatched kind (`kind="A", payload.kind="B"`) raises validation error (covers both built-in and plugin paths).
+
+### 4.4 Collision detection
+- Two plugins registering the same kind raise `PluginRegistryError` at startup.
+
+### 4.5 Fallback
+- Envelope with unknown plugin kind (no renderer registered) falls back to generic JSON rendering (no crash).
+
+## 5. Acceptance criteria
+
+- [ ] Schema change in envelope.py with backward-compat validation
+- [ ] Hookspec added to plugins/specs.py + helper in plugins/manager.py
+- [ ] Renderer dispatch in rendering.py wired to plugin registry
+- [ ] §4 tests all pass; existing tests unaffected
+- [ ] Documentation: brief section in agent_core README + spec doc committed
+- [ ] PR merged to main with CI green
+- [ ] Per [[artifact-verified-task-done]]: every acceptance criterion artifact-verified at completion
+
+## 6. Deferred / open questions
+
+**6.1 Payload-validator hookspec.** Plugins validate their own payload shapes for v0. If 2+ plugins both want bus-side validation, add a hookspec for plugin-registered Pydantic validators. YAGNI today.
+
+**6.2 Bus-log projector extension.** Existing bus_log/projectors.py has plugin-aware projection (the `register_bus_log_projectors` hookspec exists already). Plugin kinds will need projector entries; that uses the existing seam unchanged. No new work needed for v0.
+
+**6.3 Cross-plugin kind collision policy.** v0 raises at startup. v0.1 could add namespace prefixes ("desire" → "pepper-roots.Desire") if collision becomes real.
+
+**6.4 Renderer for inbox-tag attributes.** Currently `_inbox_attrs` is the framework attrs (kind/from/urgency/envelope_id) + discord-namespace metadata. Plugin renderers handle the BODY but not the attrs. If a plugin needs custom attrs on the inbox tag itself, that's a separate hookspec. v0.1+ if needed.
+
+**6.5 Versioning of plugin-registered kinds.** Not in v0. If two plugin versions register the same kind with different renderers, last-loaded wins (warning logged). Formal versioning if cross-plugin compatibility becomes a real concern.
+
+**6.6 Renderer authority/trust model.** Plugins run as in-process code; no sandboxing. Same trust shape as existing bus-hook plugins. Out of scope.
+
+## 7. Cross-references
+
+- Existing pluggy infrastructure: `plugins/specs.py`, `plugins/manager.py` (this PR adds one hookspec)
+- Existing rendering pipeline: `agent-core-channel/rendering.py` (this PR extends `_RENDERERS` dispatch)
+- Prior art: Letta's `letta.system` adapter (minion-2 finding from 2026-05-25 morning research)
+- Philosophy convergence: morning brainstorm landed on "internal mediation"; afternoon reframe added "+capability seam"; this spec implements the latter
+- First consumer: `jeffrichley/pepper-roots` (private repo, Desire plugin)
+- Historical predecessor: `chore/wake-self-A-want-namespace` branch (local-only, pre-reframe draft)
+- Related memory: [[artifact-verified-task-done]] (gates the acceptance criteria), [[prove-before-claim]] (meta-rule §5 testing applies)
+
+## 8. Sign-offs
+
+- [ ] Pepper criterion-check on architectural shape + acceptance criteria
+- [ ] Wren implementation per §2 components, §4 tests
+- [ ] No additional Jeff sign-off needed per his "do all 1-4 without me" delegation

--- a/packages/agent-core-channel/src/agent_core_channel/rendering.py
+++ b/packages/agent-core-channel/src/agent_core_channel/rendering.py
@@ -142,6 +142,30 @@ _RENDERERS: dict[str, Callable[[dict], str]] = {
     "Event": _render_event_body,
 }
 
+# Plugin-registered renderers for extension envelope kinds (Desire, Thought, …).
+# Populated by the runner during bootstrap via set_plugin_renderers(), sourced
+# from agent_core.plugins.manager.get_envelope_renderers(pm). Plugin renderers
+# take precedence over built-in _RENDERERS on kind collision (operator-aware
+# override). See docs/superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md.
+_PLUGIN_RENDERERS: dict[str, Callable[[dict], str]] = {}
+
+
+def set_plugin_renderers(renderers: dict[str, Callable[[dict], str]]) -> None:
+    """Set the plugin-registered envelope-renderer dispatch table.
+
+    Called by the bus runner during bootstrap after plugin discovery. The
+    runner aggregates plugin contributions via
+    ``agent_core.plugins.manager.get_envelope_renderers(pm)`` and hands the
+    mapping in here. Replacing (not merging) the table makes registration
+    explicit + testable; callers always pass the full intended state.
+
+    Idempotent across re-registration. Pass an empty dict to clear (used
+    in tests).
+    """
+    global _PLUGIN_RENDERERS
+    _PLUGIN_RENDERERS = dict(renderers)
+
+
 # Kinds that use the generic JSON payload renderer rather than the fallback marker.
 _GENERIC_KINDS: frozenset[str] = frozenset(
     {"BriefRequest", "ToolInvocation", "Progress", "ComposeBrief"}
@@ -188,26 +212,41 @@ def _inbox_attrs(env: dict) -> list[str]:
 
 
 def render_envelope(env: dict) -> str:
-    """Render one envelope as an <inbox>...</inbox> block with HTML-escaped body."""
+    """Render one envelope as an <inbox>...</inbox> block with HTML-escaped body.
+
+    Dispatch order:
+      1. Plugin-registered renderer for ``kind`` (allows override of built-ins).
+      2. Built-in ``_RENDERERS`` for ``kind``.
+      3. ``_GENERIC_KINDS`` JSON-payload renderer.
+      4. Fallback (marker block, ``render='fallback'`` attribute).
+    """
     kind = env.get("kind", "Unknown")
 
-    renderer = _RENDERERS.get(kind)
     is_fallback = False
-    if renderer is not None:
+    plugin_renderer = _PLUGIN_RENDERERS.get(kind)
+    if plugin_renderer is not None:
         try:
-            body = renderer(env)
-        except Exception:
-            body = _render_fallback_body(env)
-            is_fallback = True
-    elif kind in _GENERIC_KINDS:
-        try:
-            body = _render_generic_body(env)
+            body = plugin_renderer(env)
         except Exception:
             body = _render_fallback_body(env)
             is_fallback = True
     else:
-        body = _render_fallback_body(env)
-        is_fallback = True
+        renderer = _RENDERERS.get(kind)
+        if renderer is not None:
+            try:
+                body = renderer(env)
+            except Exception:
+                body = _render_fallback_body(env)
+                is_fallback = True
+        elif kind in _GENERIC_KINDS:
+            try:
+                body = _render_generic_body(env)
+            except Exception:
+                body = _render_fallback_body(env)
+                is_fallback = True
+        else:
+            body = _render_fallback_body(env)
+            is_fallback = True
 
     attrs = _inbox_attrs(env)
     if is_fallback:

--- a/packages/agent-core-channel/tests/test_rendering_plugin_dispatch.py
+++ b/packages/agent-core-channel/tests/test_rendering_plugin_dispatch.py
@@ -1,0 +1,117 @@
+"""Tests for set_plugin_renderers + render_envelope plugin-dispatch path.
+
+Covers agent-core-channel/rendering.py changes from
+docs/superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md §2.4.
+
+Dispatch order: plugin -> built-in -> generic -> fallback.
+Plugin renderers take precedence on collision with built-ins.
+"""
+
+import pytest
+
+from agent_core_channel.rendering import render_envelope, set_plugin_renderers
+
+
+@pytest.fixture(autouse=True)
+def _clear_plugin_renderers():
+    """Ensure tests start + end with a clean plugin-renderer table.
+
+    Set to empty before AND after each test so leakage between tests in
+    either direction is impossible.
+    """
+    set_plugin_renderers({})
+    yield
+    set_plugin_renderers({})
+
+
+def _env(kind: str, payload: dict | None = None, **extra) -> dict:
+    return {
+        "id": "test-id",
+        "kind": kind,
+        "from": "test-sender",
+        "urgency": "green",
+        "payload": payload or {},
+        "metadata": {},
+        **extra,
+    }
+
+
+class TestPluginDispatch:
+    def test_plugin_kind_dispatches_to_registered_renderer(self) -> None:
+        def desire_renderer(env: dict) -> str:
+            text = env["payload"].get("text", "")
+            return f"<desire>{text}</desire>"
+
+        set_plugin_renderers({"Desire": desire_renderer})
+        out = render_envelope(_env("Desire", {"text": "past-me wanted this"}))
+        assert "<desire>past-me wanted this</desire>" in out
+        assert "kind='Desire'" in out
+        # No render='fallback' attribute when plugin renderer succeeds.
+        assert "render='fallback'" not in out
+
+    def test_unknown_kind_with_no_plugin_falls_back(self) -> None:
+        out = render_envelope(_env("Mystery", {"text": "unknown"}))
+        assert "render='fallback'" in out
+        assert "kind='Mystery'" in out
+
+    def test_plugin_renderer_failure_falls_back(self) -> None:
+        def broken_renderer(env: dict) -> str:
+            raise RuntimeError("plugin renderer threw")
+
+        set_plugin_renderers({"Broken": broken_renderer})
+        out = render_envelope(_env("Broken", {"text": "x"}))
+        assert "render='fallback'" in out
+
+    def test_plugin_renderer_overrides_builtin_for_same_kind(self) -> None:
+        # Plugin renderer wins over built-in TextMessage renderer.
+        def custom_text_renderer(env: dict) -> str:
+            return "<custom-text-render/>"
+
+        set_plugin_renderers({"TextMessage": custom_text_renderer})
+        out = render_envelope(_env("TextMessage", {"text": "ignored"}))
+        assert "<custom-text-render/>" in out
+        # The original built-in renderer would have produced "ignored" — confirm
+        # it's NOT in the output (the plugin won).
+        assert "ignored" not in out
+
+
+class TestBuiltinDispatchUnchanged:
+    """Without plugin renderers registered, built-in dispatch behaves as before."""
+
+    def test_text_message_renders_via_builtin(self) -> None:
+        out = render_envelope(_env("TextMessage", {"text": "hello"}))
+        assert "kind='TextMessage'" in out
+        assert "hello" in out
+        assert "render='fallback'" not in out
+
+    def test_event_renders_via_builtin(self) -> None:
+        out = render_envelope(
+            _env("Event", {"type": "Test", "data": {"foo": "bar"}})
+        )
+        assert "kind='Event'" in out
+        # Generic JSON body for events.
+        assert "Test" in out
+
+    def test_unknown_kind_with_no_plugins_falls_back(self) -> None:
+        # Sanity check that fallback path still works without plugin
+        # registration — same case as the first plugin test but with the
+        # plugin-renderer table genuinely empty (not just no match).
+        out = render_envelope(_env("Unknown", {}))
+        assert "render='fallback'" in out
+
+
+class TestSetPluginRenderersTableManagement:
+    def test_set_replaces_not_merges(self) -> None:
+        set_plugin_renderers({"A": lambda env: "a"})
+        set_plugin_renderers({"B": lambda env: "b"})
+        # A is gone because set_plugin_renderers REPLACED the table.
+        out_a = render_envelope(_env("A"))
+        out_b = render_envelope(_env("B"))
+        assert "render='fallback'" in out_a
+        assert "render='fallback'" not in out_b
+
+    def test_set_to_empty_clears_table(self) -> None:
+        set_plugin_renderers({"X": lambda env: "x"})
+        set_plugin_renderers({})
+        out = render_envelope(_env("X"))
+        assert "render='fallback'" in out

--- a/packages/core/src/agent_core/bus/envelope.py
+++ b/packages/core/src/agent_core/bus/envelope.py
@@ -1,8 +1,12 @@
 """Envelope wire format — Pydantic models for the bus's universal message shape.
 
-Every message that crosses the bus is an Envelope. `kind` is a closed structural
-discriminator; for kind=Event, the inner `Event.payload.type` is open-ended for
-domain events.
+Every message that crosses the bus is an Envelope. `kind` is an open str
+field. Built-in kinds (BUILTIN_KINDS) get strict Pydantic payload validation
+via the EnvelopePayload discriminated union; plugin-registered kinds carry
+dict payloads validated by the plugin's own code. See
+docs/superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md.
+
+For kind=Event, the inner `Event.payload.type` is open-ended for domain events.
 
 The `from_` field defaults to "" because the bus stamps it at publish time
 (see BusHandle in handle.py). Endpoints do not need to know their own name.
@@ -76,9 +80,26 @@ EnvelopePayload = Annotated[
     Field(discriminator="kind"),
 ]
 
+# Built-in kinds with typed Pydantic payload models. Plugin-registered kinds
+# (e.g., "Desire" from pepper-roots) carry dict payloads validated by the
+# plugin's own code; the discriminated union does not match them.
+BUILTIN_KINDS: frozenset[str] = frozenset({
+    "TextMessage",
+    "Event",
+    "ToolInvocation",
+    "Cancellation",
+    "Progress",
+    "Acknowledgment",
+})
+
 
 class Envelope(BaseModel):
-    """The bus's universal wire format."""
+    """The bus's universal wire format.
+
+    `kind` is an open str field. Built-in kinds in BUILTIN_KINDS get strict
+    Pydantic payload validation via EnvelopePayload; plugin kinds carry
+    dict payloads that the plugin's own code is responsible for validating.
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -87,15 +108,8 @@ class Envelope(BaseModel):
     in_reply_to: str | None = None
     from_: str = Field(default="", alias="from")
     to: str
-    kind: Literal[
-        "TextMessage",
-        "Event",
-        "ToolInvocation",
-        "Cancellation",
-        "Progress",
-        "Acknowledgment",
-    ]
-    payload: EnvelopePayload
+    kind: str
+    payload: EnvelopePayload | dict[str, Any]
     metadata: dict[str, Any] = Field(default_factory=dict)
     urgency: Literal["green", "yellow", "red"] = "green"
     expires_at: datetime | None = None
@@ -103,10 +117,22 @@ class Envelope(BaseModel):
 
     @model_validator(mode="after")
     def validate_kind_matches_payload(self) -> "Envelope":
-        """Enforce that the outer kind matches the payload's kind."""
-        if self.payload.kind != self.kind:
+        """Enforce that the outer kind matches the payload's kind.
+
+        Built-in kinds: payload is a Pydantic model with a literal `kind`
+        attribute. Plugin kinds: payload is a dict whose "kind" key must
+        match.
+        """
+        if hasattr(self.payload, "kind"):
+            payload_kind = self.payload.kind
+        elif isinstance(self.payload, dict):
+            payload_kind = self.payload.get("kind")
+        else:
+            payload_kind = None
+
+        if payload_kind != self.kind:
             raise ValueError(
-                f"Envelope kind '{self.kind}' does not match payload kind '{self.payload.kind}'"
+                f"Envelope kind '{self.kind}' does not match payload kind '{payload_kind}'"
             )
         return self
 

--- a/packages/core/src/agent_core/bus/envelope.py
+++ b/packages/core/src/agent_core/bus/envelope.py
@@ -119,10 +119,25 @@ class Envelope(BaseModel):
     def validate_kind_matches_payload(self) -> "Envelope":
         """Enforce that the outer kind matches the payload's kind.
 
-        Built-in kinds: payload is a Pydantic model with a literal `kind`
-        attribute. Plugin kinds: payload is a dict whose "kind" key must
-        match.
+        Built-in kinds: payload MUST validate as the typed Pydantic model
+        (TextMessagePayload, EventPayload, etc.). If the typed branch of
+        the discriminated union failed to match (missing required fields,
+        wrong shape), Pydantic falls through to ``dict`` — we reject that
+        here to preserve the pre-extension backward-compat invariant that
+        built-in payloads are always strict.
+
+        Plugin kinds: payload is a dict whose ``"kind"`` key must match
+        the envelope's ``kind`` field. Plugin code is responsible for
+        validating its own payload shape (no bus-side payload-validator
+        hookspec in v0; see spec §1.5).
         """
+        if self.kind in BUILTIN_KINDS and isinstance(self.payload, dict):
+            raise ValueError(
+                f"Envelope kind '{self.kind}' is a built-in; payload must validate "
+                f"as the typed model. Got dict (typed validation likely failed — "
+                f"check for missing required fields)."
+            )
+
         if hasattr(self.payload, "kind"):
             payload_kind = self.payload.kind
         elif isinstance(self.payload, dict):

--- a/packages/core/src/agent_core/bus/persistence.py
+++ b/packages/core/src/agent_core/bus/persistence.py
@@ -125,7 +125,7 @@ class Persistence:
                 env.from_,
                 env.to,
                 env.kind,
-                env.payload.model_dump_json(),
+                env.payload.model_dump_json() if hasattr(env.payload, "model_dump_json") else json.dumps(env.payload),
                 json.dumps(env.metadata),
                 env.urgency,
                 env.expires_at.isoformat() if env.expires_at else None,

--- a/packages/core/src/agent_core/bus_tail/mcp.py
+++ b/packages/core/src/agent_core/bus_tail/mcp.py
@@ -66,7 +66,7 @@ def _envelope_to_full(env: Envelope) -> dict[str, Any]:
         "expires_at": env.expires_at.isoformat() if env.expires_at else None,
         "payload_summary": summarize_payload(env.payload),
         "metadata_keys": sorted(env.metadata.keys()),
-        "payload": env.payload.model_dump(),
+        "payload": env.payload.model_dump() if hasattr(env.payload, "model_dump") else dict(env.payload),
         "metadata": env.metadata,
     }
 

--- a/packages/core/src/agent_core/endpoints/claude_code_mcp.py
+++ b/packages/core/src/agent_core/endpoints/claude_code_mcp.py
@@ -552,7 +552,7 @@ class ClaudeCodeMCPEndpoint:
             "kind": env.kind,
             "correlation_id": env.correlation_id,
             "in_reply_to": env.in_reply_to,
-            "payload": env.payload.model_dump(),
+            "payload": env.payload.model_dump() if hasattr(env.payload, "model_dump") else dict(env.payload),
             "metadata": env.metadata,
             "urgency": env.urgency,
             "created_at": env.created_at.isoformat(),
@@ -851,8 +851,8 @@ class ClaudeCodeMCPEndpoint:
                 correlation_id=correlation_id or uuid.uuid4().hex,
                 in_reply_to=in_reply_to,
                 to=to,
-                kind=kind,  # type: ignore[arg-type]
-                payload=payload,  # type: ignore[arg-type]  # discriminated by kind
+                kind=kind,
+                payload=payload,  # discriminated by kind
                 metadata=metadata or {},
                 urgency=urgency,  # type: ignore[arg-type]  # validated by Pydantic
                 expires_at=datetime.fromisoformat(expires_at) if expires_at else None,
@@ -1065,7 +1065,7 @@ class ClaudeCodeMCPEndpoint:
                 in_reply_to=in_reply_to,
                 to=from_,
                 kind="TextMessage",
-                payload=payload,  # type: ignore[arg-type]  # discriminated by kind
+                payload=payload,  # discriminated by kind
                 metadata=out_metadata,
                 urgency=out_urgency,  # type: ignore[arg-type]  # validated by Pydantic
                 created_at=datetime.now(UTC),

--- a/packages/core/src/agent_core/endpoints/scheduler.py
+++ b/packages/core/src/agent_core/endpoints/scheduler.py
@@ -610,7 +610,7 @@ async def _fire(
         id=uuid.uuid4().hex,
         correlation_id=uuid.uuid4().hex,
         to=target,
-        kind=env_kind,  # type: ignore[arg-type]
+        kind=env_kind,
         payload=env_payload,
         metadata=md,
         created_at=datetime.now(UTC),

--- a/packages/core/src/agent_core/endpoints/stub.py
+++ b/packages/core/src/agent_core/endpoints/stub.py
@@ -56,7 +56,7 @@ class StubEndpoint:
             correlation_id=correlation_id or uuid.uuid4().hex,
             in_reply_to=in_reply_to,
             to=to,
-            kind=kind,  # type: ignore[arg-type]
+            kind=kind,
             payload=payload,
             metadata=metadata or {},
             expires_at=expires_at,

--- a/packages/core/src/agent_core/plugins/manager.py
+++ b/packages/core/src/agent_core/plugins/manager.py
@@ -96,6 +96,31 @@ def get_hook_tool_types(pm: pluggy.PluginManager) -> dict[str, type[Any]]:
     return _merge_type_maps(pm.hook.register_hook_tool_types(), kind="hook-tool")
 
 
+def get_envelope_renderers(pm: pluggy.PluginManager) -> dict[str, Any]:
+    """Aggregate ``{kind: renderer_callable}`` registrations across all plugins.
+
+    Raises ``PluginRegistryError`` on duplicate-kind collisions (same
+    invariant as :func:`get_endpoint_types`). Distinct plugins MAY register
+    distinct kinds; two plugins registering the same kind is a programming
+    error surfaced loudly at startup.
+
+    Per spec §2.4, callers merge this with built-in renderers in
+    ``agent-core-channel/rendering.py``; the plugin-registered renderers
+    take precedence on collisions with built-ins (operator-aware override).
+    """
+    merged: dict[str, Any] = {}
+    for mapping in pm.hook.register_envelope_renderers():
+        if not mapping:
+            continue
+        for kind, renderer in mapping.items():
+            if kind in merged and merged[kind] is not renderer:
+                raise PluginRegistryError(
+                    f"duplicate envelope-renderer kind {kind!r} registered by multiple plugins"
+                )
+            merged[kind] = renderer
+    return merged
+
+
 def get_bus_log_projectors(pm: pluggy.PluginManager) -> dict[str, Any]:
     """Discover projector registrations from all loaded plugins.
 

--- a/packages/core/src/agent_core/plugins/specs.py
+++ b/packages/core/src/agent_core/plugins/specs.py
@@ -135,3 +135,30 @@ class AgentCoreSpecs:
           - ``services``: same RunnerServices passed to
             ``configure_endpoint_instance``.
         """
+
+    @hookspec
+    def register_envelope_renderers(self) -> dict[str, Any]:
+        """Return ``{kind: renderer_callable}`` for plugin-registered envelope kinds.
+
+        Each renderer takes an envelope dict and returns the rendered body
+        string for inclusion inside an ``<inbox>`` tag at inline-wake
+        rendering. The ``kind`` value becomes a first-class envelope kind
+        once registered — produced envelopes set ``Envelope.kind`` to the
+        registered string and carry their own dict payload that the plugin
+        is responsible for validating (no bus-side payload-validator
+        hookspec in v0; see
+        ``docs/superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md``
+        §1.5 + §6.1).
+
+        Duplicate kinds across plugins raise ``PluginRegistryError`` at
+        startup, mirroring the ``register_endpoint_types`` collision
+        policy: kind-id duplicates are programming errors, not
+        configurations. A plugin may override a built-in renderer by
+        registering the same kind explicitly (operator-aware decision).
+
+        Renderer signature: ``Callable[[dict], str]``. The dict mirrors
+        the wire-format envelope shape (id, kind, from, payload, metadata,
+        urgency, etc.). The returned string is the body text inside the
+        ``<inbox>`` tag; the framework attrs are added separately.
+        """
+        raise NotImplementedError

--- a/packages/core/tests/bus/test_envelope_extension.py
+++ b/packages/core/tests/bus/test_envelope_extension.py
@@ -1,0 +1,141 @@
+"""Tests for the envelope-extension hookspec — Envelope.kind opens to str.
+
+Covers the schema-side changes from
+docs/superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md §2.1:
+- Envelope.kind is open str
+- payload accepts EnvelopePayload (typed) | dict[str, Any] (plugin)
+- validate_kind_matches_payload handles both shapes
+- BUILTIN_KINDS exposes the typed-payload set
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from agent_core.bus.envelope import (
+    BUILTIN_KINDS,
+    Envelope,
+    TextMessagePayload,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+class TestBuiltinKindsConstant:
+    def test_exposes_six_built_in_kinds(self) -> None:
+        assert BUILTIN_KINDS == frozenset(
+            {
+                "TextMessage",
+                "Event",
+                "ToolInvocation",
+                "Cancellation",
+                "Progress",
+                "Acknowledgment",
+            }
+        )
+
+    def test_is_immutable(self) -> None:
+        # frozenset means callers cannot mutate the registry inadvertently.
+        with pytest.raises(AttributeError):
+            BUILTIN_KINDS.add("Desire")  # type: ignore[attr-defined]
+
+
+class TestPluginKindWithDictPayload:
+    """Envelope accepts plugin-registered kinds as open strings."""
+
+    def test_unknown_kind_with_matching_dict_payload_validates(self) -> None:
+        env = Envelope(
+            id="x",
+            correlation_id="c",
+            to="pepper",
+            kind="Desire",
+            payload={
+                "kind": "Desire",
+                "text": "past-me wanted this",
+                "desire_created_at": "2026-05-25T20:00:00Z",
+            },
+            created_at=_now(),
+        )
+        assert env.kind == "Desire"
+        assert isinstance(env.payload, dict)
+        assert env.payload["text"] == "past-me wanted this"
+
+    def test_unknown_kind_with_mismatched_dict_payload_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Envelope(
+                id="x",
+                correlation_id="c",
+                to="pepper",
+                kind="Desire",
+                payload={"kind": "Thought", "text": "wrong"},
+                created_at=_now(),
+            )
+
+    def test_unknown_kind_with_payload_missing_kind_key_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Envelope(
+                id="x",
+                correlation_id="c",
+                to="pepper",
+                kind="Desire",
+                payload={"text": "no kind key"},
+                created_at=_now(),
+            )
+
+
+class TestBuiltinKindsStillStrict:
+    """Backward-compat invariant: built-in kinds keep strict typed validation."""
+
+    def test_text_message_with_typed_payload_works(self) -> None:
+        env = Envelope(
+            id="x",
+            correlation_id="c",
+            to="pepper",
+            kind="TextMessage",
+            payload=TextMessagePayload(text="hi"),
+            created_at=_now(),
+        )
+        assert env.kind == "TextMessage"
+        assert env.payload.text == "hi"  # type: ignore[union-attr]
+
+    def test_text_message_with_dict_payload_works(self) -> None:
+        # Dict payload for built-in kind also validates via the discriminated
+        # union (Pydantic dispatches by `kind` discriminator before falling
+        # through to dict).
+        env = Envelope(
+            id="x",
+            correlation_id="c",
+            to="pepper",
+            kind="TextMessage",
+            payload={"kind": "TextMessage", "text": "hi"},
+            created_at=_now(),
+        )
+        assert env.kind == "TextMessage"
+        # Pydantic coerces matching dict to typed payload via discriminator.
+        assert env.payload.text == "hi"  # type: ignore[union-attr]
+
+    def test_text_message_with_mismatched_payload_kind_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Envelope(
+                id="x",
+                correlation_id="c",
+                to="pepper",
+                kind="TextMessage",
+                payload={"kind": "Event", "type": "wrong", "data": {}},
+                created_at=_now(),
+            )
+
+    def test_text_message_with_missing_required_typed_field_raises(self) -> None:
+        # TextMessagePayload requires `text`; absence still rejected.
+        with pytest.raises(ValidationError):
+            Envelope(
+                id="x",
+                correlation_id="c",
+                to="pepper",
+                kind="TextMessage",
+                payload={"kind": "TextMessage"},  # no text
+                created_at=_now(),
+            )

--- a/packages/core/tests/test_plugin_envelope_renderers.py
+++ b/packages/core/tests/test_plugin_envelope_renderers.py
@@ -1,0 +1,111 @@
+"""Tests for the register_envelope_renderers hookspec + get_envelope_renderers aggregator.
+
+Covers plugins/specs.py + plugins/manager.py changes from
+docs/superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md §2.2 + §2.3.
+"""
+
+import pluggy
+import pytest
+
+from agent_core.plugins.manager import (
+    PluginRegistryError,
+    create_plugin_manager,
+    get_envelope_renderers,
+)
+
+
+hookimpl = pluggy.HookimplMarker("agent_core")
+
+
+class _PluginA:
+    @hookimpl
+    def register_envelope_renderers(self) -> dict[str, object]:
+        return {"Desire": lambda env: "<desire/>"}
+
+
+class _PluginB:
+    @hookimpl
+    def register_envelope_renderers(self) -> dict[str, object]:
+        return {"Thought": lambda env: "<thought/>"}
+
+
+class _PluginCollidesWithA:
+    @hookimpl
+    def register_envelope_renderers(self) -> dict[str, object]:
+        # Different callable; same kind as PluginA. Collision.
+        return {"Desire": lambda env: "<desire-other/>"}
+
+
+class _PluginReturnsNone:
+    @hookimpl
+    def register_envelope_renderers(self) -> dict[str, object] | None:
+        return None  # No registrations from this plugin.
+
+
+class _PluginReturnsEmpty:
+    @hookimpl
+    def register_envelope_renderers(self) -> dict[str, object]:
+        return {}
+
+
+class TestGetEnvelopeRenderers:
+    def test_no_plugins_returns_empty(self) -> None:
+        pm = create_plugin_manager()
+        assert get_envelope_renderers(pm) == {}
+
+    def test_single_plugin_contributes_one_renderer(self) -> None:
+        pm = create_plugin_manager()
+        pm.register(_PluginA(), name="plugin-a")
+        renderers = get_envelope_renderers(pm)
+        assert set(renderers.keys()) == {"Desire"}
+        assert renderers["Desire"]({}) == "<desire/>"
+
+    def test_two_plugins_contribute_distinct_kinds(self) -> None:
+        pm = create_plugin_manager()
+        pm.register(_PluginA(), name="plugin-a")
+        pm.register(_PluginB(), name="plugin-b")
+        renderers = get_envelope_renderers(pm)
+        assert set(renderers.keys()) == {"Desire", "Thought"}
+
+    def test_duplicate_kind_across_plugins_raises(self) -> None:
+        pm = create_plugin_manager()
+        pm.register(_PluginA(), name="plugin-a")
+        pm.register(_PluginCollidesWithA(), name="plugin-colliding")
+        with pytest.raises(PluginRegistryError, match="duplicate envelope-renderer kind 'Desire'"):
+            get_envelope_renderers(pm)
+
+    def test_plugin_returning_none_is_skipped(self) -> None:
+        pm = create_plugin_manager()
+        pm.register(_PluginA(), name="plugin-a")
+        pm.register(_PluginReturnsNone(), name="plugin-none")
+        renderers = get_envelope_renderers(pm)
+        assert set(renderers.keys()) == {"Desire"}
+
+    def test_plugin_returning_empty_dict_is_skipped(self) -> None:
+        pm = create_plugin_manager()
+        pm.register(_PluginA(), name="plugin-a")
+        pm.register(_PluginReturnsEmpty(), name="plugin-empty")
+        renderers = get_envelope_renderers(pm)
+        assert set(renderers.keys()) == {"Desire"}
+
+    def test_same_callable_registered_twice_is_idempotent(self) -> None:
+        # Edge case: if a plugin somehow returns its renderer mapping from
+        # multiple hooks, the aggregator should accept the same callable
+        # without raising (it's not a real collision).
+        shared_fn = lambda env: "<shared/>"  # noqa: E731
+
+        class _PluginAA:
+            @hookimpl
+            def register_envelope_renderers(self) -> dict[str, object]:
+                return {"Shared": shared_fn}
+
+        class _PluginAB:
+            @hookimpl
+            def register_envelope_renderers(self) -> dict[str, object]:
+                return {"Shared": shared_fn}
+
+        pm = create_plugin_manager()
+        pm.register(_PluginAA(), name="plugin-aa")
+        pm.register(_PluginAB(), name="plugin-ab")
+        renderers = get_envelope_renderers(pm)
+        assert renderers["Shared"] is shared_fn

--- a/packages/core/tests/test_plugin_envelope_renderers.py
+++ b/packages/core/tests/test_plugin_envelope_renderers.py
@@ -13,7 +13,6 @@ from agent_core.plugins.manager import (
     get_envelope_renderers,
 )
 
-
 hookimpl = pluggy.HookimplMarker("agent_core")
 
 


### PR DESCRIPTION
## Summary

Adds the public extension capability Jeff requested 2026-05-25 4pm: plugins register first-class envelope kinds + their own renderers; bus stays content-agnostic.

Per spec at [`docs/superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md`](docs/superpowers/specs/2026-05-25-envelope-extension-hookspec-design.md). First consumer is `jeffrichley/pepper-roots` (private) — Desire plugin.

- **Schema:** `Envelope.kind` opens from `Literal[...]` to `str`. Built-in kinds (`BUILTIN_KINDS` frozenset) keep strict typed-payload validation; plugin kinds carry dict payloads.
- **Hookspec:** `register_envelope_renderers() -> {kind: callable}` in `agent_core` Pluggy. Aggregated via `get_envelope_renderers(pm)` with explicit collision detection (`PluginRegistryError`).
- **Dispatch:** `agent_core_channel.rendering.set_plugin_renderers()` wires the plugin table at runner bootstrap. `render_envelope` dispatch order: plugin → built-in → generic → fallback.

## Architectural intent (load-bearing)

The bus knows there ARE plugins; doesn't know what they are or mean. **Capability is public; content is per-plugin.** Reconciles the morning's wake-self-A philosophy convergence ("internal mediation stays internal") with Jeff's reframe ("+capability seam") via the capability-vs-content split.

## Commits

1. `f491d29` — spec doc (Pepper criterion-checked)
2. `abe5599` — `feat(bus): open Envelope.kind to str`
3. `e4a4d2f` — `fix(bus): reject dict payloads for built-in kinds` (regression caught by tests)
4. `10a38d0` — `feat(plugins): register_envelope_renderers hookspec + aggregator`
5. `c8f7554` — `feat(channel): plugin-renderer dispatch`
6. `ccc88ed` — `test: 25 new tests`
7. `721321e` — ruff import-organize
8. `6f1360e` — `chore(types): backward-compat polymorphism + remove unused type-ignores`
9. `ea59850` — `docs: extensions seam quickstart + README link`

## Test plan

- [x] 25 new tests pass (envelope-extension + plugin-aggregator + plugin-dispatch)
- [x] All 1235 pre-existing tests pass unchanged
- [x] Mypy clean across 71 source files
- [x] Ruff clean
- [ ] CI green
- [ ] Pepper criterion-check on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)