### PR TITLE
fix(discord): on_message hands bot authors to the access gate

### DIFF
--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -994,17 +994,29 @@ class DiscordEndpoint:
 
     def _make_on_message_handler(self):
         async def on_message(message: Any) -> None:
-            # 1. Filter our own messages and other bots.
-            if message.author == self._client.user or message.author.bot:
+            # 1. Filter our OWN messages only — self-loops would feed the
+            # bot its own posts. Other bots are NOT pre-filtered here:
+            # the access gate's ``allowed_bot_ids`` field (added in
+            # PR #158 for agent_core#143) is the right layer to decide
+            # which other-bot authors should pass. Pre-filtering all
+            # bots here made ``allowed_bot_ids`` structurally
+            # unreachable; surfaced 2026-06-07 during the Pepper-Wren
+            # cross-bot rollout smoke test, where Pepper's posts in a
+            # shared channel never reached Wren's bus inbox.
+            if message.author == self._client.user:
                 return
 
-            # 2. Build inbound context for the access gate.
+            # 2. Build inbound context for the access gate. ``is_bot`` is
+            # piped through from the discord.py Member/User flag so the
+            # gate can route through the allowed_bot_ids branch
+            # correctly (was hardcoded ``False`` before, which made the
+            # ``ctx.is_bot`` check in ``gate_message`` permanently dead).
             is_dm = message.guild is None
             ctx = InboundContext(
                 is_dm=is_dm,
                 author_id=str(message.author.id),
                 channel_id=str(message.channel.id),
-                is_bot=False,
+                is_bot=bool(getattr(message.author, "bot", False)),
             )
 
             # 3. Run the access gate.
@@ -1083,6 +1095,11 @@ class DiscordEndpoint:
                     "author_id": str(message.author.id),
                     "author_display_name": getattr(message.author, "display_name", "") or "",
                     "is_dm": is_dm,
+                    # is_bot piped through so downstream beings can tell "this
+                    # is from another agent-core being" vs "this is from Jeff"
+                    # without inspecting bot id maps. Pairs with the
+                    # allowed_bot_ids gate (agent_core#143).
+                    "is_bot": ctx.is_bot,
                 },
             }
             if attachments:

--- a/packages/agent-core-discord/tests/test_endpoint_inbound.py
+++ b/packages/agent-core-discord/tests/test_endpoint_inbound.py
@@ -76,7 +76,12 @@ async def test_on_message_publishes_text_envelope(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_on_message_drops_messages_from_bots(monkeypatch):
+async def test_on_message_drops_messages_from_bots_not_in_allowlist(monkeypatch):
+    """A bot author with empty allowedBotIds is gate-denied — same outcome
+    as the historical "all bots blocked" default. The drop now happens at
+    the gate layer (not the on_message pre-filter), so allowed_bot_ids
+    can still grant specific other-bots through.
+    """
     ep, handle, fake = await _start_endpoint(monkeypatch)
     fake.add_channel(FakeChannel(id="200"))
     msg = _msg(content="hi", is_bot=True)
@@ -84,6 +89,52 @@ async def test_on_message_drops_messages_from_bots(monkeypatch):
     try:
         await fake.fire("on_message", msg)
         assert handle.published == []
+    finally:
+        await ep.stop()
+
+
+@pytest.mark.asyncio
+async def test_on_message_allows_bots_in_allowed_bot_ids(monkeypatch, tmp_path):
+    """foreman#143 regression guard: a bot author whose id IS in the
+    access config's ``allowedBotIds`` must reach the bus inbox.
+
+    The Pepper-Wren cross-bot rollout surfaced this 2026-06-07: PR #158
+    added the ``allowed_bot_ids`` field to ``AccessConfig`` + the gate
+    logic, but the on_message handler still pre-filtered ALL bots
+    (``message.author.bot`` → return) before the gate could see them,
+    AND constructed ``InboundContext`` with ``is_bot=False`` hardcoded —
+    so even if the pre-filter were dropped, the gate would never route
+    through the bot-allowlist branch. Both layers had to know about the
+    rule for ``allowedBotIds`` to actually work.
+    """
+    import json
+
+    pepper_bot_id = "1480938766246871050"
+    access = tmp_path / "access.json"
+    access.write_text(
+        json.dumps({"dmPolicy": "open", "allowedBotIds": [pepper_bot_id]}),
+        encoding="utf-8",
+    )
+    ep, handle, fake = await _start_endpoint(monkeypatch, access_path=str(access))
+    fake.add_channel(FakeChannel(id="200"))
+    msg = _msg(
+        id="m-bot",
+        channel_id="200",
+        content="cross-bot smoke test",
+        author_id=pepper_bot_id,
+        is_bot=True,
+    )
+    msg.channel = fake.get_channel("200")
+    try:
+        await fake.fire("on_message", msg)
+        assert len(handle.published) == 1, (
+            "allowedBotIds entry should let this bot's message through to the bus"
+        )
+        env = handle.published[0]
+        assert env.payload.text == "cross-bot smoke test"
+        assert env.metadata["discord"]["author_id"] == pepper_bot_id
+        # is_bot must be piped through so downstream consumers can see who's a bot.
+        assert env.metadata["discord"]["is_bot"] is True
     finally:
         await ep.stop()
 


### PR DESCRIPTION
## Summary

Completes the work begun in PR #158 (closes #143). PR #158 added the `allowed_bot_ids` field + gate semantics on the **access.py** side; this PR fixes the **endpoint.py** side so the gate actually sees bot authors.

## Root cause (TDD-discovered)

Wrote a regression test first to prove the bug:

```python
async def test_on_message_allows_bots_in_allowed_bot_ids(monkeypatch, tmp_path):
    # access.json with allowedBotIds: [pepper_bot_id]
    # post a bot-authored message
    # assert it was published
```

On unpatched code: **`assert 0 == 1`** — the message was dropped at `on_message`'s pre-filter (`message.author.bot → return`) before the access gate ever ran. Even if the pre-filter were removed, `InboundContext(is_bot=False)` was hardcoded — so the gate's bot branch was permanently unreachable.

Both layers had to know about the rule for `allowed_bot_ids` to actually do anything.

Surfaced 2026-06-07 during the Pepper-Wren cross-bot rollout smoke test where Pepper's posts in `#general` never reached Wren's bus inbox.

## What changed

- **`on_message` pre-filter** drops only self-authored messages now (self-loop guard). Other bots flow to the access gate.
- **`InboundContext.is_bot`** is read from `message.author.bot` so `gate_message` can route through the `allowed_bot_ids` branch.
- **Published envelope's `metadata.discord.is_bot`** carries the flag so downstream beings can tell apart agent-core peer messages from human messages without inspecting bot-id maps.

## Test plan

- [x] `test_on_message_allows_bots_in_allowed_bot_ids` — new regression: fails on unpatched code, passes with fix.
- [x] `test_on_message_drops_messages_from_bots_not_in_allowlist` (renamed from `..._from_bots`) — empty allowlist still blocks all bots; drop now happens at the gate layer instead of the pre-filter.
- [x] Full `agent-core-discord` suite: 269 passed, 1 skipped.

## Out of scope / follow-up

Jeff and I opened a brainstorm on a **voting filter model** (each rule is a positive grant, any "yes" lets it through, default-deny) as a v2 architecture. Parked to land later this week as a separate spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)