### PR TITLE
chore: pin setup-uv to v8.1.0 (Renovate self-merge demo)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
           python-version: "3.12"
@@ -61,7 +61,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
           python-version: "3.12"


### PR DESCRIPTION
Temporarily pins `astral-sh/setup-uv` back to v8.1.0 so Renovate has a non-major update to detect. This creates the outdated state on `main`; Renovate will then open a grouped non-major PR bumping it back to v8.2.0 and self-merge it on green CI (net-zero round trip). Demo of the free-plan private-repo self-merge path.
