### PR TITLE
chore: fast dev test loop + fix Hypothesis xdist flake

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,8 @@ integration tests don't race across workers.
 
 | Goal | Command |
 |---|---|
+| **Fast inner loop — whole suite, no coverage** (~110s vs ~230s) | `just test-fast` |
+| Fast scoped run while editing one package | `just test-core` / `just test-channel` |
 | Quick local debug of one test | `uv run pytest --no-cov -n0 -x packages/<pkg>/tests/test_x.py::test_name` |
 | Re-run with a specific random seed (reproducing a failure) | `uv run pytest --no-cov --randomly-seed=<N>` |
 | Disable random order entirely | `uv run pytest -p no:randomly --no-cov` |

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,22 @@
+"""Project-wide pytest configuration (loaded once at the repo root)."""
+
+from __future__ import annotations
+
+from hypothesis import HealthCheck, settings
+
+# Hypothesis enforces a per-example deadline (200ms by default) measured in
+# wall-clock time. Under our default `-n auto` xdist run, many workers
+# saturate every core, so a trivial example can blow that budget purely from
+# CPU scheduling contention and raise DeadlineExceeded -- a test that passes
+# in isolation fails flakily in the full parallel suite (observed on
+# test_persistence_reader.py::...test_percentiles_are_sorted_by_rank).
+#
+# Our property tests exercise pure functions where wall-clock-per-example
+# carries no signal, so disable the deadline (and the matching too_slow
+# health check) globally. Correctness is still asserted by every test body.
+settings.register_profile(
+    "default",
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+settings.load_profile("default")

--- a/justfile
+++ b/justfile
@@ -46,18 +46,24 @@ typecheck:
 contracts:
     uv run --no-sync lint-imports
 
-# Tests
+# Tests (full suite, coverage + 85% gate — matches CI)
 test:
     uv run --no-sync pytest -q
 
+# Fast inner-loop run: full suite, NO coverage instrumentation.
+# Branch-coverage doubles wall time (~230s -> ~110s) and adds no signal
+# while iterating. The 85% gate still runs in `just check` / CI.
 test-fast:
-    uv run --no-sync pytest {{core-tests}} {{channel-tests}} -q
+    uv run --no-sync pytest --no-cov -q
 
+# Scoped runs for when you're only touching one package. These skip
+# coverage too — running a subset under the whole-repo 85% gate would
+# always fail the gate (the other packages' source goes unexercised).
 test-core:
-    uv run --no-sync pytest {{core-tests}} -q
+    uv run --no-sync pytest {{core-tests}} --no-cov -q
 
 test-channel:
-    uv run --no-sync pytest {{channel-tests}} -q
+    uv run --no-sync pytest {{channel-tests}} --no-cov -q
 
 # Setup
 sync:


### PR DESCRIPTION
## Why

Two dev-experience problems with the test suite:

1. **The inner loop was slow.** `just check` runs branch-coverage
   instrumentation on every run, which roughly doubles wall time
   (~230s with coverage vs ~30-45s without, warm). There was no fast
   feedback target — the existing `test-fast`/`test-core`/`test-channel`
   recipes inherited the whole-repo `--cov-fail-under=85` gate, so a
   scoped subset run would actually *fail* the gate.

2. **A flaky property test.** `test_percentiles_are_sorted_by_rank`
   failed intermittently in the full `-n auto` run but passed in
   isolation. Root cause: Hypothesis's default 200ms per-example
   deadline is wall-clock based; under xdist CPU contention a trivial
   example blows it and raises `DeadlineExceeded`. The property itself
   is sound (rounding is monotonic) — it's a contention artifact.

## What

- **`conftest.py`** (new, repo root): register a global Hypothesis
  profile with `deadline=None` + suppress the `too_slow` health check.
  Our property tests cover pure functions, so wall-clock-per-example
  carries no signal.
- **`justfile`**: `test-fast` now runs the full suite with `--no-cov`;
  `test-core`/`test-channel` also get `--no-cov` so scoped runs work.
  The 85% coverage gate still runs in `just check` and CI — unchanged.
- **`CLAUDE.md`**: surface `just test-fast` in the test-invocation table
  so dev agents discover it.

## Verification

- `just test-fast`: 1421 passed, 5 skipped in ~29s.
- Pre-push `just check` (full gate): 1421 passed, coverage 89.27% ≥ 85%
  — the previously-flaky test passes under real xdist+coverage.

## Not in this PR

A follow-up will tighten the `slow` boundary (the marker says ">5s",
but the dev-loop pain is in the 1-5s band) and either speed up or
slow-mark the heavy real-I/O tests (busproxy subprocess/timeout tests,
credentials KeePass-KDF tests). That touches per-test judgment + the
slow-lane CI scope, so it's separate.