### PR TITLE
ci: upload coverage to Codecov + add canonical badge row

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,17 @@ jobs:
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
       - run: uv sync --locked --all-packages
       - run: just check
+      # Upload coverage to Codecov (Linux job only — one upload per run keeps
+      # us under the free tier's 250 private-repo uploads/month). Uses the
+      # CODECOV_TOKEN secret if set, else the installed Codecov GitHub App
+      # (tokenless). Never reddens CI: fail_ci_if_error is false.
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
       # Patch-coverage gate: fail PRs whose diff drops below 80% covered.
       # Runs only on PRs (push-to-main has no meaningful base to diff) and
       # only on Linux (the coverage.xml shape is identical across OSes so

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # agent_core
 
+[![CI](https://github.com/jeffrichley/agent_core/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffrichley/agent_core/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/jeffrichley/agent_core/branch/main/graph/badge.svg)](https://codecov.io/gh/jeffrichley/agent_core)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org)
+
 Core infrastructure for AI agents. Consolidates memory, knowledge compilation, and shared tooling.
 
 ## Setup


### PR DESCRIPTION
Pilots the Codecov half of the canonical project standard on agent_core.

- Adds a **Codecov upload step** to the Linux `check` job after `just check` produces `coverage.xml`. Linux-only = one upload per run (stays under the free tier's 250 private uploads/month). `fail_ci_if_error: false` so a failed upload never reddens CI.
- Auth: uses the installed **Codecov GitHub App tokenless**; if a `CODECOV_TOKEN` secret is later added it's used automatically.
- Adds the **canonical README badge row** (CI · codecov · Ruff · mypy · License · Python 3.12+).
- Action pinned to SHA (v7.0.0) per house style.

After merge, main's CI run uploads coverage and the badge goes live. If the tokenless upload doesn't land, we add the repo upload token as a secret.