### PR TITLE
ci: add Dependabot grouping + auto-merge for patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot: keep Python deps and GitHub Actions up to date.
+# https://docs.github.com/en/code-security/dependabot
+#
+# Grouping: all minor + patch bumps collapse into ONE PR per ecosystem per
+# week, so the queue stays small. Majors are deliberately NOT grouped, so they
+# arrive as their own PR and get human review (a major can break at runtime
+# even when CI is green).
+#
+# The pip ecosystem reads pyproject.toml; after a bump merges, uv.lock is
+# refreshed by CI / `uv lock`.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        # Action bumps are low-risk; group everything including majors.
+        update-types: ["minor", "patch", "major"]
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+      # Majors are intentionally left ungrouped -> individual PRs for review.

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot PRs that are patch or minor once all required checks
+# pass. Majors are skipped on purpose so a human reviews them.
+#
+# Safety: `gh pr merge --auto` respects branch protection — it only merges once
+# the repo's REQUIRED status checks are green. This repo's ruleset requires the
+# CI checks, so a red build can never auto-merge.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only ever act on Dependabot's own PRs.
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch & minor
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds Dependabot **grouping + auto-merge** so dependency bumps stop piling up (the N-loops problem from the 2026-07-02 sweep).

## What
- `.github/dependabot.yml` — groups minor+patch into **one weekly PR per ecosystem** (pip + github-actions). Majors stay ungrouped so they get individual review.
- `.github/workflows/dependabot-auto-merge.yml` — enables `gh pr merge --auto --squash` on Dependabot **patch/minor** PRs; majors are skipped.

## Safety
`--auto` respects branch protection — it merges **only when the required checks pass**. This repo's `phase1-main-gate` ruleset already requires the CI checks, so a red build can never auto-merge. The workflow only touches Dependabot patch/minor PRs; human PRs, foreman PRs, and majors are untouched.

Reference implementation to propagate to the other active repos + the `scaffold-agent-core-project` skill. Requires the repo setting **Allow auto-merge** (enabled alongside this).
