### PR TITLE
fix(channel): wire set_plugin_renderers at __main__ bootstrap

### DIFF
--- a/packages/agent-core-channel/src/agent_core_channel/__main__.py
+++ b/packages/agent-core-channel/src/agent_core_channel/__main__.py
@@ -59,8 +59,18 @@ def main(
     inline_per_envelope_bytes: int | None = _INLINE_PER_ENVELOPE_BYTES_OPTION,
 ) -> None:
     """Run the agent-core stdio channel relay."""
+    from agent_core.plugins.manager import create_plugin_manager, get_envelope_renderers
     from agent_core_channel.config import load_config
+    from agent_core_channel.rendering import set_plugin_renderers
     from agent_core_channel.stdio_server import run_relay
+
+    # Wire plugin-registered envelope renderers into the rendering dispatch
+    # table. agent_core PR #124 added the capability + dispatch but deferred
+    # the bootstrap wiring; without this call, plugin renderers like
+    # pepper-roots' `Desire` renderer never load and dispatch falls back to
+    # JSON. Caught by Pepper's behavioral round-trip 2026-05-25.
+    pm = create_plugin_manager()
+    set_plugin_renderers(get_envelope_renderers(pm))
 
     cli_args = SimpleNamespace(
         inline_mode=inline_mode,

--- a/packages/agent-core-channel/tests/test_rendering_plugin_dispatch.py
+++ b/packages/agent-core-channel/tests/test_rendering_plugin_dispatch.py
@@ -115,3 +115,39 @@ class TestSetPluginRenderersTableManagement:
         set_plugin_renderers({})
         out = render_envelope(_env("X"))
         assert "render='fallback'" in out
+
+
+class TestMainBootstrapWiring:
+    """Regression: channel-relay's main() bootstrap actually wires plugin renderers.
+
+    Caught 2026-05-25 by Pepper's behavioral round-trip — PR #124 added
+    set_plugin_renderers() as a capability but never wired it to be CALLED at
+    channel-relay startup. The renderer table stayed empty at runtime; plugin
+    renderers like pepper-roots' Desire never loaded; wakes fell back to JSON.
+    """
+
+    def test_bootstrap_pattern_populates_table_without_error(self) -> None:
+        """Mirror what __main__.main() does at startup; verify it runs cleanly.
+
+        Doesn't assert specific plugins are present (depends on what's installed
+        in the test venv). Does assert that the wiring chain runs end-to-end:
+        create_plugin_manager → get_envelope_renderers → set_plugin_renderers.
+        """
+        from agent_core.plugins.manager import (
+            create_plugin_manager,
+            get_envelope_renderers,
+        )
+        from agent_core_channel.rendering import (
+            _PLUGIN_RENDERERS,
+            set_plugin_renderers,
+        )
+
+        pm = create_plugin_manager()
+        renderers = get_envelope_renderers(pm)
+        set_plugin_renderers(renderers)
+
+        # The table reflects whatever get_envelope_renderers returned for this
+        # venv's installed plugins. Could be {} (clean test venv) or contain
+        # plugin-registered kinds. Either way, the wiring ran.
+        assert _PLUGIN_RENDERERS == renderers
+        assert isinstance(_PLUGIN_RENDERERS, dict)


### PR DESCRIPTION
## Summary

Wires the channel-relay's `__main__.main()` bootstrap to actually CALL `set_plugin_renderers()` so plugin-registered envelope renderers (e.g., pepper-roots' `Desire`) load on relay startup.

## Why

PR #124 added the envelope-extension hookspec + `set_plugin_renderers()` capability but deferred the bootstrap wiring with this comment in the commit message:

> *"Wiring into the runner (calling set_plugin_renderers at bootstrap) is intentionally deferred — adapters/tests register inline via direct set_plugin_renderers call until runner integration in a later step."*

That follow-up was never filed. Pepper's behavioral round-trip of wake-self-A caught it tonight — Desire envelopes received with `kind='Desire'` attr (correct) but body rendered with `render='fallback'` (renderer never registered).

Static tests passed under PR #124 because the tests called `set_plugin_renderers()` manually. Production never called it.

## Fix

4-line addition in `packages/agent-core-channel/src/agent_core_channel/__main__.py` `main()`:

```python
pm = create_plugin_manager()
set_plugin_renderers(get_envelope_renderers(pm))
```

After this lands + Pepper's session restarts, her channel relay re-spawns with the wired bootstrap and loads pepper-roots' Desire renderer via the standard `agent_core` Pluggy entry-points group.

## Discipline note

This is the "never call done without running" rule landing for the third time today at successively deeper layers:
1. Voice v0 yesterday: static tests passed, real backend never run, QwenTTSBackend bug
2. PR #124 wiring tonight: static tests passed, capability never invoked at startup
3. (Latent) Scheduler kind=Desire support: separate PR coming

The discipline of behavioral-as-keystone is doing the catching every time.

## Test plan

- [x] Added regression test `TestMainBootstrapWiring.test_bootstrap_pattern_populates_table_without_error` — asserts the bootstrap chain runs end-to-end without exception and `_PLUGIN_RENDERERS == get_envelope_renderers(pm)` after main()'s bootstrap runs
- [x] Pre-push hook ran full suite locally: 1261 passed (+1 from new regression test)
- [ ] CI green on this PR
- [ ] After merge: release-please should auto-fire on the push (this is a `fix:` commit, version-bumping) — and IF the new App-token (from PR #127, merged this evening) properly closes the GITHUB_TOKEN anti-recursion cycle, the release PR it creates will fire CI automatically without close+reopen ritual. That's the empirical validation of the App-token swap.
- [ ] After release-please run: restart Pepper's claude-code session → her channel relay loads pepper-roots → behavioral round-trip with a real Desire envelope renders `<desire created_at='…' created_by='pepper'>…</desire>` properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)