### PR TITLE
docs: make 'just test-fast' the explicit default for the inner loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,12 @@ integration tests don't race across workers.
 | Just the suite with coverage report visible | `uv run pytest --cov=packages --cov-branch --cov-report=term-missing` |
 
 **Rules of thumb:**
-- Iterating on a single test? Always pass `--no-cov`. Coverage adds 100×
-  overhead for a one-test run.
+- **Default while iterating: `just test-fast`** — the whole suite with no
+  coverage instrumentation (roughly half the wall time). Coverage is the gate's
+  job, not the inner loop's. Reach for `just check` only when you're about to
+  commit. Editing just one package? `just test-core` / `just test-channel`.
+- Iterating on a single test? `uv run pytest --no-cov -n0 -x <path>::<name>` —
+  coverage adds ~100× overhead for a one-test run.
 - Before committing? Run `just check` — that's the gate CI runs.
 - Test failed and you suspect order-dependence? Pytest prints the random
   seed at the top of every run; rerun with `--randomly-seed=<seed>` to


### PR DESCRIPTION
Follow-up to #205 / #206 (answers "how will agents know to run the fast tests?").

#205 added `just test-fast` to the test-invocation table, but a table row alone
doesn't change behavior — agents (and humans) default to whatever the
**rules-of-thumb** say, which still pointed at `just check`. State plainly that
`just test-fast` is the iteration default and `just check` is reserved for
pre-commit, so the fast lane actually gets used.

Discovery path: CLAUDE.md is auto-loaded by every Claude Code session in the
repo — including foreman's Worker — so this is where the default belongs.

Docs only; no code change.