### PR TITLE
ci: switch Dependabot Python ecosystem from pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,10 @@
 # arrive as their own PR and get human review (a major can break at runtime
 # even when CI is green).
 #
-# The pip ecosystem reads pyproject.toml; after a bump merges, uv.lock is
-# refreshed by CI / `uv lock`.
+# Uses the `uv` ecosystem (not `pip`): this repo is a uv workspace, so uv.lock
+# is the source of truth. The uv ecosystem bumps pyproject.toml AND uv.lock
+# together, keeping the lockfile consistent (pip bumps pyproject only, which
+# breaks `uv` on lock-consistency checks).
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -21,7 +23,7 @@ updates:
         # Action bumps are low-risk; group everything including majors.
         update-types: ["minor", "patch", "major"]
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Follow-up to #225. Switches the Dependabot Python ecosystem from `pip` to **`uv`**.

## Why
agent_core is a uv workspace — `uv.lock` is the source of truth. The `pip` ecosystem bumps only `pyproject.toml`, leaving `uv.lock` inconsistent, so every such PR **failed CI** on lock-consistency (#228-232, now closed). It also ran *in parallel* with Dependabot's native `uv` security updates, doubling coverage.

The `uv` ecosystem bumps `pyproject.toml` **and** `uv.lock` together, so:
- CI passes (lock stays consistent),
- updates are proper semver bumps -> **grouping works** (minor/patch collapse to one PR),
- and the auto-merge semver guard catches them (proven live: #233 joserfc auto-merged on green).

One clean Python stream instead of a broken pip stream + a parallel uv stream.
