### PR TITLE
test(persistence-reader): inject Clock + extract pure percentile fn

### DIFF
--- a/packages/core/src/agent_core/bus/persistence.py
+++ b/packages/core/src/agent_core/bus/persistence.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 import json
 import os
 import sys
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import aiosqlite
 
 from agent_core.bus.envelope import Envelope
+from agent_core.clock import Clock, SystemClock
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS envelopes (
@@ -73,9 +74,10 @@ def _row_to_envelope(row: dict[str, Any]) -> Envelope:
 class Persistence:
     """Async SQLite wrapper for the bus's durable mailbox state."""
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path, *, clock: Clock | None = None):
         self.path = Path(path)
         self._conn: aiosqlite.Connection | None = None
+        self._clock: Clock = clock or SystemClock()
 
     def _require_conn(self) -> aiosqlite.Connection:
         if self._conn is None:
@@ -175,7 +177,7 @@ class Persistence:
                    last_attempted = ?,
                    in_flight_until = ?
                WHERE id = ?""",
-            (datetime.now(UTC).isoformat(), in_flight_until.isoformat(), id_),
+            (self._clock.now().isoformat(), in_flight_until.isoformat(), id_),
         )
         await conn.commit()
 

--- a/packages/core/src/agent_core/bus_tail/reader.py
+++ b/packages/core/src/agent_core/bus_tail/reader.py
@@ -8,13 +8,14 @@ queries against the existing envelopes table.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import Any, Literal
 
 import aiosqlite
 
 from agent_core.bus.envelope import Envelope
 from agent_core.bus.persistence import Persistence, _row_to_envelope
+from agent_core.clock import Clock, SystemClock
 
 DEFAULT_LIMIT = 50
 MAX_LIMIT = 1000
@@ -26,8 +27,9 @@ DEFAULT_METRICS_WINDOW_HOURS = 24
 class PersistenceReader:
     """Read-only query layer for the audit/tail surface."""
 
-    def __init__(self, persistence: Persistence) -> None:
+    def __init__(self, persistence: Persistence, *, clock: Clock | None = None) -> None:
         self._persistence = persistence
+        self._clock: Clock = clock or SystemClock()
 
     def _conn(self) -> aiosqlite.Connection:
         # Reuse the persistence's existing connection. Assumes connect() ran.
@@ -129,7 +131,7 @@ class PersistenceReader:
     async def metrics_snapshot(
         self, *, window_hours: int = DEFAULT_METRICS_WINDOW_HOURS
     ) -> dict[str, Any]:
-        cutoff = datetime.now(UTC) - timedelta(hours=window_hours)
+        cutoff = self._clock.now() - timedelta(hours=window_hours)
         cutoff_iso = cutoff.isoformat()
         conn = self._conn()
         conn.row_factory = aiosqlite.Row
@@ -186,7 +188,7 @@ class PersistenceReader:
         if len(latencies_ms) < ACK_LATENCY_MIN_SAMPLES:
             ack_latency_ms = None
         else:
-            ack_latency_ms = _percentiles(latencies_ms, (50, 95, 99))
+            ack_latency_ms = compute_latency_percentiles(latencies_ms, (50, 95, 99))
 
         return {
             "window": f"last_{window_hours}h",
@@ -198,8 +200,15 @@ class PersistenceReader:
         }
 
 
-def _percentiles(values: list[float], pcts: tuple[int, ...]) -> dict[str, int]:
-    """Linear-interpolation percentiles, rounded to nearest int ms."""
+def compute_latency_percentiles(
+    values: list[float], pcts: tuple[int, ...]
+) -> dict[str, int]:
+    """Linear-interpolation percentiles, rounded to nearest int ms.
+
+    Pure function — no I/O, no time, no DB. Tested directly so the
+    percentile math has tight assertions that don't depend on runner
+    speed or wall-clock jitter.
+    """
     sorted_values = sorted(values)
     n = len(sorted_values)
     out: dict[str, int] = {}
@@ -216,4 +225,4 @@ def _percentiles(values: list[float], pcts: tuple[int, ...]) -> dict[str, int]:
     return out
 
 
-__all__ = ["PersistenceReader"]
+__all__ = ["PersistenceReader", "compute_latency_percentiles"]

--- a/packages/core/src/agent_core/clock.py
+++ b/packages/core/src/agent_core/clock.py
@@ -1,0 +1,48 @@
+"""Injectable time source.
+
+Production code that needs ``datetime.now()`` should accept a ``Clock``
+parameter and call ``clock.now()`` instead of reaching for the wall
+clock directly. Tests then pass ``FakeClock`` to get deterministic
+timestamps without depending on runner speed.
+
+Default ``Clock`` is ``SystemClock``; passing a ``Clock`` is a kwarg-only
+seam so existing call sites keep working unchanged.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Clock(Protocol):
+    """Source of the current time. Implementations must return timezone-aware ``datetime``."""
+
+    def now(self) -> datetime: ...
+
+
+class SystemClock:
+    """Real-time clock — returns ``datetime.now(UTC)`` on every call."""
+
+    def now(self) -> datetime:
+        return datetime.now(UTC)
+
+
+class FakeClock:
+    """Deterministic clock for tests. Time only moves when ``advance()`` is called."""
+
+    def __init__(self, *, start: datetime) -> None:
+        if start.tzinfo is None:
+            raise ValueError("FakeClock start must be timezone-aware")
+        self._now = start
+
+    def now(self) -> datetime:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        """Push the clock forward by ``seconds`` (may be fractional)."""
+        self._now += timedelta(seconds=seconds)
+
+
+__all__ = ["Clock", "FakeClock", "SystemClock"]

--- a/packages/core/tests/test_clock.py
+++ b/packages/core/tests/test_clock.py
@@ -1,0 +1,69 @@
+"""Tests for the Clock seam."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agent_core.clock import Clock, FakeClock, SystemClock
+
+
+class TestSystemClock:
+    def test_now_returns_timezone_aware(self) -> None:
+        # Arrange - SystemClock should produce UTC datetimes.
+        clock = SystemClock()
+        # Act - Call now() twice.
+        first = clock.now()
+        second = clock.now()
+        # Assert - Both are tzaware UTC, and time moves forward (or stays equal).
+        assert first.tzinfo is not None
+        assert second.tzinfo is not None
+        assert second >= first
+
+    def test_satisfies_clock_protocol(self) -> None:
+        # Arrange + Act
+        clock: Clock = SystemClock()
+        # Assert - structural typing check (also runtime via @runtime_checkable).
+        assert isinstance(clock, Clock)
+
+
+class TestFakeClock:
+    def test_now_returns_start(self) -> None:
+        # Arrange - Pin start to a specific instant.
+        start = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        clock = FakeClock(start=start)
+        # Act + Assert
+        assert clock.now() == start
+
+    def test_advance_moves_clock_forward(self) -> None:
+        # Arrange
+        start = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        clock = FakeClock(start=start)
+        # Act
+        clock.advance(7.5)
+        # Assert
+        assert clock.now() == start + timedelta(seconds=7.5)
+
+    def test_now_is_idempotent_between_advance_calls(self) -> None:
+        # Arrange
+        start = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        clock = FakeClock(start=start)
+        # Act
+        first = clock.now()
+        second = clock.now()
+        # Assert - No drift; deterministic.
+        assert first == second
+
+    def test_start_must_be_tzaware(self) -> None:
+        # Arrange - Naive datetime should be rejected.
+        naive = datetime(2026, 1, 1, 12, 0, 0)
+        # Act + Assert
+        with pytest.raises(ValueError, match="timezone-aware"):
+            FakeClock(start=naive)
+
+    def test_satisfies_clock_protocol(self) -> None:
+        # Arrange
+        clock: Clock = FakeClock(start=datetime(2026, 1, 1, tzinfo=UTC))
+        # Assert
+        assert isinstance(clock, Clock)

--- a/packages/core/tests/test_persistence_reader.py
+++ b/packages/core/tests/test_persistence_reader.py
@@ -10,7 +10,8 @@ import pytest_asyncio
 
 from agent_core.bus.envelope import Envelope, TextMessagePayload
 from agent_core.bus.persistence import Persistence
-from agent_core.bus_tail.reader import PersistenceReader
+from agent_core.bus_tail.reader import PersistenceReader, compute_latency_percentiles
+from agent_core.clock import FakeClock
 
 
 def _make_envelope(
@@ -235,25 +236,77 @@ async def test_metrics_ack_latency_null_below_sample_threshold(persistence: Pers
     assert snap["ack_latency_ms"] is None
 
 
+class TestComputeLatencyPercentiles:
+    """Pure-function tests for the percentile math. No DB, no clock."""
+
+    def test_linear_interpolation_at_15_samples(self) -> None:
+        # Arrange - 15 samples spaced 1s apart: 1000, 2000, ..., 15000 ms.
+        samples = [float(i * 1000) for i in range(1, 16)]
+        # Act
+        result = compute_latency_percentiles(samples, (50, 95, 99))
+        # Assert - Linear interpolation against n=15: rank = p/100 * (n-1).
+        # p50: rank=7.0  -> samples[7] = 8000
+        # p95: rank=13.3 -> 14000 + 1000*0.3 = 14300
+        # p99: rank=13.86-> 14000 + 1000*0.86 = 14860
+        assert result == {"p50": 8000, "p95": 14300, "p99": 14860}
+
+    def test_single_sample(self) -> None:
+        # Arrange - Use a whole-number sample to avoid banker's-rounding noise.
+        samples = [1234.0]
+        # Act
+        result = compute_latency_percentiles(samples, (50, 95, 99))
+        # Assert - Every percentile collapses to the single value.
+        assert result == {"p50": 1234, "p95": 1234, "p99": 1234}
+
+    def test_monotonic_ordering(self) -> None:
+        # Arrange - Random-order samples must give the same result as sorted.
+        samples = [5000.0, 1000.0, 3000.0, 2000.0, 4000.0]
+        # Act
+        result = compute_latency_percentiles(samples, (50, 95, 99))
+        # Assert - p50 <= p95 <= p99 invariant must hold.
+        assert result["p50"] <= result["p95"] <= result["p99"]
+
+    def test_empty_pcts_returns_empty_dict(self) -> None:
+        # Arrange
+        samples = [1000.0, 2000.0]
+        # Act
+        result = compute_latency_percentiles(samples, ())
+        # Assert - No percentiles requested -> empty mapping.
+        assert result == {}
+
+
 @pytest.mark.asyncio
 async def test_metrics_ack_latency_percentiles_above_sample_threshold(
-    persistence: Persistence,
+    tmp_path: Path,
 ):
-    # Persistence.mark_in_flight always sets last_attempted=now(); we vary
-    # created_at so each envelope's (last_attempted - created_at) latency
-    # lands in [1s, 15s]. Loop jitter adds a few ms but stays well under
-    # the assertion ceiling.
-    base = datetime.now(UTC)
-    for i in range(15):
-        created = base - timedelta(seconds=i + 1)
-        await persistence.insert(_make_envelope(id_=f"e{i}", created_at=created))
-        await persistence.mark_in_flight(f"e{i}", base + timedelta(seconds=30))
-        await persistence.mark_acked(f"e{i}")
-    reader = PersistenceReader(persistence)
-    snap = await reader.metrics_snapshot()
-    latency = snap["ack_latency_ms"]
-    assert latency is not None
-    assert {"p50", "p95", "p99"}.issubset(latency.keys())
-    # Latencies are approximately 1s..15s plus a few ms of loop jitter.
-    for v in latency.values():
-        assert 0 < v <= 16_000
+    # Arrange - Use FakeClock so mark_in_flight stamps a deterministic
+    # last_attempted. By advancing the clock between insert and
+    # mark_in_flight, the synthetic ack latencies are EXACT. The earlier
+    # version relied on Persistence calling datetime.now() and asserted
+    # "<= 16s with hope," which flaked on slow Windows runners (16.038s).
+    # The percentile math itself is covered by TestComputeLatencyPercentiles
+    # above; here we just verify the insert -> reader -> snapshot wiring
+    # delivers exact synthetic samples through to the same expected output.
+    start = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(start=start)
+    p = Persistence(tmp_path / "bus.sqlite", clock=clock)
+    await p.connect()
+    try:
+        for i in range(15):
+            created = clock.now()
+            await p.insert(_make_envelope(id_=f"e{i}", created_at=created))
+            # Advance the clock so last_attempted = created + (i+1) seconds.
+            clock.advance(i + 1)
+            await p.mark_in_flight(f"e{i}", clock.now() + timedelta(seconds=30))
+            await p.mark_acked(f"e{i}")
+            # Reset clock so the next envelope's created_at is also `start`.
+            # Latencies become {1000, 2000, ..., 15000} ms exactly.
+            clock._now = start
+        # Act
+        reader = PersistenceReader(p, clock=clock)
+        snap = await reader.metrics_snapshot()
+        # Assert - Same expected output as the pure unit test above, proving
+        # the wiring carries exact samples through. No tolerance, no jitter.
+        assert snap["ack_latency_ms"] == {"p50": 8000, "p95": 14300, "p99": 14860}
+    finally:
+        await p.close()


### PR DESCRIPTION
## Summary

`test_metrics_ack_latency_percentiles_above_sample_threshold` flaked deterministically on slow Windows runners — assertion `16038 <= 16000` because Persistence called `datetime.now()` directly and the test asserted "latency <= 16_000ms with hope." Same anti-pattern as algokit's sliding-mode test: loose threshold + tight margin + runner-speed sensitivity.

This PR fixes the underlying coupling rather than the symptom.

## What changed

1. **New `agent_core.clock` module** — `Clock` Protocol, `SystemClock`, `FakeClock`. Provides a deterministic time source for tests without leaking wall-clock dependencies into production behavior.

2. **`Persistence` and `PersistenceReader` now take `clock` kwarg** (default `SystemClock` — every existing call site keeps working unchanged). All `datetime.now()` calls inside both classes route through the injected clock.

3. **`reader._percentiles` promoted to `reader.compute_latency_percentiles`** — pure public function, no I/O. New unit tests pin exact output: with `[1000, 2000, ..., 15000]` the expected result is `{p50=8000, p95=14300, p99=14860}`.

4. **Flaky integration test rewritten with `FakeClock`** — by advancing the clock between insert and `mark_in_flight`, synthetic latencies become EXACT. Test asserts equality against the same expected output, proving the insert → reader → snapshot wiring carries exact samples through.

## Why this shape

- **`A` (inject Clock)**: removes the hidden time dependency from production code. Future timing-dependent tests anywhere in the stack can use `FakeClock`.
- **`B` (extract pure function)**: separates math from plumbing. The percentile correctness is verified by 4 pure unit tests that need no DB, no time, no jitter budget. The integration test then only verifies wiring.

The two are orthogonal but both required: clock injection alone leaves an integration test that's hard to assert against precisely; function extraction alone still needs deterministic time for the wiring test.

## Test plan

- [x] `just check` locally: 1326 passed, 0 failed (102s)
- [x] Target integration test runs deterministically across 3 reruns (no jitter)
- [x] Pure unit tests cover percentile shape with exact bounds (no tolerance)
- [x] Existing call sites of `Persistence(path)` keep working — `clock` is keyword-only with default

## Out of scope (separate PRs)

- pytest-randomly + pytest-timeout (test-infra hardening)
- pytest-xdist (parallel CI execution)
- hypothesis (property-based tests for the new pure function)