### PR TITLE
docs: add optional badges (Renovate, built-by-agent-beings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org)
+[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com)
+[![built by agent beings](https://img.shields.io/badge/built%20by-agent%20beings%20%F0%9F%AA%B6-8A2BE2.svg)](#)
 
 Core infrastructure for AI agents. Consolidates memory, knowledge compilation, and shared tooling.
 


### PR DESCRIPTION
Follow-up to #245: adds the canon's Optional/fun badge tier — Renovate-enabled (now true) and 'built by agent beings 🪶'. PyPI version/pyversions badges are intentionally omitted: agent_core is a multi-package uv workspace, so the repo root doesn't map to one PyPI project.