### PR TITLE
ci: pin renovate action to v46.1.17

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Renovate
-        uses: renovatebot/github-action@v46
+        uses: renovatebot/github-action@v46.1.17
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:


### PR DESCRIPTION
The floating major tag `renovatebot/github-action@v46` does not exist (the action only publishes full version tags like `v46.1.17`), so Renovate's first run failed with "unable to find version v46". Pin to the current release. Renovate will keep it bumped going forward.