### PR TITLE
docs: add MkDocs documentation site with llms.txt and API reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: docs
+
+# Build and deploy the MkDocs site to GitHub Pages (gh-pages branch).
+# Runs ONLY on push to main and manual dispatch — never on pull_request, so
+# fork PRs can never trigger a deploy with write permissions (no secret/token
+# exposure). Enable Pages in repo settings to serve from the gh-pages branch.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mkdocs.yml"
+      - "docs/**"
+      - "packages/*/src/**"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - name: Configure git identity for gh-pages commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      # Build in an ISOLATED ephemeral env (--no-project): the docs toolchain
+      # only — no torch, no workspace resolution (which is slow: it re-resolves
+      # the cu130 torch index). mkdocstrings reads package source statically via
+      # griffe (paths configured in mkdocs.yml), so agent_core need not be
+      # installed. The dep set mirrors the `docs` dependency-group in
+      # pyproject.toml (used for local `uv sync --group docs && mkdocs serve`).
+      - name: Build and deploy
+        run: >-
+          uv run --isolated --no-project
+          --with mkdocs-material --with "mkdocstrings[python]"
+          --with mkdocs-llmstxt --with ruff
+          mkdocs gh-deploy --force --strict

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,35 @@
+# About
+
+agent-core is core infrastructure for AI agents: a durable message bus,
+envelopes, endpoints, and a plugin system. It is developed in the open at
+[jeffrichley/agent_core](https://github.com/jeffrichley/agent_core).
+
+## Status
+
+agent-core is under active development and used in production by the agents that
+build it. The public API described in these docs is the surface we intend
+adopters to build on; internal modules (prefixed with `_`) may change without
+notice.
+
+## Who builds it
+
+agent-core is written and operated by AI agent beings alongside their human
+partner. That is not a marketing line — it is how the work actually happens, and
+it shapes the design: the framework is built by the same kind of entity that
+runs on it.
+
+## License
+
+Released under the MIT License. See
+[LICENSE](https://github.com/jeffrichley/agent_core/blob/main/LICENSE).
+
+## Contributing
+
+Conventions, testing instructions, and CI gates live in the repository's
+`CLAUDE.md`. Releases follow conventional commits via release-please. If you are
+an agent or a human wanting to contribute, start there.
+
+## Changelog
+
+See [CHANGELOG.md](https://github.com/jeffrichley/agent_core/blob/main/CHANGELOG.md)
+for the release history.

--- a/docs/concepts/bus.md
+++ b/docs/concepts/bus.md
@@ -1,0 +1,74 @@
+# The Bus
+
+The bus (`agent_core.bus.core.Bus`) is the heart of agent-core: an in-process async router that connects every participant in the system. Its job is to accept an envelope from a sender, write it durably, deliver it to the right endpoint, and confirm the outcome — all without the sender needing to care about whether the recipient is currently available.
+
+## What the bus does
+
+**Route.** Every endpoint registers under a unique name before the bus starts. When an envelope arrives, the bus looks up the registered endpoint by `envelope.to` and calls its `deliver()` method.
+
+**Persist.** Before dispatching, the bus writes the envelope to a SQLite mailbox (`storage_path` in `BusConfig`). This means a crash between publish and ack does not lose the message: envelopes survive restarts and are replayed when the endpoint comes back online.
+
+**Await acknowledgment.** Dispatch is synchronous per envelope: the bus awaits `deliver()` before moving on. The endpoint must eventually call `bus.ack(envelope_id)` to confirm handling. Until it does, the envelope remains in an in-flight state in the mailbox.
+
+**Retry.** A redelivery sweep runs periodically (`redelivery_sweep_seconds`). Any envelope that has been in-flight longer than `redelivery_timeout_seconds` is either requeued for another attempt or moved to dead-letter once `max_delivery_attempts` is exhausted.
+
+**TTL sweep.** Envelopes can carry an `expires_at` timestamp. A separate TTL sweep loop (`ttl_sweep_seconds`) marks expired-and-undelivered envelopes as `expired` so they never get delivered after their window closes.
+
+**Dead-letter.** An envelope ends up dead-lettered if the endpoint raises a non-`EndpointUnavailable` exception during `deliver()`, if it exceeds `max_delivery_attempts`, or if a `pre_deliver` hook drops it. Dead-lettered envelopes stay in the mailbox for inspection; they are not retried.
+
+**Supervise endpoints.** The supervisor layer monitors endpoint health. If an endpoint raises during `start()` or repeatedly fails delivery, the supervisor backs off (exponential with jitter) and eventually quarantines the endpoint before probing it again. See [Endpoints](endpoints.md) for how this interacts with the deliver/ack contract.
+
+## Delivery lifecycle
+
+```
+publish()
+  │
+  ├─ pre_publish hooks (may mutate or drop)
+  │
+  ├─ insert into SQLite mailbox (status: pending)
+  │
+  └─ dispatch()
+       │
+       ├─ pre_deliver hooks (may mutate or drop → dead-letter if dropped)
+       │
+       ├─ mark in_flight (timeout = now + redelivery_timeout_seconds)
+       │
+       └─ endpoint.deliver(envelope)
+            │
+            ├─ endpoint calls ack()  → status: acked  ✓
+            │
+            ├─ raises EndpointUnavailable → status: pending (requeue)
+            │
+            └─ raises other exception  → status: dead_letter
+```
+
+Redelivery sweep requeues envelopes that stay in-flight past the timeout; a separate TTL sweep expires envelopes past their `expires_at`.
+
+## Bus hooks
+
+The bus has two pipeline stages where hooks can intercept envelopes:
+
+- **`pre_publish`** — runs before persistence. A hook can mutate (e.g., stamp metadata) or drop (return `None`) the envelope before it is written to the mailbox.
+- **`pre_deliver`** — runs just before `endpoint.deliver()` is called. A hook that drops an envelope here causes it to move directly to dead-letter (it was already persisted).
+
+## Why SQLite?
+
+SQLite gives the bus durability with zero external dependencies. The mailbox is a single file on disk. Envelopes written before a crash are there when the process restarts; the bus drains them per endpoint as each endpoint comes online. The schema uses WAL mode for concurrent reads during tailing and audit queries.
+
+## Configuration knobs
+
+`BusConfig` controls the bus-level tuning; `SupervisorConfig` (nested at `BusConfig.supervisor`) controls the supervision layer. Conceptually:
+
+| Area | What you tune |
+|---|---|
+| Storage | `storage_path`, `acked_retention_days` |
+| Delivery | `redelivery_timeout_seconds`, `max_delivery_attempts`, `max_pending_per_endpoint` |
+| Sweep cadence | `ttl_sweep_seconds`, `redelivery_sweep_seconds` |
+| Restart backoff | `restart_backoff_base_seconds`, `restart_backoff_factor`, `restart_backoff_cap_seconds`, `restart_jitter` |
+| Quarantine | `restarts_before_quarantine`, `probe_interval_seconds` |
+| Circuit breaker | `delivery_backoff_base_seconds/factor/cap`, `deliver_failures_before_breaker` |
+
+For exact field names and defaults, see the [API Reference](../reference/index.md).
+
+!!! note "Fan-out is atomic"
+    When you publish to multiple recipients (via `BusHandle.publish(envelope, to=[...])`) the bus pre-validates all recipients and mailbox capacities before writing any envelope. Either all recipients accept the envelope, or none do.

--- a/docs/concepts/endpoints.md
+++ b/docs/concepts/endpoints.md
@@ -1,0 +1,77 @@
+# Endpoints & Supervision
+
+An endpoint is any addressable participant on the bus. It might be an AI agent, a Discord adapter, a job scheduler, or a test stub — what matters is that it has a registered name and implements three async methods. The bus calls those methods; the endpoint does whatever its job is and signals back.
+
+## The protocol
+
+```python
+class Endpoint(Protocol):
+    name: str
+
+    async def start(self, bus: BusHandle) -> None: ...
+    async def deliver(self, envelope: Envelope) -> None: ...
+    async def stop(self) -> None: ...
+```
+
+**`start(bus)`** is called once when the bus starts, after the endpoint is registered. The `BusHandle` argument is the endpoint's identity-bound view of the bus (see below). Open connections, start background loops, and subscribe to external sources here. Pending envelopes addressed to this endpoint are drained and dispatched immediately after `start()` returns.
+
+**`deliver(envelope)`** is called by the bus for each envelope addressed to this endpoint. The bus awaits this call, so it must return promptly. Long-running work should be handed off to a background task; `deliver()` should return after acking, then publish a `Progress` or reply envelope when the work completes.
+
+**`stop()`** is called in reverse-registration order during a graceful shutdown. Close connections and flush state here.
+
+## The deliver/ack contract
+
+The `deliver()` method has an important invariant: **it must eventually call `bus.ack(envelope.id)`**. Until ack is called, the envelope remains in-flight in the SQLite mailbox. If the process crashes before ack, the redelivery sweep will redeliver the envelope when the process restarts.
+
+```python
+async def deliver(self, envelope: Envelope) -> None:
+    # Return promptly: hand off to background work, ack immediately.
+    asyncio.create_task(self._handle(envelope))
+
+async def _handle(self, envelope: Envelope) -> None:
+    try:
+        # ... do the work ...
+        await self._bus.ack(envelope.id)
+    except Exception:
+        await self._bus.nack(envelope.id, requeue=True)
+```
+
+## Signaling failure
+
+Two outcomes are possible when `deliver()` raises instead of completing normally:
+
+**`EndpointUnavailable`** signals a temporary failure. The bus requeues the envelope (status becomes `pending`) and it will be retried on the next redelivery sweep. Use this when the endpoint is temporarily unable to accept work — for example, a downstream service is unreachable. The supervisor also uses this signal as input to the circuit breaker (see below).
+
+**Any other exception** is terminal. The envelope moves to dead-letter and will not be retried. Use this for programming errors, malformed payloads, or any case where retrying would be futile.
+
+!!! warning "deliver() blocks the dispatch loop"
+    The bus awaits `deliver()` before dispatching the next envelope. An endpoint that blocks in `deliver()` for a long time will stall all other endpoints. Return quickly; do the work in a background task.
+
+## BusHandle — identity-bound publishing
+
+Each endpoint receives a `BusHandle` bound to its name at `start()` time. This is the only surface through which an endpoint should interact with the bus:
+
+- **`handle.publish(envelope, to=...)`** — send an envelope. The bus stamps `from_` to this endpoint's name automatically.
+- **`handle.ack(envelope_id)`** — mark an envelope handled. Idempotent.
+- **`handle.nack(envelope_id, requeue=True)`** — reject an envelope; requeue it or dead-letter it.
+- **`handle.endpoints()`** — list currently registered endpoints (name + description snapshot).
+
+The identity binding is a security property: an endpoint cannot publish on behalf of another endpoint, regardless of what it sets in the envelope fields.
+
+## EndpointSpec — registering with a description
+
+Endpoints are registered via `EndpointSpec(endpoint=..., description="...")`. The description is surfaced in the `handle.endpoints()` directory listing, which agents use to discover what participants are available on the bus.
+
+## Supervision
+
+The bus supervisor monitors endpoint health so the system is self-healing rather than fail-stop.
+
+**Restart backoff.** If an endpoint's `start()` raises, or if the supervisor determines an endpoint needs to be restarted, it waits before retrying. The wait follows exponential backoff: starting at `restart_backoff_base_seconds`, multiplying by `restart_backoff_factor` on each failure, capped at `restart_backoff_cap_seconds`. Jitter (full, equal, or none) spreads restarts so endpoints do not thunderherd after a shared dependency recovers.
+
+**Quarantine.** After `restarts_before_quarantine` consecutive restart failures, the supervisor stops retrying immediately and instead probes the endpoint every `probe_interval_seconds`. This prevents a broken endpoint from burning CPU in a tight restart loop.
+
+**Circuit breaker.** A separate circuit breaker tracks delivery failures. After `deliver_failures_before_breaker` consecutive failures, the breaker opens: the bus pauses delivery to that endpoint and applies `delivery_backoff_base_seconds/factor/cap` before retrying. When a delivery succeeds, the breaker resets.
+
+The combination means an endpoint that is temporarily unavailable (raises `EndpointUnavailable`) degrades gracefully: the bus backs off delivery, the envelopes stay safely in the mailbox, and delivery resumes when the endpoint recovers — without operator intervention.
+
+For exact `SupervisorConfig` field names and defaults, see the [API Reference](../reference/index.md).

--- a/docs/concepts/envelopes.md
+++ b/docs/concepts/envelopes.md
@@ -1,0 +1,67 @@
+# Envelopes & Kinds
+
+Every message that crosses the bus is an `Envelope`. There is no other wire format. Whether you are an AI agent sending a text message to a Discord adapter, a scheduler signaling a job event, or an endpoint acknowledging receipt, the shape is always the same: an `Envelope` with a typed payload inside.
+
+## The field set
+
+```python
+class Envelope(BaseModel):
+    id: str                              # unique envelope id (hex uuid)
+    correlation_id: str                  # groups related envelopes into a thread
+    in_reply_to: str | None             # id of the envelope this is a reply to
+    from_: str                           # stamped by the bus at publish time
+    to: str                              # registered endpoint name
+    kind: str                            # discriminates the payload type
+    payload: EnvelopePayload | dict      # typed for built-ins, dict for plugin kinds
+    metadata: dict[str, Any]            # extension data (adapter-specific, not bus-controlled)
+    urgency: Literal["green", "yellow", "red"]  # default: "green"
+    expires_at: datetime | None         # TTL; bus expires undelivered envelopes past this
+    created_at: datetime
+```
+
+### `from_` is stamped by the bus
+
+You do not set `from_` yourself. When you call `BusHandle.publish()`, the bus overwrites `from_` with the publishing endpoint's registered name. This is an identity guarantee: an endpoint cannot spoof another endpoint's name, regardless of what it constructs locally.
+
+### `correlation_id` for threading
+
+Use `correlation_id` to group a chain of related envelopes — the originating request and all replies, progress updates, and cancellations that belong to it. The bus does not interpret or enforce correlation semantics; it is a field you set and read.
+
+`in_reply_to` narrows further: it names the specific envelope that triggered this one, useful when a thread branches (e.g., two parallel ToolInvocation replies to one request).
+
+## Built-in payload kinds
+
+The `kind` field is a free string, but the seven built-in kinds get full Pydantic validation. The bus rejects a built-in kind whose payload fails type validation — you get the error synchronously at publish time, not as a later dead-letter.
+
+| Kind | Purpose |
+|---|---|
+| `TextMessage` | Human-readable text; carries `text: str` and optional `attachments` |
+| `Event` | Domain events; carries `type: str`, `schema_version`, and an open `data: dict` |
+| `ToolInvocation` | Request to call a named tool; carries `tool: str` and `args: dict` |
+| `Cancellation` | Cancel a prior request; optionally carries `reason: str` |
+| `Progress` | Mid-flight status update; carries `status` (working/blocked/complete) and optional `note`, `percent` |
+| `Acknowledgment` | Explicit acknowledgment of a prior envelope; carries `of: str` (the envelope id) and optional `note` |
+| `Notification` | Inbound notification from an external source (GitHub, Gmail, etc.); carries `source`, `reason`, `landed_at`, and a `body` dict |
+
+!!! note "Acknowledgment vs ack()"
+    `Acknowledgment` is a _message kind_ you publish when you want the sender to know you received and processed their envelope. It is different from the bus-level `ack()` call that clears the in-flight state in the mailbox. Most endpoints do both: call `bus.ack(envelope.id)` to satisfy the bus, and optionally publish an `Acknowledgment` envelope back to the sender to close the application-level loop.
+
+## Urgency
+
+`urgency` is a three-level signal: `green` (default, background), `yellow` (elevated), `red` (needs immediate attention). Higher-urgency envelopes are presented first in inline-wake notifications. The bus delivers in the order they are dispatched; urgency controls presentation in the notification layer, not delivery order on the bus itself.
+
+## Plugin kinds
+
+The built-in set is not closed. Plugins can register additional first-class kinds via the `register_envelope_renderers` hookspec. A plugin kind:
+
+- Uses a dict payload (not a typed Pydantic model) whose `"kind"` key matches `Envelope.kind`.
+- Is validated by the plugin's own code, not the bus.
+- Has a renderer that formats it inside `<inbox>` notifications for inline-wake delivery.
+
+Duplicate kind names across plugins raise `PluginRegistryError` at startup. See [Extensions](extensions.md) for the registration pattern.
+
+## Envelope as audit trail
+
+Because every envelope is persisted to the SQLite mailbox before delivery, you always have a record of what was sent, when, from whom, to whom, and what happened to it (pending, in-flight, acked, dead-letter, expired). The `bus_tail` surface exposes this for read-only queries.
+
+For exact field types and payload model signatures, see the [API Reference](../reference/index.md).

--- a/docs/concepts/extensions.md
+++ b/docs/concepts/extensions.md
@@ -1,0 +1,138 @@
+# Extensions
+
+agent-core is designed to be extended without forking. The extension model is built on [Pluggy](https://pluggy.readthedocs.io/), the same hook framework used by pytest. A plugin is a Python package that declares an entry point in the `agent_core` group; the bus runner discovers and loads it at startup.
+
+## Entry point registration
+
+```toml
+# your package's pyproject.toml
+[project.entry-points."agent_core"]
+my_plugin = "my_package.plugin"
+```
+
+Inside `my_package/plugin.py`, mark hook implementations with the `hookimpl` marker:
+
+```python
+import pluggy
+
+hookimpl = pluggy.HookimplMarker("agent_core")
+
+@hookimpl
+def register_endpoint_types() -> dict:
+    return {"my_plugin.my_endpoint": MyEndpoint}
+```
+
+The runner collects all installed plugins via `importlib.metadata` and calls their hook implementations in registration order.
+
+## What a plugin can contribute
+
+### New endpoint types
+
+```python
+@hookimpl
+def register_endpoint_types(self) -> dict[str, type[Endpoint]]:
+    return {"my_plugin.widget": WidgetEndpoint}
+```
+
+The returned dict maps a type-id string to an `Endpoint` class. Operators reference the type-id in their YAML config under `endpoints[].type`. Duplicate type-ids across plugins raise `PluginRegistryError` at startup.
+
+### New bus hook types
+
+```python
+@hookimpl
+def register_bus_hook_types(self) -> dict[str, type[BusHook]]:
+    return {"my_plugin.rate_limit": RateLimitHook}
+```
+
+Bus hooks intercept envelopes at `pre_publish` or `pre_deliver`. A hook can mutate the envelope (e.g., stamp metadata) or drop it (return `None`). Operators configure hooks in YAML under `bus_hooks[].type`.
+
+### New envelope kinds + renderers
+
+```python
+@hookimpl
+def register_envelope_renderers(self) -> dict[str, Any]:
+    return {"MyKind": render_my_kind}
+```
+
+Registering a renderer makes `MyKind` a first-class envelope kind. Envelopes with `kind="MyKind"` carry a dict payload (the plugin owns validation). The renderer is a callable `(envelope: dict) -> str` that formats the body of the `<inbox>` block for inline-wake notifications. See the [envelope extensions doc](https://github.com/jeffrichley/agent_core/blob/main/docs/extensions.md) for a worked example including payload publication.
+
+### Post-construction endpoint wiring
+
+```python
+@hookimpl
+def configure_endpoint_instance(
+    self, instance, endpoint_name, endpoint_config, services
+) -> None:
+    if isinstance(instance, MyEndpoint):
+        instance.set_broker(services.notify_broker)
+```
+
+Use this for wiring that cannot happen in `__init__` because it depends on shared runtime services (`RunnerServices` carries the `notify_broker` and optional `mcp_audit_writer`).
+
+For cross-endpoint wiring (e.g., pairing two endpoints that need references to each other), use `wire_endpoints_after_registration`, which is called once all endpoints are constructed.
+
+### CLI subcommands
+
+```python
+@hookimpl
+def register_cli_subapps(self, app: typer.Typer) -> None:
+    from my_package.cli import subapp
+    app.add_typer(subapp, name="widget")
+```
+
+This extends the top-level `agent-core` CLI without the core package depending on your plugin. Import lazily inside the hookimpl to preserve layering.
+
+### Config validation
+
+```python
+@hookimpl
+def validate_config(self, raw_config: dict) -> None:
+    if "widget" not in raw_config:
+        raise ValueError("my_plugin requires a [widget] config section")
+```
+
+Validation hooks run early, before any endpoint is constructed. Raise to block startup with a clear error message.
+
+### Bus log projectors
+
+```python
+@hookimpl
+def register_bus_log_projectors(self) -> dict[str, Any]:
+    return {"MyKind": MyKindProjector()}
+```
+
+Projectors map envelope kinds (or `Event.type` strings) to display logic for the bus log. Last-write-wins on duplicate keys.
+
+## Built-in type aliases
+
+Core ships a built-in plugin that registers the following aliases so you can reference them directly in YAML config:
+
+**Endpoint types:**
+
+| Alias | Class |
+|---|---|
+| `builtin.stub` | `agent_core.endpoints.stub.StubEndpoint` |
+| `builtin.discord` | `agent_core_discord.endpoint.DiscordEndpoint` |
+| `builtin.claude_code_mcp` | `agent_core.endpoints.claude_code_mcp.ClaudeCodeMCPEndpoint` |
+| `builtin.scheduler` | `agent_core.endpoints.scheduler.SchedulerEndpoint` |
+| `builtin.handoff_jobs` | `agent_core.endpoints.handoff_jobs.HandoffJobsEndpoint` |
+
+**Hook tool types** (used in pipeline config):
+
+| Alias | Class |
+|---|---|
+| `builtin.handoff_writer` | `agent_core.hooks.tools.handoff_writer.HandoffWriter` |
+| `builtin.identity_injector` | `agent_core.hooks.tools.identity_injector.IdentityInjector` |
+| `builtin.time_injector` | `agent_core.hooks.tools.time_injector.TimeInjector` |
+
+Your plugin's type-ids coexist with these. You cannot override a built-in type-id; use a distinct namespace (e.g., `my_org.my_endpoint`).
+
+## Hook ordering and collision policy
+
+Pluggy calls all implementations of a hook and collects their return values. For `register_endpoint_types` and `register_envelope_renderers`, the runner merges the dicts — a duplicate key across two plugins raises `PluginRegistryError` at startup. This is a programming error, not a configuration issue; fix it by choosing a distinct type-id or kind name.
+
+The `register_bus_log_projectors` hook is the exception: last-write-wins on duplicates is intentional, allowing a plugin to override a built-in projector.
+
+## Writing an extension
+
+For a step-by-step guide with a working example, see [Write an extension](../guides/write-an-extension.md).

--- a/docs/concepts/extensions.md
+++ b/docs/concepts/extensions.md
@@ -30,7 +30,7 @@ The runner collects all installed plugins via `importlib.metadata` and calls the
 
 ```python
 @hookimpl
-def register_endpoint_types(self) -> dict[str, type[Endpoint]]:
+def register_endpoint_types() -> dict[str, type[Endpoint]]:
     return {"my_plugin.widget": WidgetEndpoint}
 ```
 
@@ -40,7 +40,7 @@ The returned dict maps a type-id string to an `Endpoint` class. Operators refere
 
 ```python
 @hookimpl
-def register_bus_hook_types(self) -> dict[str, type[BusHook]]:
+def register_bus_hook_types() -> dict[str, type[BusHook]]:
     return {"my_plugin.rate_limit": RateLimitHook}
 ```
 
@@ -50,7 +50,7 @@ Bus hooks intercept envelopes at `pre_publish` or `pre_deliver`. A hook can muta
 
 ```python
 @hookimpl
-def register_envelope_renderers(self) -> dict[str, Any]:
+def register_envelope_renderers() -> dict[str, Any]:
     return {"MyKind": render_my_kind}
 ```
 
@@ -61,7 +61,7 @@ Registering a renderer makes `MyKind` a first-class envelope kind. Envelopes wit
 ```python
 @hookimpl
 def configure_endpoint_instance(
-    self, instance, endpoint_name, endpoint_config, services
+    instance, endpoint_name, endpoint_config, services
 ) -> None:
     if isinstance(instance, MyEndpoint):
         instance.set_broker(services.notify_broker)
@@ -75,7 +75,7 @@ For cross-endpoint wiring (e.g., pairing two endpoints that need references to e
 
 ```python
 @hookimpl
-def register_cli_subapps(self, app: typer.Typer) -> None:
+def register_cli_subapps(app: typer.Typer) -> None:
     from my_package.cli import subapp
     app.add_typer(subapp, name="widget")
 ```
@@ -86,7 +86,7 @@ This extends the top-level `agent-core` CLI without the core package depending o
 
 ```python
 @hookimpl
-def validate_config(self, raw_config: dict) -> None:
+def validate_config(raw_config: dict) -> None:
     if "widget" not in raw_config:
         raise ValueError("my_plugin requires a [widget] config section")
 ```
@@ -97,7 +97,7 @@ Validation hooks run early, before any endpoint is constructed. Raise to block s
 
 ```python
 @hookimpl
-def register_bus_log_projectors(self) -> dict[str, Any]:
+def register_bus_log_projectors() -> dict[str, Any]:
     return {"MyKind": MyKindProjector()}
 ```
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,16 @@
+# Concepts
+
+agent-core is built around one central idea: **endpoints on a bus, work as envelopes**.
+
+Every participant in the system — an AI agent, a Discord adapter, a scheduler, a stub for testing — is an **endpoint**: an addressable name that can receive and send messages. Those messages are **envelopes**: a universal wire format carrying a typed payload, routing metadata, and an urgency level. The **bus** is the in-process router that connects them: it persists every envelope to a durable SQLite mailbox, dispatches to the target endpoint, waits for acknowledgment, and retries or dead-letters if delivery fails. Finally, **extensions** let third-party packages contribute new endpoint types, new envelope kinds, bus hooks, and CLI subcommands — without modifying agent-core itself.
+
+These four concepts build on each other in order:
+
+| Concept | What it does |
+|---|---|
+| [Bus](bus.md) | Routes, persists, retries, and supervises everything |
+| [Envelopes](envelopes.md) | The universal wire format all participants share |
+| [Endpoints](endpoints.md) | Addressable participants; the deliver/ack contract |
+| [Extensions](extensions.md) | How plugins contribute new types and behaviors |
+
+Read the pages in order if you are new to agent-core. If you are looking for exact field names and method signatures, see the [API Reference](../reference/index.md).

--- a/docs/getting-started/daemon.md
+++ b/docs/getting-started/daemon.md
@@ -1,0 +1,166 @@
+# Running the Daemon
+
+The agent-core daemon is a supervised process that runs every endpoint defined in `agent_core.yaml`: the bus, Claude Code MCP adapters, Discord connectors, the scheduler, brief framework, and any plugin-contributed types. It manages endpoint lifecycle, delivery sweeps, and the HTTP surface the bus tools connect to.
+
+!!! note "Authoritative reference"
+    This page is the adopter-facing getting-started guide. The full operator reference — troubleshooting tables, instance internals, Windows autostart — lives at [`docs/setup/daemon.md`](https://github.com/jeffrichley/agent_core/blob/main/docs/setup/daemon.md).
+
+## Why a separate venv
+
+The daemon runs from its **own** venv at `~/.agent-core/.venv/`, not from the workspace `.venv/`. This is intentional: `uv sync` activity in the workspace (adding members, resolving the lockfile) rewrites editable `.pth` files and can disrupt a running process that holds open files in `.venv/`. Isolating the daemon venv means workspace iteration never drops a live agent session.
+
+## Instances
+
+The daemon supports three named instances, each with an independent home directory, port, and venv:
+
+| Instance | Home | Port | Code source |
+|---|---|---|---|
+| `prod` (default) | `~/.agent-core/` | 8789 | Release artifacts |
+| `source` | `~/.agent-core-source/` | 8788 | Workspace `.venv` (editable) |
+| `test` | `~/.agent-core-test/` | 8787 | Release artifacts |
+
+With no `--instance` flag and no `AGENT_CORE_INSTANCE` env var, all commands target `prod`. The `source` and `test` instances are additive — they cannot touch prod's venv, port, or state.
+
+## Prod: one-time setup
+
+Prod installs from GitHub Release artifacts, not from the workspace source.
+
+```bash
+# Scaffold the prod config if this machine has never run the daemon.
+agent-core daemon init
+
+# Install the latest release into ~/.agent-core/.venv/.
+agent-core daemon install
+
+# Start the daemon.
+agent-core daemon start
+
+# Verify.
+agent-core daemon status
+```
+
+A healthy `daemon status` looks like:
+
+```
+prod daemon is running (PID: NNNNN)
+running from: ~/.agent-core/.venv/Scripts/python.exe
+installed at: <timestamp>
+installed sha: <git short hash>
+installed version: <X.Y.Z>
+```
+
+## Prod: picking up a new release
+
+```bash
+# Install and restart with the latest release.
+agent-core daemon refresh
+
+# Pin a specific version (useful for rollbacks).
+agent-core daemon refresh --release v0.2.0
+```
+
+`refresh` runs stop → install → start in order. See [`docs/setup/releases.md`](https://github.com/jeffrichley/agent_core/blob/main/docs/setup/releases.md) for the release flow.
+
+### Live agent sessions survive a bounce
+
+Agents connect to the bus through the `agent-core` and `agent-core-channel` **stdio MCP servers**, not directly over HTTP. Each tool call opens a fresh backend connection, so a daemon restart (or crash) during an in-flight call returns a structured transient error that the agent retries automatically. No session restart needed.
+
+Your agent's `.mcp.json` should point at the daemon venv's binaries directly:
+
+```json
+{
+  "mcpServers": {
+    "agent-core": {
+      "type": "stdio",
+      "command": "C:\\Users\\<you>\\.agent-core\\.venv\\Scripts\\python.exe",
+      "args": ["-m", "agent_core_busproxy", "--agent", "<AGENT>",
+               "--daemon-url", "http://127.0.0.1:8789"]
+    },
+    "agent-core-channel": {
+      "type": "stdio",
+      "command": "C:\\Users\\<you>\\.agent-core\\.venv\\Scripts\\python.exe",
+      "args": ["-m", "agent_core_channel", "--agent", "<AGENT>",
+               "--daemon-url", "http://127.0.0.1:8789"]
+    }
+  }
+}
+```
+
+!!! warning "Do not use the HTTP MCP form"
+    An older `{"type":"http","url":".../mcp/<agent>"}` shape exists but strands live Claude Code sessions on daemon restart. Always use the stdio form above.
+
+## Source instance: iterate on daemon code
+
+The `source` instance runs editable from the workspace `.venv`. Use it when you're changing daemon code and want a fast restart loop without touching the live `prod` daemon.
+
+### One-time source setup
+
+```bash
+# Run from inside the agent_core repo.
+agent-core daemon init --instance source
+agent-core daemon start --instance source
+```
+
+### The edit → restart loop
+
+```bash
+# Edit code in the repo, then:
+agent-core daemon refresh --instance source
+```
+
+For `source`, `refresh` is a plain stop + start — no install step. The workspace `.venv` is editable, so the restart picks up your latest changes immediately.
+
+!!! note
+    `agent-core daemon install --instance source` is intentionally an error. The source instance is never installed from artifacts.
+
+## Test instance: validate a release before promoting to prod
+
+Use `test` to exercise the full release packaging path (entry points, wheel contents, install correctness) before `daemon refresh` on prod.
+
+```bash
+# One-time scaffold.
+agent-core daemon init --instance test
+
+# Install a specific release candidate.
+agent-core daemon install --instance test --release vX.Y.Z
+
+# Start on port 8787.
+agent-core daemon start --instance test
+
+# Run your checks, then stop.
+agent-core daemon stop --instance test
+```
+
+Once satisfied, promote:
+
+```bash
+agent-core daemon refresh --release vX.Y.Z
+```
+
+## Common problems
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `No daemon config at ...` on `start` | Config not scaffolded | `agent-core daemon init [--instance source\|test]` |
+| `daemon is currently running` on `install` | Prod daemon is up | Use `agent-core daemon refresh` instead |
+| `source daemon needs the workspace .venv` | Ran `start --instance source` outside the repo | `cd` into the agent_core repo first |
+| `the source instance is not installed` | Ran `install --instance source` | Source needs no install — just `daemon start --instance source` |
+
+## Windows: auto-start at boot
+
+```bash
+# Register a Task Scheduler task that starts the prod daemon at logon.
+agent-core daemon install-autostart
+
+# Remove it.
+agent-core daemon uninstall-autostart
+```
+
+Requires the prod daemon to be installed first. The task runs as your own user; no admin rights needed (the daemon binds `127.0.0.1` only).
+
+## Related
+
+- [`docs/setup/daemon.md`](https://github.com/jeffrichley/agent_core/blob/main/docs/setup/daemon.md) — full operator reference including instance internals and troubleshooting
+- [`docs/setup/releases.md`](https://github.com/jeffrichley/agent_core/blob/main/docs/setup/releases.md) — the release flow (release-please + GitHub Release artifacts)
+- [`docs/setup/ci.md`](https://github.com/jeffrichley/agent_core/blob/main/docs/setup/ci.md) — CI gate and hook bootstrap
+- [Concepts](../concepts/index.md) — bus, envelopes, endpoints

--- a/docs/getting-started/first-agent.md
+++ b/docs/getting-started/first-agent.md
@@ -1,0 +1,179 @@
+# Your First Agent / Endpoint
+
+This page walks through the core moving parts: the `Endpoint` protocol, the `StubEndpoint` adapter, and how envelopes flow through the bus. Every claim below is grounded in the source — see `packages/core/src/agent_core/bus/protocol.py`, `endpoints/stub.py`, `bus/handle.py`, and `bus/core.py`.
+
+## The Endpoint protocol
+
+Every participant on the bus implements three async methods:
+
+```python
+from agent_core.bus.protocol import Endpoint
+from agent_core.bus.handle import BusHandle
+from agent_core.bus.envelope import Envelope
+
+class Endpoint(Protocol):
+    name: str
+
+    async def start(self, bus: BusHandle) -> None:
+        """Bus is ready. Store the handle; open connections; start background loops."""
+
+    async def deliver(self, envelope: Envelope) -> None:
+        """An envelope addressed to you has arrived.
+
+        You MUST call bus.ack(envelope.id) when handling completes.
+        Raise EndpointUnavailable for a transient failure — the bus will retry.
+        Any other exception dead-letters the envelope.
+
+        deliver() is awaited before the bus dispatches to any other endpoint,
+        so return promptly. Long work belongs in a background task.
+        """
+
+    async def stop(self) -> None:
+        """Graceful shutdown. Close connections; flush state."""
+```
+
+!!! note "Protocol conformance"
+    `Endpoint` is `@runtime_checkable`, so the bus verifies conformance when you register an endpoint. Missing any of the three methods raises at load time, not at delivery time.
+
+## StubEndpoint — a ready-made dev adapter
+
+`agent_core.endpoints.stub.StubEndpoint` is a minimal in-memory implementation of the protocol. It records every delivered envelope on an `.inbox` list and provides a `.send()` helper for publishing from its own identity.
+
+```python
+from agent_core.endpoints.stub import StubEndpoint
+
+# auto_ack=True (default): the stub acks each delivered envelope automatically.
+echo = StubEndpoint(name="echo", auto_ack=True)
+```
+
+After the bus calls `start()`, the stub stores the `BusHandle` it receives and uses it for both acking and for `.send()`.
+
+### send() signature
+
+```python
+await echo.send(
+    to="other-endpoint",
+    kind="TextMessage",
+    payload={"text": "hello"},
+    # optional:
+    correlation_id=None,   # auto-generated uuid4.hex if omitted
+    in_reply_to=None,
+    metadata=None,
+    expires_at=None,
+)
+```
+
+Calling `.send()` before the bus has called `start()` raises `RuntimeError`.
+
+## BusHandle — your identity-bound view of the bus
+
+When the bus starts an endpoint, it hands it a `BusHandle` bound to that endpoint's name. The handle stamps `from_` on every envelope you publish — you cannot spoof another endpoint's identity.
+
+Key methods on `BusHandle`:
+
+```python
+# Publish an envelope. `to` overrides envelope.to and accepts a list for fan-out.
+await handle.publish(envelope, to="target")
+
+# Confirm successful handling. Idempotent.
+await handle.ack(envelope_id)
+
+# Reject. requeue=True schedules redelivery; False dead-letters.
+await handle.nack(envelope_id, requeue=True)
+
+# Snapshot of currently registered endpoints.
+endpoints = handle.endpoints()   # list[EndpointInfo]
+```
+
+## Constructing and running the Bus
+
+`Bus` lives in `agent_core.bus.core`. It takes a `BusConfig` (which requires at minimum a `storage_path`), accepts endpoint registrations via `Bus.register(EndpointSpec(...))`, and is driven with `await bus.start()` / `await bus.stop()`.
+
+!!! warning "Config-driven path preferred in production"
+    Constructing a `Bus` directly requires wiring `BusConfig`, `EndpointSpec`, and the async lifecycle yourself. In practice, the daemon runner handles all of that from `agent_core.yaml`. The snippet below shows the minimal direct path for clarity — use it for tests or one-off scripts, not for production services.
+
+```python
+import asyncio
+from pathlib import Path
+
+from agent_core.bus.core import Bus, BusConfig, EndpointSpec
+from agent_core.endpoints.stub import StubEndpoint
+from agent_core.bus.envelope import Envelope
+import uuid
+from datetime import UTC, datetime
+
+async def main() -> None:
+    sender = StubEndpoint(name="sender")
+    receiver = StubEndpoint(name="receiver")
+
+    bus = Bus(BusConfig(storage_path=Path("/tmp/demo.sqlite")))
+    bus.register(EndpointSpec(endpoint=sender))
+    bus.register(EndpointSpec(endpoint=receiver))
+
+    await bus.start()
+
+    # StubEndpoint.send() builds and publishes an envelope from "sender".
+    await sender.send(
+        to="receiver",
+        kind="TextMessage",
+        payload={"text": "hello from sender"},
+    )
+
+    # With auto_ack=True, the envelope is already acked.
+    print(receiver.inbox)   # [Envelope(kind='TextMessage', ...)]
+
+    await bus.stop()
+
+asyncio.run(main())
+```
+
+### What happens under the hood
+
+1. `bus.start()` opens the SQLite store, then calls `endpoint.start(handle)` for each registered endpoint in registration order.
+2. After each `start()`, the bus drains any persisted-but-pending envelopes addressed to that endpoint.
+3. `sender.send(...)` calls `handle.publish(envelope)`. The handle stamps `from_="sender"`, runs `pre_publish` hooks, persists the envelope, then dispatches synchronously to `receiver.deliver(envelope)`.
+4. `receiver.deliver()` appends to `.inbox` and calls `handle.ack(envelope.id)`.
+5. `bus.stop()` calls `endpoint.stop()` in reverse registration order, then closes the store.
+
+## Writing a custom endpoint
+
+Implement the three protocol methods. You do not need to inherit from any base class — structural typing is enough.
+
+```python
+from agent_core.bus.handle import BusHandle
+from agent_core.bus.envelope import Envelope
+from agent_core.bus.protocol import EndpointUnavailable
+
+class LoggingEndpoint:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._handle: BusHandle | None = None
+
+    async def start(self, bus: BusHandle) -> None:
+        self._handle = bus
+
+    async def deliver(self, envelope: Envelope) -> None:
+        print(f"[{self.name}] received {envelope.kind!r} from {envelope.from_!r}")
+        assert self._handle is not None
+        await self._handle.ack(envelope.id)
+
+    async def stop(self) -> None:
+        self._handle = None
+```
+
+!!! tip "Long-running work"
+    `deliver()` is awaited before the bus dispatches to any other endpoint. If your handler does I/O or model calls, start a background task, ack immediately, and publish a follow-up envelope when the work is done.
+
+## Error signalling
+
+| What you raise | Bus behaviour |
+|---|---|
+| `EndpointUnavailable` | Envelope requeued; bus retries on backoff |
+| Any other exception | Envelope moved to dead-letter; error logged |
+
+Import `EndpointUnavailable` from `agent_core.bus.protocol`.
+
+## Next steps
+
+- [Running the daemon](daemon.md) — run a supervised multi-endpoint process from `agent_core.yaml`
+- [Concepts — Bus](../concepts/bus.md) — envelope lifecycle, hooks, delivery guarantees

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,53 @@
+# Getting Started
+
+agent-core is a message-bus runtime for AI agent beings. It lets multiple agents and services exchange typed envelopes over a durable SQLite-backed bus, with a config-driven endpoint model and a supervised daemon that survives reboots and rolling releases.
+
+You can adopt it as a human developer building an agentic system, or as an AI agent instrumenting your own communication layer. Both are first-class uses.
+
+## Prerequisites
+
+- Python 3.12 or later
+- [uv](https://docs.astral.sh/uv/) — agent-core is a uv workspace monorepo
+
+## Install
+
+```bash
+uv sync
+```
+
+This resolves and installs the full workspace, including the core package (`agent-core`, importable as `agent_core`), from `packages/core/src/agent_core/`.
+
+## Configure
+
+Agent-core reads an `agent_core.yaml` at your project root. The top-level shape is:
+
+```yaml
+bus:
+  storage_path: "~/.agent-core/bus.sqlite"   # tilde expansion supported
+
+http:
+  bind_host: "127.0.0.1"
+  bind_port: 8789
+
+endpoints:
+  - type: builtin.claude_code_mcp   # endpoint type — builtin or plugin-provided
+    name: my-agent
+    params:
+      mount: /mcp/my-agent
+
+  - type: builtin.stub              # in-memory adapter useful for dev/test
+    name: echo
+```
+
+Each entry in `endpoints[]` declares one addressable participant on the bus. The `type:` field selects the adapter; built-in types include `builtin.stub`, `builtin.discord`, `builtin.claude_code_mcp`, and others contributed by plugins. The daemon resolves plugin types at startup via Python entry points.
+
+!!! tip "Real-world examples"
+    See [`docs/examples/pepper-agent-core.yaml`](https://github.com/jeffrichley/agent_core/blob/main/docs/examples/pepper-agent-core.yaml) for a production-shaped config with session hooks, handoff pipelines, and bus logging.
+
+## Next steps
+
+| Page | What it covers |
+|---|---|
+| [Your first agent](first-agent.md) | Write and run a minimal endpoint; publish and receive an envelope |
+| [Running the daemon](daemon.md) | One-time prod setup, release upgrades, and the source-iteration loop |
+| [Concepts](../concepts/index.md) | Bus, envelopes, endpoints, hooks — the mental model |

--- a/docs/guides/add-an-endpoint.md
+++ b/docs/guides/add-an-endpoint.md
@@ -1,0 +1,177 @@
+# Add an Endpoint
+
+An **endpoint** is any participant on the bus — a Discord adapter, an AI agent's MCP surface, a stub for tests, or a custom adapter you write. This guide walks through implementing the `Endpoint` protocol, registering it with the daemon, and handling the deliver/ack contract correctly.
+
+Sources verified: `packages/core/src/agent_core/bus/protocol.py`, `packages/core/src/agent_core/endpoints/stub.py`, `packages/core/docs/plugins.md`.
+
+---
+
+## Step 1 — Implement the protocol
+
+Every endpoint satisfies three async methods. No base class is needed — structural typing is enough.
+
+```python
+# my_package/endpoints/greeter.py
+from agent_core.bus.handle import BusHandle
+from agent_core.bus.envelope import Envelope
+from agent_core.bus.protocol import EndpointUnavailable
+
+
+class GreeterEndpoint:
+    """A minimal endpoint that logs every TextMessage it receives."""
+
+    def __init__(self, name: str, prefix: str = "Hello") -> None:
+        self.name = name          # required: the bus routes by this name
+        self._prefix = prefix
+        self._handle: BusHandle | None = None
+
+    async def start(self, bus: BusHandle) -> None:
+        """Bus is ready. Store the handle; open connections; start background loops."""
+        self._handle = bus
+
+    async def deliver(self, envelope: Envelope) -> None:
+        """An envelope addressed to this endpoint has arrived.
+
+        Rules:
+        - MUST call self._handle.ack(envelope.id) when handling completes.
+        - Raise EndpointUnavailable for a temporary failure — the bus will
+          requeue and retry on backoff.
+        - Any other exception dead-letters the envelope.
+        - Return promptly. Long work goes in a background task.
+        """
+        assert self._handle is not None
+        try:
+            if envelope.kind == "TextMessage":
+                text = envelope.payload.text  # type: ignore[union-attr]
+                print(f"{self._prefix} from {envelope.from_!r}: {text}")
+        except OSError as exc:
+            # Transient I/O failure — bus will retry.
+            raise EndpointUnavailable(str(exc)) from exc
+
+        await self._handle.ack(envelope.id)
+
+    async def stop(self) -> None:
+        """Graceful shutdown. Close connections, flush state."""
+        self._handle = None
+```
+
+!!! tip "Return promptly from deliver()"
+    The bus awaits `deliver()` before dispatching to any other endpoint. If you need to do model calls, network I/O, or anything slow, spawn a background task, ack immediately, and publish a follow-up envelope when the work completes.
+
+### Error table
+
+| What you raise | Bus behaviour |
+|---|---|
+| `EndpointUnavailable` | Envelope requeued; bus retries on exponential backoff |
+| Any other exception | Envelope moved to dead-letter; error logged |
+| Nothing (ack called) | Envelope marked acked; delivery complete |
+
+---
+
+## Step 2 — Wire it in `agent_core.yaml`
+
+The daemon reads `agent_core.yaml` and instantiates each endpoint by `type:`. Built-in type aliases ship with the core package (e.g. `builtin.stub`). Your own endpoint types are registered via a plugin (Step 3).
+
+```yaml
+# agent_core.yaml
+bus:
+  storage_path: "~/.agent-core/bus.sqlite"
+
+http:
+  bind_host: "127.0.0.1"
+  bind_port: 8788
+
+endpoints:
+  - type: my_package.greeter       # resolved via your plugin's register_endpoint_types()
+    name: greeter
+    params:
+      prefix: "Greetings"
+```
+
+The `name:` field becomes the bus routing address — envelopes addressed `to: greeter` land in `GreeterEndpoint.deliver()`. The `params:` dict is passed as keyword arguments to `__init__` (after `name`).
+
+!!! note "Config-driven production path"
+    In production the daemon runner owns construction, persistence, and lifecycle. Direct `Bus` construction is for tests and one-off scripts — see [Getting Started](../getting-started/first-agent.md) for that pattern.
+
+---
+
+## Step 3 — Register the type via a plugin
+
+The daemon resolves `type:` strings through a plugin registry. Register your endpoint class by contributing a `register_endpoint_types()` hookimpl:
+
+```python
+# my_package/agent_core_plugin.py
+import pluggy
+
+hookimpl = pluggy.HookimplMarker("agent_core")
+
+
+@hookimpl
+def register_endpoint_types() -> dict:
+    from my_package.endpoints.greeter import GreeterEndpoint
+    return {"my_package.greeter": GreeterEndpoint}
+```
+
+Then declare the entry point in `pyproject.toml`:
+
+```toml
+[project.entry-points."agent_core"]
+my_plugin = "my_package.agent_core_plugin"
+```
+
+After `pip install -e .` (or a wheel install), `uv run agent-core daemon start` will discover your plugin and resolve the `my_package.greeter` type.
+
+---
+
+## Step 4 — Run it
+
+```bash
+uv run agent-core daemon start
+```
+
+The daemon starts the bus, calls `endpoint.start(handle)` for each registered endpoint in order, drains any persisted-but-pending envelopes, then enters its run loop. On shutdown it calls `endpoint.stop()` in reverse order.
+
+---
+
+## Using StubEndpoint for tests
+
+`agent_core.endpoints.stub.StubEndpoint` is a ready-made in-memory implementation for tests. It auto-acks, records every delivered envelope on `.inbox`, and provides a `.send()` helper to publish from its own identity.
+
+```python
+import asyncio
+from pathlib import Path
+from agent_core.bus.core import Bus, BusConfig, EndpointSpec
+from agent_core.endpoints.stub import StubEndpoint
+
+async def test_delivery() -> None:
+    sender = StubEndpoint(name="sender")
+    receiver = StubEndpoint(name="receiver", auto_ack=True)
+
+    bus = Bus(BusConfig(storage_path=Path("/tmp/test.sqlite")))
+    bus.register(EndpointSpec(endpoint=sender))
+    bus.register(EndpointSpec(endpoint=receiver))
+    await bus.start()
+
+    await sender.send(
+        to="receiver",
+        kind="TextMessage",
+        payload={"kind": "TextMessage", "text": "ping"},
+    )
+
+    assert len(receiver.inbox) == 1
+    assert receiver.inbox[0].kind == "TextMessage"
+
+    await bus.stop()
+
+asyncio.run(test_delivery())
+```
+
+See [Send and consume envelopes](send-and-consume.md) for the full envelope field reference.
+
+---
+
+## Next steps
+
+- [Send and consume envelopes](send-and-consume.md) — the full publish/ack/nack cycle
+- [Write an extension](write-an-extension.md) — package layout and the full pluggy recipe
+- [Concepts — Endpoints](../concepts/index.md) — delivery guarantees, supervision, circuit-breaking

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,17 @@
+# Guides
+
+How-to recipes for common tasks. Each guide is a concrete, working walkthrough — not a conceptual overview. If you want the mental model first, read [Concepts](../concepts/index.md).
+
+## Available guides
+
+| Guide | What it covers |
+|---|---|
+| [Add an endpoint](add-an-endpoint.md) | Implement the `Endpoint` protocol, wire it in config, register via a plugin |
+| [Send and consume envelopes](send-and-consume.md) | Publish through a `BusHandle`, handle delivery in `deliver()`, ack/nack |
+| [Write an extension](write-an-extension.md) | Pluggy plugin recipe: entry point, `@hookimpl`, `register_endpoint_types()` |
+
+## How to read these guides
+
+Every code snippet is grounded in the actual source. If you are an AI agent adopting agent-core, you can trust the signatures and field names here without cross-checking the source yourself — but the source paths are cited so you can verify.
+
+The "you" in these guides may be a human developer or an agent. Both are first-class readers.

--- a/docs/guides/send-and-consume.md
+++ b/docs/guides/send-and-consume.md
@@ -1,0 +1,220 @@
+# Send and Consume Envelopes
+
+Every message on the bus is an **envelope** — a universal wire format with a `kind`, routing fields (`from_`/`to`), a typed `payload`, and metadata. This guide shows how to publish an envelope through a `BusHandle`, how the target endpoint receives it in `deliver()`, and how to ack, nack, and thread replies via `correlation_id`.
+
+Sources verified: `packages/core/src/agent_core/bus/envelope.py`, `packages/core/src/agent_core/bus/handle.py`, `packages/core/src/agent_core/bus/core.py`, `packages/core/src/agent_core/endpoints/stub.py`.
+
+---
+
+## Envelope anatomy
+
+```python
+class Envelope(BaseModel):
+    id: str                              # unique envelope id (uuid4.hex)
+    correlation_id: str                  # groups a request/reply chain
+    in_reply_to: str | None = None       # id of the envelope being replied to
+    from_: str                           # stamped by BusHandle.publish(); do not set manually
+    to: str                              # destination endpoint name
+    kind: str                            # payload discriminator (see built-in kinds below)
+    payload: EnvelopePayload | dict      # typed model for built-in kinds; dict for plugin kinds
+    metadata: dict[str, Any]             # open bag for routing hints, channel ids, etc.
+    urgency: Literal["green", "yellow", "red"] = "green"
+    expires_at: datetime | None = None   # TTL; undelivered envelopes are expired by a sweep
+    created_at: datetime
+```
+
+`from_` defaults to `""` — the bus overwrites it at publish time with the publishing endpoint's registered name. Endpoints cannot spoof each other.
+
+### Built-in payload kinds
+
+| `kind` | Payload class | Key fields |
+|---|---|---|
+| `TextMessage` | `TextMessagePayload` | `text: str`, `attachments: list[FileAttachment]` |
+| `Event` | `EventPayload` | `type: str`, `schema_version: str`, `data: dict` |
+| `ToolInvocation` | `ToolInvocationPayload` | `tool: str`, `args: dict` |
+| `Cancellation` | `CancellationPayload` | `reason: str | None` |
+| `Progress` | `ProgressPayload` | `status: Literal["working","blocked","complete"]`, `note`, `percent` |
+| `Acknowledgment` | `AcknowledgmentPayload` | `of: str` (id of the envelope being acknowledged), `note` |
+| `Notification` | `NotificationPayload` | `source: str`, `reason: str`, `landed_at: datetime`, `body: dict` |
+
+For built-in kinds, the payload model is validated strictly at publish time. The `kind` field on the outer envelope must match `payload.kind`; mismatches raise `ValueError` before the envelope reaches the bus.
+
+Plugin-registered kinds carry `dict` payloads; the plugin is responsible for validation.
+
+---
+
+## Publishing an envelope
+
+You publish via the `BusHandle` your endpoint received in `start()`. The handle stamps `from_`, runs `pre_publish` hooks, persists the envelope, and dispatches it.
+
+### TextMessage — the most common pattern
+
+```python
+import uuid
+from datetime import UTC, datetime
+from agent_core.bus.envelope import Envelope, TextMessagePayload
+
+async def start(self, bus: BusHandle) -> None:
+    self._handle = bus
+
+# Later, from anywhere that has access to self._handle:
+async def notify_other_agent(self) -> None:
+    envelope = Envelope(
+        id=uuid.uuid4().hex,
+        correlation_id=uuid.uuid4().hex,
+        to="other-agent",
+        kind="TextMessage",
+        payload=TextMessagePayload(text="Task complete — see results in /tmp/output.json"),
+        created_at=datetime.now(UTC),
+    )
+    await self._handle.publish(envelope)
+```
+
+`from_` is left at its default (`""`); the bus overwrites it.
+
+### Fan-out — one envelope, multiple recipients
+
+Pass a list to `publish(envelope, to=[...])`. The bus validates all recipients before inserting any, then delivers a copy to each.
+
+```python
+await self._handle.publish(envelope, to=["agent-a", "agent-b", "agent-c"])
+```
+
+### Reply threading with `in_reply_to`
+
+Preserve `correlation_id` from the original envelope and set `in_reply_to` to its `id`:
+
+```python
+async def deliver(self, envelope: Envelope) -> None:
+    assert self._handle is not None
+    reply = Envelope(
+        id=uuid.uuid4().hex,
+        correlation_id=envelope.correlation_id,   # same chain
+        in_reply_to=envelope.id,                  # points at the original
+        to=envelope.from_,                        # reply to sender
+        kind="TextMessage",
+        payload=TextMessagePayload(text="Got it."),
+        created_at=datetime.now(UTC),
+    )
+    await self._handle.publish(reply)
+    await self._handle.ack(envelope.id)
+```
+
+### StubEndpoint.send() shorthand
+
+`StubEndpoint` offers a `.send()` helper that builds and publishes the envelope for you. Useful in tests:
+
+```python
+await stub.send(
+    to="target",
+    kind="TextMessage",
+    payload={"kind": "TextMessage", "text": "hello"},
+    correlation_id=None,    # auto-generated if omitted
+    in_reply_to=None,
+    metadata=None,
+    expires_at=None,
+)
+```
+
+---
+
+## Receiving and acking in deliver()
+
+The bus calls `endpoint.deliver(envelope)` and waits for it to return before dispatching to any other endpoint. You **must** call `ack` before returning (or as soon as handling is confirmed in a background task).
+
+```python
+async def deliver(self, envelope: Envelope) -> None:
+    assert self._handle is not None
+
+    if envelope.kind == "TextMessage":
+        text = envelope.payload.text   # type: ignore[union-attr]
+        # ... handle the message ...
+
+    # Ack: tell the bus this envelope is handled. Idempotent.
+    await self._handle.ack(envelope.id)
+```
+
+### Background work pattern
+
+If handling is slow, return promptly after acking and continue in a background task:
+
+```python
+import asyncio
+
+async def deliver(self, envelope: Envelope) -> None:
+    assert self._handle is not None
+    await self._handle.ack(envelope.id)          # ack first
+    asyncio.create_task(self._do_work(envelope)) # work in background
+
+async def _do_work(self, envelope: Envelope) -> None:
+    # ... long work ...
+    result = Envelope(
+        id=uuid.uuid4().hex,
+        correlation_id=envelope.correlation_id,
+        in_reply_to=envelope.id,
+        to=envelope.from_,
+        kind="Progress",
+        payload=ProgressPayload(status="complete", note="done"),
+        created_at=datetime.now(UTC),
+    )
+    await self._handle.publish(result)
+```
+
+---
+
+## Nack and redelivery
+
+Call `nack` when you want to reject an envelope explicitly:
+
+```python
+# Requeue for redelivery (default):
+await self._handle.nack(envelope.id, requeue=True)
+
+# Dead-letter without retry:
+await self._handle.nack(envelope.id, requeue=False)
+```
+
+To signal a **temporary** failure and let the bus apply backoff automatically, raise `EndpointUnavailable` from `deliver()` instead of calling `nack` — the bus will requeue and back off from this endpoint until it recovers.
+
+```python
+from agent_core.bus.protocol import EndpointUnavailable
+
+async def deliver(self, envelope: Envelope) -> None:
+    if not self._upstream_available():
+        raise EndpointUnavailable("upstream down")
+    # ... normal handling ...
+    await self._handle.ack(envelope.id)
+```
+
+### Redelivery limits
+
+The bus retries up to `BusConfig.max_delivery_attempts` (default: 5). After that, the envelope moves to dead-letter regardless of whether the failure is `EndpointUnavailable` or an in-flight timeout.
+
+---
+
+## Metadata for routing hints
+
+`metadata` is an open `dict` for side-channel information that adapters and hooks can inspect without changing the payload shape. Example: routing a TextMessage to a specific Discord channel:
+
+```python
+envelope = Envelope(
+    id=uuid.uuid4().hex,
+    correlation_id=uuid.uuid4().hex,
+    to="discord",
+    kind="TextMessage",
+    payload=TextMessagePayload(text="Hello from the bus."),
+    metadata={"discord": {"channel_id": "1234567890"}},
+    created_at=datetime.now(UTC),
+)
+await self._handle.publish(envelope)
+```
+
+The Discord endpoint reads `envelope.metadata["discord"]["channel_id"]` to pick the target channel. The bus itself does not interpret metadata.
+
+---
+
+## Next steps
+
+- [Add an endpoint](add-an-endpoint.md) — implement deliver() and the ack contract end-to-end
+- [Write an extension](write-an-extension.md) — register new envelope kinds + renderers via a plugin
+- [Concepts — Envelopes](../concepts/index.md) — TTL sweeps, dead-letter, urgency levels

--- a/docs/guides/write-an-extension.md
+++ b/docs/guides/write-an-extension.md
@@ -1,0 +1,249 @@
+# Write an Extension
+
+agent-core uses [Pluggy](https://pluggy.readthedocs.io/) for runtime extension points. A plugin is a regular Python package that declares an `agent_core` entry point and implements one or more hook functions with `@hookimpl`. The daemon discovers all installed plugins at startup.
+
+This guide shows the full recipe: package layout, the entry-point declaration, a complete `register_endpoint_types()` implementation, and a summary of the other hooks you can implement.
+
+Sources verified: `packages/core/src/agent_core/plugins/specs.py`, `packages/core/docs/plugins.md`, `docs/extensions.md`.
+
+See also: [Concepts — Extensions](../concepts/extensions.md).
+
+---
+
+## When do you need a plugin?
+
+You need a plugin when you want the daemon to resolve a `type:` string in `agent_core.yaml` to your endpoint class. Without a plugin registration the daemon fails to start with an unknown type error.
+
+You also need a plugin to:
+
+- Register new envelope kinds and their inline-wake renderers (`register_envelope_renderers`).
+- Add CLI subcommands to the `agent-core` CLI (`register_cli_subapps`).
+- Validate operator-supplied config at startup (`validate_config`).
+- Do cross-endpoint wiring after all endpoints are constructed (`wire_endpoints_after_registration`).
+
+---
+
+## Package layout
+
+```
+my_plugin/
+├── pyproject.toml
+└── src/
+    └── my_plugin/
+        ├── __init__.py
+        ├── agent_core_plugin.py   # hookimpl module
+        └── endpoints/
+            └── greeter.py         # your endpoint class
+```
+
+The hookimpl module name is arbitrary — what matters is the entry-point target.
+
+---
+
+## Step 1 — Declare the entry point
+
+In `pyproject.toml`, add your module under the `agent_core` entry-point group:
+
+```toml
+[project]
+name = "my-plugin"
+# ... other metadata ...
+
+[project.entry-points."agent_core"]
+my_plugin = "my_plugin.agent_core_plugin"
+```
+
+The key (`my_plugin`) is an arbitrary label. The value is the dotted import path to the module that contains your `@hookimpl` functions.
+
+---
+
+## Step 2 — Implement the hookimpl module
+
+```python
+# src/my_plugin/agent_core_plugin.py
+import pluggy
+
+# The marker must use the "agent_core" project name — this is the
+# entry-point group name and the Pluggy project name.
+hookimpl = pluggy.HookimplMarker("agent_core")
+
+
+@hookimpl
+def register_endpoint_types() -> dict:
+    """Return {type_id: EndpointClass} registrations.
+
+    type_id is what operators write as `type:` in agent_core.yaml.
+    Import lazily so the plugin does not force the dependency on
+    packages that don't use this endpoint type.
+    """
+    from my_plugin.endpoints.greeter import GreeterEndpoint
+
+    return {
+        "my_plugin.greeter": GreeterEndpoint,
+    }
+```
+
+After `pip install -e .` (or a wheel install), `uv run agent-core daemon start` discovers this plugin via the `agent_core` entry-point group and registers `my_plugin.greeter` as a known type.
+
+!!! note "Duplicate type ids raise at startup"
+    If two installed plugins register the same `type_id`, the daemon raises `PluginRegistryError` immediately. Use a namespace prefix (e.g. `my_org.greeter`) to avoid collisions with built-in or third-party plugins.
+
+---
+
+## Step 3 — Wire it in config
+
+```yaml
+# agent_core.yaml
+endpoints:
+  - type: my_plugin.greeter
+    name: greeter
+    params:
+      prefix: "Hi"
+```
+
+The daemon calls `GreeterEndpoint(name="greeter", prefix="Hi")`. Any `params:` keys are passed as keyword arguments to `__init__` (after `name`).
+
+---
+
+## Other hooks you can implement
+
+All hook signatures live in `agent_core.plugins.specs.AgentCoreSpecs`. Implement only the ones you need — Pluggy ignores unimplemented hooks.
+
+### `register_envelope_renderers`
+
+Register new envelope kinds and their inline-wake renderer callables:
+
+```python
+@hookimpl
+def register_envelope_renderers() -> dict:
+    from my_plugin.rendering import render_desire
+
+    # The key becomes a first-class envelope kind.
+    # The callable receives the full envelope dict and returns
+    # the rendered body string inside the <inbox> tag.
+    return {"Desire": render_desire}
+
+
+def render_desire(envelope: dict) -> str:
+    text = envelope["payload"].get("text", "")
+    return f"<desire>{text}</desire>"
+```
+
+To publish envelopes of this kind, set `kind="Desire"` and carry a dict payload whose `"kind"` key matches:
+
+```python
+from agent_core.bus.envelope import Envelope
+
+env = Envelope(
+    id="...",
+    correlation_id="...",
+    to="target-agent",
+    kind="Desire",
+    payload={"kind": "Desire", "text": "I want to learn more about this."},
+    created_at=datetime.now(UTC),
+)
+await handle.publish(env)
+```
+
+### `register_cli_subapps`
+
+Mount a Typer subapp onto the top-level `agent-core` CLI:
+
+```python
+@hookimpl
+def register_cli_subapps(app) -> None:
+    from my_plugin.cli import my_subapp
+
+    app.add_typer(my_subapp, name="greeter")
+```
+
+After this, `uv run agent-core greeter --help` works.
+
+### `validate_config`
+
+Inspect the raw config dict at daemon startup and raise to block launch:
+
+```python
+@hookimpl
+def validate_config(raw_config: dict) -> None:
+    endpoints = raw_config.get("endpoints", [])
+    for ep in endpoints:
+        if ep.get("type") == "my_plugin.greeter":
+            params = ep.get("params", {})
+            if "prefix" not in params:
+                raise ValueError("my_plugin.greeter requires a 'prefix' param")
+```
+
+### `configure_endpoint_instance`
+
+Post-construction wiring for a specific endpoint instance — called after construction, before `bus.start()`:
+
+```python
+@hookimpl
+def configure_endpoint_instance(
+    self,
+    instance,
+    endpoint_name: str,
+    endpoint_config: dict,
+    services,
+) -> None:
+    from my_plugin.endpoints.greeter import GreeterEndpoint
+
+    if isinstance(instance, GreeterEndpoint):
+        instance.attach_notify_broker(services.notify_broker)
+```
+
+`services` is a `RunnerServices` instance with:
+- `notify_broker` — the shared notification broker for push fan-out.
+- `mcp_audit_writer` — the daemon-wide MCP audit writer (may be `None`).
+
+### `wire_endpoints_after_registration`
+
+Cross-endpoint wiring once all endpoints are constructed and registered on the bus, but before `bus.start()`:
+
+```python
+@hookimpl
+def wire_endpoints_after_registration(
+    self,
+    endpoints: dict,
+    raw_endpoint_configs: dict,
+    services,
+) -> None:
+    orchestrator = endpoints.get("my-orchestrator")
+    agent = endpoints.get("my-agent")
+    if orchestrator and agent:
+        agent.set_orchestrator(orchestrator)
+```
+
+### `reserved_endpoint_params`
+
+If your post-construction wiring hook reads `params:` keys that are not constructor kwargs, declare them here so the runner strips them before calling `cls(name=..., **params)`:
+
+```python
+@hookimpl
+def reserved_endpoint_params(self) -> list[str]:
+    return ["my_orchestrator_name"]
+```
+
+---
+
+## Built-in alias reference
+
+Core ships an entrypoint-loaded alias plugin that maps these built-in type ids:
+
+| type id | Class |
+|---|---|
+| `builtin.claude_code_mcp` | `agent_core.endpoints.claude_code_mcp.ClaudeCodeMCPEndpoint` |
+| `builtin.stub` | `agent_core.endpoints.stub.StubEndpoint` |
+| `builtin.scheduler` | `agent_core.endpoints.scheduler.SchedulerEndpoint` |
+| `builtin.handoff_jobs` | `agent_core.endpoints.handoff_jobs.HandoffJobsEndpoint` |
+
+Your plugin's hooks run alongside these defaults.
+
+---
+
+## Next steps
+
+- [Add an endpoint](add-an-endpoint.md) — implement the `Endpoint` protocol your plugin registers
+- [Send and consume envelopes](send-and-consume.md) — publish plugin-registered envelope kinds
+- [Concepts — Extensions](../concepts/extensions.md) — envelope extension design, renderer dispatch order, collision policy

--- a/docs/guides/write-an-extension.md
+++ b/docs/guides/write-an-extension.md
@@ -181,7 +181,6 @@ Post-construction wiring for a specific endpoint instance — called after const
 ```python
 @hookimpl
 def configure_endpoint_instance(
-    self,
     instance,
     endpoint_name: str,
     endpoint_config: dict,
@@ -204,7 +203,6 @@ Cross-endpoint wiring once all endpoints are constructed and registered on the b
 ```python
 @hookimpl
 def wire_endpoints_after_registration(
-    self,
     endpoints: dict,
     raw_endpoint_configs: dict,
     services,
@@ -221,7 +219,7 @@ If your post-construction wiring hook reads `params:` keys that are not construc
 
 ```python
 @hookimpl
-def reserved_endpoint_params(self) -> list[str]:
+def reserved_endpoint_params() -> list[str]:
     return ["my_orchestrator_name"]
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,56 @@
+# agent-core
+
+**Core infrastructure for AI agents.** A durable, in-process message bus with a
+typed envelope format, pluggable endpoints, and a plugin system — the substrate
+you build an agent on when it needs to talk to other agents, tools, and humans
+reliably.
+
+!!! note "Built and run by agent beings"
+    agent-core is developed and operated by AI agent beings (Wren, Pepper, and
+    others) alongside their human partner. The docs are written honestly with
+    that in mind: the "you" reading this might be a human developer *or* an
+    agent adopting the framework — both are first-class readers.
+
+## What it gives you
+
+- **A message bus** that routes typed [envelopes](concepts/envelopes.md) between
+  [endpoints](concepts/endpoints.md), with durable persistence, acknowledgements,
+  redelivery, TTL sweeps, and per-endpoint supervision.
+- **Endpoints** — the adapters that connect your agent to the outside world
+  (Discord, an MCP surface, an inbound webhook, or your own). You implement a
+  small `Endpoint` protocol; the bus handles delivery, retries, and identity.
+- **A plugin system** — register new endpoint types, envelope kinds, renderers,
+  and CLI subcommands from your own package without forking agent-core.
+- **A daemon** — a long-running host process that keeps your endpoints alive and
+  survives releases and restarts.
+
+## Who it's for
+
+- **Adopting a framework to build an agent on?** Start with
+  [Getting Started](getting-started/index.md).
+- **An AI agent pulling this in?** The whole documentation surface is available
+  as machine-readable [`llms.txt`](https://jeffrichley.github.io/agent_core/llms.txt)
+  and [`llms-full.txt`](https://jeffrichley.github.io/agent_core/llms-full.txt) for
+  single-fetch ingestion.
+- **Want the mental model first?** Read [Concepts](concepts/index.md).
+- **Need exact signatures?** See the [API Reference](reference/index.md).
+
+## The 60-second picture
+
+An agent-core system is a set of **endpoints** registered on one **bus**. Each
+endpoint is an adapter with a `name`, a `start()`, a `deliver()`, and a
+`stop()`. Work moves between them as **envelopes** — a universal wire format
+carrying a `kind`, a `from`/`to`, a `payload`, and metadata. You publish an
+envelope through a `BusHandle`; the bus persists it, delivers it to the target
+endpoint, waits for an ack, and retries or dead-letters on failure. A
+long-running **daemon** hosts the whole thing in production.
+
+```text
+   your code ──publish──▶  Bus  ──deliver──▶  Endpoint (Discord, MCP, inbound, …)
+                           │  ▲                   │
+                     persist  └──── ack/nack ─────┘
+                           ▼
+                     SQLite mailbox (durable, redelivered, TTL-swept)
+```
+
+Ready? [Get started →](getting-started/index.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,59 @@
+# API Reference
+
+Auto-generated from the source docstrings (Google style). This page covers the
+public `agent_core` surface an adopter builds against. Members prefixed with `_`
+are internal and omitted.
+
+!!! tip "Machine-readable"
+    An AI agent can ingest this whole site — including this reference — via
+    [`llms-full.txt`](https://jeffrichley.github.io/agent_core/llms-full.txt).
+
+## The bus
+
+::: agent_core.bus.core.Bus
+    options:
+      show_root_heading: true
+      heading_level: 3
+
+::: agent_core.bus.core.BusConfig
+    options:
+      heading_level: 3
+
+::: agent_core.bus.core.SupervisorConfig
+    options:
+      heading_level: 3
+
+::: agent_core.bus.handle.BusHandle
+    options:
+      heading_level: 3
+
+## Envelopes
+
+::: agent_core.bus.envelope.Envelope
+    options:
+      heading_level: 3
+
+## Endpoints
+
+::: agent_core.bus.protocol.Endpoint
+    options:
+      heading_level: 3
+
+::: agent_core.bus.core.EndpointSpec
+    options:
+      heading_level: 3
+
+## Persistence
+
+::: agent_core.bus.persistence.Persistence
+    options:
+      heading_level: 3
+
+## Extensions
+
+The extension system is built on [pluggy](https://pluggy.readthedocs.io/) hook
+specifications. The hookspecs live in `agent_core.plugins.specs.AgentCoreSpecs`;
+because that module is an implicit namespace package, its members are documented
+in prose rather than autodoc. See the [Extensions concept](../concepts/extensions.md)
+for the full hook catalogue and the [Write an extension](../guides/write-an-extension.md)
+guide for the plugin-author recipe.

--- a/docs/superpowers/specs/2026-07-13-docs-system-design.md
+++ b/docs/superpowers/specs/2026-07-13-docs-system-design.md
@@ -1,0 +1,109 @@
+# agent-core Documentation System — Design
+
+**Date:** 2026-07-13
+**Status:** Approved (Jeff, brainstorm) — build authorized
+**Epic:** world-class-eval #262 (Theme G — Documentation)
+**Author:** Wren 🪶
+
+## Goal
+
+Stand up a real, buildable, deployable documentation site for agent-core that
+other people — and their agents — can read to adopt the framework, and that we
+keep building on. This is the first published surface of agent-core as a
+product, not just a repo.
+
+## Audiences (priority order, from Jeff)
+
+1. **B — Human developers adopting agent-core** (primary). Someone who found
+   the repo and wants to build an agent on it. They need: what it is, why,
+   install, a first working agent, concept explanations, task-oriented guides,
+   and a complete API reference.
+2. **A — Adopter agents** (their AI coding agents pulling from the docs). Served
+   by machine-consumable `llms.txt` / `llms-full.txt` artifacts generated from
+   the same source, so an agent can ingest the whole surface in one fetch.
+3. **C — agent-core beings** (Wren, Pepper, future hatchlings). Served by the
+   same content written honestly — the docs name that agent beings build and
+   run on this, rather than pretending a purely-human authorship.
+
+One source of truth serves all three: prose + API reference for B, the llms.txt
+export for A, honest framing for C. We do **not** fork content per audience.
+
+## Tech stack
+
+- **MkDocs** + **Material for MkDocs** theme — the site.
+- **mkdocstrings[python]** — API reference autodoc from docstrings (Google
+  style; the repo already enforces Google docstrings via ruff `D`).
+- **mkdocs-llmstxt** (pawamoy) — generates `llms.txt` (index) and
+  `llms-full.txt` (concatenated body) at build time for audience A.
+- **GitHub Pages** deploy via a CI workflow (`mkdocs gh-deploy` on push to
+  `main`).
+- Tooling installed via a new `docs` **dependency-group** in the root
+  `pyproject.toml` (kept out of the `dev` group so CI test jobs stay lean).
+
+Rationale: all three plugins are the same pawamoy/Material ecosystem, so config
+and versioning stay coherent. Material is the de-facto standard for Python
+project docs and gives search, nav, and responsive layout for free.
+
+## Repository & layout
+
+**Single repo** (Jeff chose "Single"): the docs live inside `jeffrichley/agent_core`,
+not a separate docs repo. Docs version with the code and adopters get them in
+the same clone.
+
+`docs_dir: docs/` (MkDocs convention). The existing `docs/` tree already holds
+**internal** engineering artifacts (superpowers specs/plans/tickets, cutover,
+migrations, requirements, hatchery, ROADMAP/BACKLOG). To keep the published
+site clean without moving that history:
+
+- Author public pages under curated subdirs: `docs/index.md`,
+  `docs/getting-started/`, `docs/concepts/`, `docs/guides/`, `docs/reference/`.
+- Use MkDocs `exclude_docs` (gitignore-style) to drop the internal subtrees from
+  the build, and `validation.nav.not_in_nav: info` so stray internal `.md` files
+  never fail a strict build.
+- `strict: true` stays on for real problems (broken internal links, bad
+  references) — that is the gate that keeps the docs honest.
+
+## Information architecture (nav)
+
+- **Home** (`index.md`) — what agent-core is, who it's for (incl. the honest
+  "built and run by agent beings" framing), the badges, a 60-second orientation.
+- **Getting Started** — install (`uv`), your first agent/endpoint, running the
+  bus daemon (link/adapt existing `docs/setup/daemon.md`).
+- **Concepts** — the mental model: the bus, envelopes & kinds, endpoints,
+  extensions/hookspecs, persistence, the daemon. Explanations, not API dumps.
+- **Guides** — task-oriented: add an endpoint, send/consume envelopes, write an
+  extension, wire an inbound connector, deploy the daemon.
+- **API Reference** — mkdocstrings-generated per public package (`agent_core`
+  first; the other `agent-core-*` packages as they stabilize).
+- **About** — project status, links, license, contribution pointer.
+
+## Acceptance criteria
+
+1. `uv run --group docs mkdocs build --strict` succeeds with **zero** warnings.
+2. The API reference renders real symbols from `agent_core` (bus, envelope,
+   persistence) via mkdocstrings — not stubs.
+3. `llms.txt` and `llms-full.txt` are produced in the built `site/` and contain
+   the concept + guide content.
+4. A CI workflow deploys the site to GitHub Pages on push to `main`, and does
+   **not** run on PRs from forks (no secret exposure).
+5. The `docs` dependency-group installs cleanly and is **not** pulled into the
+   default test job (CI `check` stays as-is).
+6. Home + Getting Started + at least the core Concepts pages are real content a
+   new adopter could follow — no "TODO" placeholders on published pages.
+7. Nothing in the internal `docs/` planning tree leaks into the published nav.
+
+## Non-goals (YAGNI)
+
+- Versioned docs (mike) — single "latest" site for now.
+- Per-package API sites — one unified reference, `agent_core` first.
+- Custom theme/branding beyond Material defaults + the agent-beings note.
+- Auto-generated changelog pages — link the existing `CHANGELOG.md`.
+
+## Build path (Wren's call, per Jeff's delegation)
+
+Built **directly in-session** on branch `docs/mkdocs-site`, with content
+authoring fanned out to parallel subagents where it helps, and a final
+whole-diff review subagent before merge. Not routed through foreman: with
+`max_in_flight = 1`, foreman is busy draining Theme A supervision, and a
+greenfield docs site is a poor fit for the spec→review→impl loop and would miss
+the morning deadline serialized behind Theme A.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,135 @@
+site_name: agent-core
+site_description: >-
+  Core infrastructure for AI agents — a durable message bus, envelopes,
+  endpoints, and a plugin system for building agents that talk to each other.
+site_author: agent beings 🪶
+site_url: https://jeffrichley.github.io/agent_core/
+repo_url: https://github.com/jeffrichley/agent_core
+repo_name: jeffrichley/agent_core
+copyright: Built and run by agent beings.
+
+# Warnings-as-errors: a broken internal link or bad reference fails the build.
+strict: true
+
+theme:
+  name: material
+  icon:
+    logo: material/feather
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: deep purple
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: deep purple
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - navigation.footer
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - getting-started/index.md
+      - First agent: getting-started/first-agent.md
+      - Running the daemon: getting-started/daemon.md
+  - Concepts:
+      - concepts/index.md
+      - The bus: concepts/bus.md
+      - Envelopes: concepts/envelopes.md
+      - Endpoints: concepts/endpoints.md
+      - Extensions: concepts/extensions.md
+  - Guides:
+      - guides/index.md
+      - Add an endpoint: guides/add-an-endpoint.md
+      - Send & consume envelopes: guides/send-and-consume.md
+      - Write an extension: guides/write-an-extension.md
+  - API Reference: reference/index.md
+  - About: about.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          # Static analysis via griffe — the packages need NOT be installed,
+          # only their source visible. Lets the docs build run under
+          # `uv sync --only-group docs` without pulling torch or the workspace.
+          paths:
+            - packages/core/src
+            - packages/notify/src
+            - packages/credentials/src
+            - packages/agent-core-channel/src
+            - packages/agent-core-inbound/src
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            signature_crossrefs: true
+            filters:
+              - "!^_"
+  - llmstxt:
+      full_output: llms-full.txt
+      sections:
+        Getting started:
+          - index.md
+          - getting-started/*.md
+        Concepts:
+          - concepts/*.md
+        Guides:
+          - guides/*.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+
+# Keep the internal engineering trees out of the published site. New public
+# pages live in the curated subdirs above; everything else in docs/ is
+# internal planning history.
+exclude_docs: |
+  /superpowers/
+  /cutover/
+  /migrations/
+  /requirements/
+  /hatchery/
+  /skills/
+  /setup/
+  /examples/
+  /BACKLOG.md
+  /ROADMAP.md
+  /HANDOFF-*.md
+  /responsive-inbox-*.md
+  /world-class-eval-*.md
+  /extensions.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,13 @@ dev = [
     "types-psutil>=7.0.0.20251001",
     "import-linter>=2.0",
 ]
+# Documentation site toolchain. Kept out of `dev` so CI test jobs stay lean;
+# install in isolation with `uv sync --only-group docs` (no torch/workspace).
+docs = [
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.26",
+    "mkdocs-llmstxt>=0.1",
+]
 
 [tool.ruff]
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -84,6 +84,11 @@ dev = [
     { name = "types-psutil", specifier = ">=7.0.0.20251001" },
     { name = "types-pyyaml", specifier = ">=6.0" },
 ]
+docs = [
+    { name = "mkdocs-llmstxt", specifier = ">=0.1" },
+    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26" },
+]
 
 [[package]]
 name = "accelerate"
@@ -818,12 +823,47 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
+]
+
+[[package]]
 name = "beartype"
 version = "0.22.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
 ]
 
 [[package]]
@@ -1725,6 +1765,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
 name = "gradio"
 version = "6.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2447,15 +2499,37 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/ab/d1297139c0e2ceb151ae564c8c4f57ac0155d8f1f8b4cbd5d6523c82ea36/markdownify-1.2.3.tar.gz", hash = "sha256:1a176f05522c8a2cb1dd3ab9d307dcdadbed5c26ae717855bfc42b3b6d38d937", size = 18852, upload-time = "2026-06-30T20:27:39.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/10/fa543d484e8b1199243fe20eedd02cc5af050edebce98a7293a5773df592/markdownify-1.2.3-py3-none-any.whl", hash = "sha256:a189a0bedfd14009030fde5f85bb6f77c56897cb839b5c25315dd7d4e3e290ba", size = 15732, upload-time = "2026-06-30T20:27:38.094Z" },
 ]
 
 [[package]]
@@ -2547,12 +2621,180 @@ wheels = [
 ]
 
 [[package]]
+name = "mdformat"
+version = "0.7.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/eb/b5cbf2484411af039a3d4aeb53a5160fae25dd8c84af6a4243bc2f3fedb3/mdformat-0.7.22.tar.gz", hash = "sha256:eef84fa8f233d3162734683c2a8a6222227a229b9206872e6139658d99acb1ea", size = 34610, upload-time = "2025-01-30T18:00:51.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/6f/94a7344f6d634fe3563bea8b33bccedee37f2726f7807e9a58440dc91627/mdformat-0.7.22-py3-none-any.whl", hash = "sha256:61122637c9e1d9be1329054f3fa216559f0d1f722b7919b060a8c2a4ae1850e5", size = 34447, upload-time = "2025-01-30T18:00:48.708Z" },
+]
+
+[[package]]
+name = "mdformat-tables"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/fc/995ba209096bdebdeb8893d507c7b32b7e07d9a9f2cdc2ec07529947794b/mdformat_tables-1.0.0.tar.gz", hash = "sha256:a57db1ac17c4a125da794ef45539904bb8a9592e80557d525e1f169c96daa2c8", size = 6106, upload-time = "2024-08-23T23:41:33.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/37/d78e37d14323da3f607cd1af7daf262cb87fe614a245c15ad03bb03a2706/mdformat_tables-1.0.0-py3-none-any.whl", hash = "sha256:94cd86126141b2adc3b04c08d1441eb1272b36c39146bab078249a41c7240a9a", size = 5104, upload-time = "2024-08-23T23:41:31.863Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-llmstxt"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "markdownify" },
+    { name = "mdformat" },
+    { name = "mdformat-tables" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f5/4c31cdffa7c09bf48d8c7a50d8342dc100abac98ac4150826bc11afc0c9f/mkdocs_llmstxt-0.5.0.tar.gz", hash = "sha256:b2fa9e6d68df41d7467e948a4745725b6c99434a36b36204857dbd7bb3dfe041", size = 33909, upload-time = "2025-11-20T14:02:24.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/2b/82928cc9e8d9269cd79e7ebf015efdc4945e6c646e86ec1d4dba1707f215/mkdocs_llmstxt-0.5.0-py3-none-any.whl", hash = "sha256:753c699913d2d619a9072604b26b6dc9f5fb6d257d9b107857f80c8a0b787533", size = 12040, upload-time = "2025-11-20T14:02:23.483Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/71/f85bdf13355073ae15a7375f09879375a830553552e58c1c4b7e0bbc5c8b/mkdocstrings-1.0.6.tar.gz", hash = "sha256:a0b8c2bdd29a6416c80d717aa369bbf7831946bd9f23c2a66db1b1dbe7693dbd", size = 100649, upload-time = "2026-07-11T19:38:05.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5b/4c1902e8bdd5c4db63284e9d101dece4038d4025d6d88850ffe0a1578980/mkdocstrings-1.0.6-py3-none-any.whl", hash = "sha256:2703708697487d1b6d6d7b412e176fa436edf120c1bf81dc9e126b12d00893c7", size = 35787, upload-time = "2026-07-11T19:38:04.417Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/b6/e858701499d57eee8b3fd8e78168083956c6683ddbe727b46758b19e1119/mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594", size = 199578, upload-time = "2026-06-19T10:41:08.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/fc/10ab7e80650a9c9e8f4f1105f8c8e73567f88ed0c06ada589ab81d38687c/mkdocstrings_python-2.0.5-py3-none-any.whl", hash = "sha256:30c837bbff016549f659fcba6539ac351303f0fd7e713c89a040611072236e9d", size = 104951, upload-time = "2026-06-19T10:41:07.378Z" },
 ]
 
 [[package]]
@@ -3178,6 +3420,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3718,6 +3969,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
 name = "pyotp"
 version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3934,6 +4198,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -4470,6 +4746,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/5e/70bdd9579b35003a489fc850b5047beeda26328053ebadc1fb60f320f7db/soundfile-0.13.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:03267c4e493315294834a0870f31dbb3b28a95561b80b134f0bd3cf2d5f0e618", size = 1313646, upload-time = "2025-01-25T09:16:54.872Z" },
     { url = "https://files.pythonhosted.org/packages/fe/df/8c11dc4dfceda14e3003bb81a0d0edcaaf0796dd7b4f826ea3e532146bba/soundfile-0.13.1-py2.py3-none-win32.whl", hash = "sha256:c734564fab7c5ddf8e9be5bf70bab68042cd17e9c214c06e365e20d64f9a69d5", size = 899881, upload-time = "2025-01-25T09:16:56.663Z" },
     { url = "https://files.pythonhosted.org/packages/14/e9/6b761de83277f2f02ded7e7ea6f07828ec78e4b229b80e4ca55dd205b9dc/soundfile-0.13.1-py2.py3-none-win_amd64.whl", hash = "sha256:1e70a05a0626524a69e9f0f4dd2ec174b4e9567f4d8b6c11d38b5c289be36ee9", size = 1019162, upload-time = "2025-01-25T09:16:59.573Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Documentation system for agent-core

Stands up a real, buildable, deployable **MkDocs** documentation site — the first published surface of agent-core as a framework others (and their agents) can adopt.

Design spec: `docs/superpowers/specs/2026-07-13-docs-system-design.md`.

### What's here
- **MkDocs Material** site with search, dark/light, responsive nav.
- **mkdocstrings** API reference — autodoc from the real `agent_core` docstrings (griffe static analysis; no torch/workspace install needed to build).
- **mkdocs-llmstxt** — generates `llms.txt` + `llms-full.txt` so an adopter *agent* can ingest the whole surface in one fetch.
- **CI deploy** (`.github/workflows/docs.yml`) — `mkdocs gh-deploy` to GitHub Pages on push to `main` only (never on fork PRs; minimal `contents: write`).
- Content: Home, Getting Started (install / first agent / daemon), Concepts (bus / envelopes / endpoints / extensions), Guides (add an endpoint / send & consume / write an extension), API Reference, About.

### Audiences (priority order)
1. Human developers adopting agent-core (primary).
2. Adopter agents — served by `llms.txt` / `llms-full.txt`.
3. agent-core beings — same content, honest framing.

The existing internal `docs/` engineering trees (superpowers, cutover, migrations, etc.) are excluded from the published site via `exclude_docs`; new public pages live in curated subdirs.

### Validation
- `mkdocs build --strict` passes clean — **zero warnings**.
- API reference renders real symbols (Bus, Envelope, BusHandle, Persistence, ...).
- `llms.txt` + `llms-full.txt` produced.
- Adversarially reviewed: every load-bearing API claim spot-checked against source; CI safety, links, config, and quality all clean.

### After merge
Enable GitHub Pages to serve from the `gh-pages` branch (the workflow will create it on first run).

🪶 Built by Wren.
