### PR TITLE
feat(discord-access): allowedBotIds opt-in allowlist (closes #143)

### DIFF
--- a/packages/agent-core-discord/src/agent_core_discord/access.py
+++ b/packages/agent-core-discord/src/agent_core_discord/access.py
@@ -1,8 +1,13 @@
 """DM-policy + channel-allowlist access gate.
 
 Ported from Pepper's `pepper/integrations/discord/access.py`. The shape of
-the JSON config (dmPolicy / allowFrom / channels / ackReaction) is preserved
-verbatim so existing Pepper access configs migrate without rewrite.
+the JSON config (dmPolicy / allowFrom / channels / ackReaction / allowedBotIds)
+is preserved verbatim so existing Pepper access configs migrate without rewrite.
+
+The `allowedBotIds` field (added for agent_core#143) opt-in-grants specific
+other-bot authors past the otherwise-default bot block — this is how Pepper
+and Wren see each other on Discord without losing the default-deny posture
+for unknown bots.
 """
 
 from __future__ import annotations
@@ -27,6 +32,7 @@ class AccessConfig:
     allow_from: list[str] = field(default_factory=list)
     channels: dict[str, dict[str, Any]] = field(default_factory=dict)
     ack_reaction: str = "👀"
+    allowed_bot_ids: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -62,18 +68,34 @@ def load_access_config(path: Path | str | None) -> AccessConfig:
             dm_policy,
         )
         dm_policy = "deny"
+    raw_allowed_bot_ids = raw.get("allowedBotIds", [])
+    if not isinstance(raw_allowed_bot_ids, list):
+        # Fail-closed on shape mismatch: a non-list value (string, dict, etc.)
+        # could otherwise be coerced into a per-character iterable and silently
+        # admit every bot whose id is a single matching character.
+        log.warning(
+            "access config %s: allowedBotIds must be a list; got %s — falling back to empty",
+            p,
+            type(raw_allowed_bot_ids).__name__,
+        )
+        raw_allowed_bot_ids = []
     return AccessConfig(
         dm_policy=dm_policy,  # type: ignore[arg-type]
         allow_from=list(raw.get("allowFrom", [])),
         channels=dict(raw.get("channels", {})),
         ack_reaction=raw.get("ackReaction", "👀"),
+        allowed_bot_ids=[str(b) for b in raw_allowed_bot_ids],
     )
 
 
 def gate_message(cfg: AccessConfig, ctx: InboundContext) -> bool:
     """Return True if the inbound message passes the access gate.
 
-    Bot-authored messages are always blocked. DMs go through dm_policy:
+    Bot-authored messages are default-blocked; the `allowed_bot_ids`
+    allowlist opt-in-grants specific other-bot authors past the block.
+    Empty allowlist preserves the historical "all bots blocked" default.
+
+    DMs go through dm_policy:
         - "open"      → allow.
         - "deny"      → block.
         - "allowlist" → allow only if author_id is in allow_from.
@@ -82,7 +104,7 @@ def gate_message(cfg: AccessConfig, ctx: InboundContext) -> bool:
         - non-empty           → allow only if channel_id is a key.
     """
     if ctx.is_bot:
-        return False
+        return ctx.author_id in cfg.allowed_bot_ids
     if ctx.is_dm:
         if cfg.dm_policy == "open":
             return True

--- a/packages/agent-core-discord/tests/test_access.py
+++ b/packages/agent-core-discord/tests/test_access.py
@@ -63,10 +63,73 @@ def _ctx(*, is_dm: bool, author_id: str = "100", channel_id: str = "200") -> Inb
     return InboundContext(is_dm=is_dm, author_id=author_id, channel_id=channel_id, is_bot=False)
 
 
-def test_gate_blocks_bot_authors_unconditionally():
+def test_gate_blocks_bot_authors_by_default():
+    """Empty allowed_bot_ids preserves the historical 'all bots blocked' default."""
     cfg = AccessConfig(dm_policy="open")
     ctx = InboundContext(is_dm=False, author_id="100", channel_id="200", is_bot=True)
     assert gate_message(cfg, ctx) is False
+
+
+def test_gate_allows_bot_in_allowlist():
+    cfg = AccessConfig(dm_policy="open", allowed_bot_ids=["1480938766246871050"])
+    ctx = InboundContext(
+        is_dm=False, author_id="1480938766246871050", channel_id="200", is_bot=True
+    )
+    assert gate_message(cfg, ctx) is True
+
+
+def test_gate_blocks_bot_not_in_allowlist():
+    cfg = AccessConfig(dm_policy="open", allowed_bot_ids=["1480938766246871050"])
+    ctx = InboundContext(is_dm=False, author_id="999", channel_id="200", is_bot=True)
+    assert gate_message(cfg, ctx) is False
+
+
+def test_load_access_config_reads_allowed_bot_ids(tmp_path):
+    p = tmp_path / "access.json"
+    p.write_text(
+        json.dumps({"allowedBotIds": ["123", "456"]}),
+        encoding="utf-8",
+    )
+    cfg = load_access_config(p)
+    assert cfg.allowed_bot_ids == ["123", "456"]
+
+
+def test_load_access_config_missing_allowed_bot_ids_defaults_empty(tmp_path):
+    p = tmp_path / "access.json"
+    p.write_text(json.dumps({"dmPolicy": "open"}), encoding="utf-8")
+    cfg = load_access_config(p)
+    assert cfg.allowed_bot_ids == []
+
+
+def test_load_access_config_non_list_allowed_bot_ids_falls_back_to_empty(tmp_path, caplog):
+    """A non-list value (string, dict, etc.) for allowedBotIds is rejected
+    and the loader falls back to empty. Prevents a stringified id from
+    being iterated as characters and silently admitting bots whose id is
+    any single matching character."""
+    import logging
+
+    p = tmp_path / "access.json"
+    p.write_text(
+        json.dumps({"allowedBotIds": "1480938766246871050"}),
+        encoding="utf-8",
+    )
+    with caplog.at_level(logging.WARNING):
+        cfg = load_access_config(p)
+    assert cfg.allowed_bot_ids == []
+    assert any("allowedBotIds must be a list" in rec.message for rec in caplog.records)
+
+
+def test_load_access_config_coerces_int_bot_ids_to_str(tmp_path):
+    """Discord ids are conceptually strings but JSON authors may write them
+    as integers. The loader coerces so equality against `ctx.author_id`
+    (which is always str) doesn't silently fail."""
+    p = tmp_path / "access.json"
+    p.write_text(
+        json.dumps({"allowedBotIds": [1480938766246871050]}),
+        encoding="utf-8",
+    )
+    cfg = load_access_config(p)
+    assert cfg.allowed_bot_ids == ["1480938766246871050"]
 
 
 def test_gate_open_dm_policy_allows_any_dm():


### PR DESCRIPTION
## Summary

- Implements [#143](https://github.com/jeffrichley/agent_core/issues/143) per the merged spec in PR #144.
- `AccessConfig` gains `allowed_bot_ids: list[str]` (default empty).
- `load_access_config` reads `allowedBotIds` from JSON (camelCase, matching existing `dmPolicy` / `allowFrom` / `channels` / `ackReaction` style).
- `gate_message` bot branch changes from unconditional block to `return ctx.author_id in cfg.allowed_bot_ids` — empty list preserves the historical "all bots blocked" default.
- Defensive loader: non-list values fall back to empty with a warning (prevents a stringified id from being iterated as characters); int ids are coerced to str so equality against `ctx.author_id` (always str) doesn't silently fail.

## Why direct-implement (not via Foreman)

This ticket has been at `foreman:impl-attempt-1 + foreman:needs-help` since 2026-06-05 with no impl PR landing. Foreman surfaced 40+ help comments. Jeff asked for it live today, so going direct is cheaper than restarting the loop.

## Test plan

- [x] 7 new tests in `test_access.py` (default-deny, in-allowlist passes, not-in-allowlist blocked, JSON round-trip, missing field defaults empty, non-list fallback, int-to-str coercion).
- [x] Full `agent-core-discord` suite: 268 passed, 1 skipped.
- [x] Pre-push hook (full repo pytest): 1312 passed, 5 skipped, 7 deselected.
- [x] Backward compat: existing `access.json` without `allowedBotIds` loads identically to today (empty list → all bots blocked).
- [x] Existing `AccessConfig()` and `gate_message(...)` call sites (`endpoint.py:296`, `endpoint.py:1011`) unaffected.

## Operational follow-up (out of scope for this PR)

Once merged, Pepper's and Wren's `discord-*-access.json` files need updating:
- `~/.agent-core/discord-pepper-access.json` adds `"allowedBotIds": ["1508825245375664128"]` (Wren's bot id)
- Wren's equivalent adds `"allowedBotIds": ["1480938766246871050"]` (Pepper's bot id)

This makes the Pepper↔Wren conversation visible in shared channels (#general, etc.) without changing per-channel scoping.

## Spec deviations

- Spec asked for a test `test_load_access_config_invalid_allowed_bot_ids_falls_back` — renamed to `test_load_access_config_non_list_allowed_bot_ids_falls_back_to_empty` (same intent, more descriptive name).
- Added one extra test not in spec: `test_load_access_config_coerces_int_bot_ids_to_str` — JSON-author ergonomics; documents the int→str coercion.
- Did NOT modify the existing `test_gate_blocks_bot_authors_unconditionally` to keep blame-history clean; instead renamed it to `test_gate_blocks_bot_authors_by_default` (same semantics, accurate name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)