### PR TITLE
ci(release-please): use GitHub App token instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  # Manual dispatch fallback. The App-token swap below should close the
+  # GITHUB_TOKEN anti-recursion family (events authored by the App DO
+  # fire downstream workflows), but kept as belt-and-suspenders for the
+  # rare case the auto-fire from push misses.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -13,9 +18,22 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived installation token from the agent-core-release-bot
+      # GitHub App (App ID stored in RELEASE_BOT_APP_ID secret). Events
+      # authored by this token cascade to downstream workflows correctly,
+      # fixing the cycle that bit us 4 times today (release.yml not auto-
+      # firing on release.published, release-please PR checks not firing,
+      # etc.). See:
+      # https://github.com/googleapis/release-please-action#using-with-a-github-app
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@8b8fd2cc23b2e18957157a9d923d75aa0c6f6ad5  # v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Swap `release-please.yml` from `GITHUB_TOKEN` to a short-lived installation token minted from the `agent-core-release-bot` GitHub App (installed on this repo today, 2026-05-25).

## Why

GitHub deliberately blocks `GITHUB_TOKEN`-authored events from triggering downstream workflows (anti-loop guard). This blocked:
1. `release.yml` not auto-firing on `release.published` (Saturday)
2. `release-please.yml` CI miss (this morning)
3. `pr-title-lint` missing `reopened` types (separate PR #126)
4. PR #125 checks not firing on release-please PR creation (this evening)

App-token-authored events DO trigger downstream workflows. The App approach is also more secure than a PAT (auto-rotating per workflow run, no user-account-coupling).

## Setup state (done by Jeff before this PR)

- GitHub App `agent-core-release-bot` created (App ID 3861562)
- Installed on agent_core repo
- Repo secrets added: `RELEASE_BOT_APP_ID`, `RELEASE_BOT_PRIVATE_KEY`

## This PR is the empirical test

If CI fires on this PR opening without needing close+reopen ritual, the App route closes the cycle. A follow-up PR (channel-relay plugin-renderer wiring, held locally) further validates on the next release-please cycle.

## Test plan

- [x] Pre-push hook ran full suite locally: 1260 passed
- [ ] CI fires on PR open (empirical: does the cycle close?)
- [ ] If CI fires: merge; next release-please cycle uses App token automatically
- [ ] If CI doesn't fire: diagnose (likely the App needs additional permissions or installation scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)