### PR TITLE
chore: run Renovate daily instead of weekly

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,7 +10,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: "0 10 * * 1" # Monday ~06:00 America/New_York
+    - cron: "0 10 * * *" # Daily ~06:00 America/New_York
   workflow_dispatch: {}
 
 permissions:

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     ":dependencyDashboard"
   ],
   "timezone": "America/New_York",
-  "schedule": ["before 6am on monday"],
+  "schedule": ["before 6am"],
   "labels": ["dependencies"],
   "platformAutomerge": false,
   "packageRules": [


### PR DESCRIPTION
Bumps both Renovate schedule layers from weekly to daily.

**Why:** with a weekly Monday cron, a dependency PR opens on one Monday but can't merge until the *next* Monday's run — because opening and merging can't happen in the same pass (CI isn't instant; Renovate opens the PR then exits, and only a later pass reads the now-green status and merges). That's a ~7-day lag between "PR green" and "PR merged." Daily cuts it to ~1 day.

Both layers had to change together — bumping only the GHA cron wouldn't help while `renovate.json` still restricted create/merge to Mondays.

- `renovate.yml` cron: `0 10 * * 1` → `0 10 * * *` (daily ~06:00 ET)
- `renovate.json` schedule: `before 6am on monday` → `before 6am` (daily early-morning window)
