### PR TITLE
ci: drop invalid 'comment' key from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
   "timezone": "America/New_York",
   "schedule": ["before 6am on monday"],
   "labels": ["dependencies"],
-  "comment": "platformAutomerge:false makes Renovate gate merges on CI itself (it waits for the PR's tests to pass) instead of relying on GitHub branch protection. That lets safe auto-merge work on private repos WITHOUT GitHub Pro.",
   "platformAutomerge": false,
   "packageRules": [
     {


### PR DESCRIPTION
Renovate strict-validates its config and rejects unknown keys. The inline `comment` field I'd added for documentation was rejected, so Renovate halted all dependency PRs and opened a config-error issue (#242). Removing the key. The rationale it held now lives in the `renovate.yml` workflow header. After merge, re-run `renovate.yml` and #242 auto-closes.