### PR TITLE
fix(discord-access): allowlisted bots must still pass channel filter

### DIFF
--- a/packages/agent-core-discord/src/agent_core_discord/access.py
+++ b/packages/agent-core-discord/src/agent_core_discord/access.py
@@ -102,9 +102,19 @@ def gate_message(cfg: AccessConfig, ctx: InboundContext) -> bool:
     Guild messages go through the channel allowlist if non-empty:
         - empty channels dict → allow all guild channels.
         - non-empty           → allow only if channel_id is a key.
+
+    The bot-block is a default-deny *guard* layered on top of the
+    DM-or-channel checks, NOT a terminal answer. An allowlisted bot
+    must STILL pass the channel filter for guild posts (and dm_policy
+    for DMs) — same gate every other author goes through. Previously
+    the bot-block returned early with `ctx.author_id in allowed_bot_ids`,
+    which bypassed the channel allowlist entirely and let any
+    allowlisted bot's posts in any channel through. Caught 2026-06-08
+    after the Wren endpoint observed every Pepper-to-Jeff message in
+    #pepper-chat (which is NOT in discord-wren's channel allowlist).
     """
-    if ctx.is_bot:
-        return ctx.author_id in cfg.allowed_bot_ids
+    if ctx.is_bot and ctx.author_id not in cfg.allowed_bot_ids:
+        return False
     if ctx.is_dm:
         if cfg.dm_policy == "open":
             return True

--- a/packages/agent-core-discord/tests/test_access.py
+++ b/packages/agent-core-discord/tests/test_access.py
@@ -175,6 +175,58 @@ def test_gate_allowlist_dm_policy_does_not_block_guild_messages():
     assert gate_message(cfg, _ctx(is_dm=False, author_id="999", channel_id="200")) is True
 
 
+def test_gate_allowlisted_bot_must_still_pass_channel_filter():
+    """Regression: an allowlisted other-bot in a NON-allowlisted channel must
+    be blocked. The bot-id allowlist opts a bot past the default bot-block,
+    not past the channel filter — both checks must apply for guild posts.
+
+    Pre-fix bug: `gate_message` returned `ctx.author_id in cfg.allowed_bot_ids`
+    as a terminal answer at the top, short-circuiting the channel filter for
+    every allowlisted bot regardless of where it posted. Pepper's bot posts
+    in #pepper-chat (which is NOT in discord-wren's `channels` allowlist)
+    reached the wren endpoint anyway. The bot-block must layer: deny
+    non-allowlisted bots, then fall through to the same channel + DM checks
+    every other author goes through.
+    """
+    cfg = AccessConfig(
+        dm_policy="open",
+        channels={"allowed-channel": {}},
+        allowed_bot_ids=["pepper-bot"],
+    )
+    ctx_allowed = InboundContext(
+        is_dm=False,
+        author_id="pepper-bot",
+        channel_id="allowed-channel",
+        is_bot=True,
+    )
+    ctx_wrong_channel = InboundContext(
+        is_dm=False,
+        author_id="pepper-bot",
+        channel_id="other-channel",
+        is_bot=True,
+    )
+    assert gate_message(cfg, ctx_allowed) is True
+    assert gate_message(cfg, ctx_wrong_channel) is False
+
+
+def test_gate_allowlisted_bot_dm_still_goes_through_dm_policy():
+    """An allowlisted bot DMing must still respect dm_policy. With
+    `allowlist` dm_policy and the bot's id not in `allow_from`, deny.
+    The bot-id allowlist opens up bot authorship, not DM access."""
+    cfg = AccessConfig(
+        dm_policy="allowlist",
+        allow_from=["jeff-user"],
+        allowed_bot_ids=["pepper-bot"],
+    )
+    ctx = InboundContext(
+        is_dm=True,
+        author_id="pepper-bot",
+        channel_id="dm",
+        is_bot=True,
+    )
+    assert gate_message(cfg, ctx) is False
+
+
 def test_load_access_config_silently_ignores_legacy_urgency_red_regex(tmp_path):
     """Migration: existing access JSON files with urgencyRedRegex set must
     still load cleanly under the post-#38 AccessConfig (which doesn't have


### PR DESCRIPTION
## Summary

- `gate_message` in `access.py` short-circuited the channel filter when the author was in `allowed_bot_ids`, returning early with `ctx.author_id in cfg.allowed_bot_ids` as a terminal answer. Every other author went through the DM-policy / channel-allowlist gate further down; allowlisted bots skipped that entirely.
- Restructured so the bot-block is a **default-deny guard**, not a terminal answer. Allowlisted bots now fall through to the same DM-policy + channel-allowlist checks every other author goes through.
- 2 new regression tests in `test_access.py`. Existing 20 tests unchanged.

## Empirical evidence

The Wren claude-code session observed today: every Pepper-to-Jeff message in #pepper-chat routed inbound to the `discord-wren` endpoint, even though #pepper-chat is NOT in discord-wren's `channels` allowlist. Pepper's bot id IS in `allowedBotIds` (so Pepper and Wren can see each other on Discord), and that allowlist was the bypass — channel filter never ran.

Privacy consequence: any Pepper-namespace channel that `discord-wren`'s Discord bot account is a member of leaks Pepper's messages to Wren's bus inbox the moment Pepper's bot id is in `allowed_bot_ids` — the channel filter has no effect for that author.

## Diff shape

```python
# Before
if ctx.is_bot:
    return ctx.author_id in cfg.allowed_bot_ids   # terminal — channel filter never runs

# After
if ctx.is_bot and ctx.author_id not in cfg.allowed_bot_ids:
    return False                                  # guard, then fall through to existing DM/channel checks
```

## Test plan

- [x] `pytest packages/agent-core-discord/tests/test_access.py -q` — 22/22 pass (20 existing + 2 new)
- [x] `pytest packages/agent-core-discord -q` — full discord-package suite 271 pass, 1 skip
- [x] `just typecheck` / `just contracts` (pre-push hooks) — clean
- [ ] Manual verification post-merge + redeploy: discord-wren no longer receives messages from channels outside its `channels` allowlist (regardless of author).

Closes #165