### PR TITLE
test(bus): guarantee bus teardown via build_bus fixture (fix #287)

### DIFF
--- a/packages/core/tests/bus/test_integration.py
+++ b/packages/core/tests/bus/test_integration.py
@@ -7,7 +7,6 @@ import pytest
 import yaml
 
 from agent_core.bus.envelope import TextMessagePayload
-from agent_core.bus.runner import build_bus_from_config
 
 
 @pytest.fixture
@@ -42,8 +41,8 @@ def cfg_path(tmp_path: Path) -> Path:
 
 
 class TestE2E:
-    async def test_alice_sends_to_bob(self, cfg_path: Path):
-        bus, _ = await build_bus_from_config(cfg_path)
+    async def test_alice_sends_to_bob(self, cfg_path: Path, build_bus):
+        bus, _ = await build_bus(cfg_path)
         await bus.start()
         try:
             alice = bus._endpoints_by_name["alice"].endpoint
@@ -60,9 +59,9 @@ class TestE2E:
         finally:
             await bus.stop()
 
-    async def test_delivered_envelope_persists_to_disk(self, cfg_path: Path):
+    async def test_delivered_envelope_persists_to_disk(self, cfg_path: Path, build_bus):
         # First run: queue an envelope to a (deliberately not-running) recipient.
-        bus1, _ = await build_bus_from_config(cfg_path)
+        bus1, _ = await build_bus(cfg_path)
         await bus1.start()
         try:
             alice = bus1._endpoints_by_name["alice"].endpoint
@@ -91,8 +90,8 @@ class TestE2E:
         finally:
             await store.close()
 
-    async def test_ttl_expires_unrouted_message(self, cfg_path: Path):
-        bus, _ = await build_bus_from_config(cfg_path)
+    async def test_ttl_expires_unrouted_message(self, cfg_path: Path, build_bus):
+        bus, _ = await build_bus(cfg_path)
         await bus.start()
         try:
             import uuid
@@ -116,7 +115,7 @@ class TestE2E:
         finally:
             await bus.stop()
 
-    async def test_pending_envelope_drains_on_restart(self, cfg_path: Path):
+    async def test_pending_envelope_drains_on_restart(self, cfg_path: Path, build_bus):
         """Durable mailbox survives restart: pending envelope is delivered on second boot."""
         import uuid
 
@@ -124,7 +123,7 @@ class TestE2E:
 
         # First boot: seed a pending envelope addressed to bob directly into the
         # store, simulating "bob was unavailable so delivery was queued."
-        bus1, _ = await build_bus_from_config(cfg_path)
+        bus1, _ = await build_bus(cfg_path)
         await bus1.start()
         try:
             env = Envelope(
@@ -145,7 +144,7 @@ class TestE2E:
         # Second boot: a fresh bus from the same config. Bus.start calls
         # drain_for for each registered endpoint, which should pick up the
         # pending envelope and deliver it to bob's fresh inbox.
-        bus2, _ = await build_bus_from_config(cfg_path)
+        bus2, _ = await build_bus(cfg_path)
         await bus2.start()
         try:
             bob = bus2._endpoints_by_name["bob"].endpoint

--- a/packages/core/tests/bus/test_runner.py
+++ b/packages/core/tests/bus/test_runner.py
@@ -41,8 +41,8 @@ def cfg_path(tmp_path: Path) -> Path:
 
 
 class TestRunner:
-    async def test_loads_endpoints(self, cfg_path: Path):
-        bus, _ = await build_bus_from_config(cfg_path)
+    async def test_loads_endpoints(self, cfg_path: Path, build_bus):
+        bus, _ = await build_bus(cfg_path)
         try:
             await bus.start()
             names = {info.name for info in bus._endpoints()}
@@ -100,7 +100,7 @@ class TestRunner:
             await build_bus_from_config(p)
 
     async def test_plugin_can_resolve_endpoint_class(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, build_bus
     ):
         class _PluginEndpoint:
             def __init__(self, *, name: str, **_: Any):
@@ -151,5 +151,5 @@ class TestRunner:
         config = {"endpoints": [{"type": "plugin.stub.Endpoint", "name": "plug", "params": {}}]}
         p = tmp_path / "plugin.yaml"
         p.write_text(yaml.dump(config))
-        bus, _ = await build_bus_from_config(p)
+        bus, _ = await build_bus(p)
         assert "plug" in bus._endpoints_by_name

--- a/packages/core/tests/bus/test_runner_endpoints_d.py
+++ b/packages/core/tests/bus/test_runner_endpoints_d.py
@@ -10,14 +10,14 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 
 @pytest.mark.asyncio
-async def test_endpoints_d_happy_path_merges_alphabetically():
+async def test_endpoints_d_happy_path_merges_alphabetically(build_bus):
     """All endpoints from main + endpoints.d/*.yaml are present in the built bus.
 
     Fragments load in sorted-glob order (a.yaml before b.yaml), main first.
     """
     config_path = FIXTURES / "endpoints_d" / "main.yaml"
 
-    bus, _http = await build_bus_from_config(config_path)
+    bus, _http = await build_bus(config_path)
     try:
         endpoint_names = {ep.name for ep in bus._endpoints()}
         assert endpoint_names == {"main-stub", "fragment-a-stub", "fragment-b-stub"}
@@ -44,7 +44,7 @@ async def test_endpoints_d_malformed_fragment_raises_with_filename():
 
 
 @pytest.mark.asyncio
-async def test_no_endpoints_d_dir_is_silent_noop(tmp_path):
+async def test_no_endpoints_d_dir_is_silent_noop(tmp_path, build_bus):
     """If no endpoints.d/ subdir exists alongside the main yaml, no error, no fragments loaded."""
     main_yaml = tmp_path / "agent_core.yaml"
     main_yaml.write_text(
@@ -56,7 +56,7 @@ async def test_no_endpoints_d_dir_is_silent_noop(tmp_path):
         '    description: "Solo"\n'
     )
 
-    bus, _http = await build_bus_from_config(main_yaml)
+    bus, _http = await build_bus(main_yaml)
     try:
         assert {ep.name for ep in bus._endpoints()} == {"only-stub"}
     finally:

--- a/packages/core/tests/conftest.py
+++ b/packages/core/tests/conftest.py
@@ -1,0 +1,55 @@
+"""Shared fixtures for core bus tests.
+
+The ``build_bus`` fixture exists to close a whole class of test-teardown
+flakiness. ``build_bus_from_config`` opens an aiosqlite persistence connection
+(a background thread). If a test builds a bus and never calls ``bus.stop()``,
+that connection is finalized only when the object is garbage-collected — which
+happens *after* the test's event loop has closed, raising
+``RuntimeError: Event loop is closed`` during teardown. Individually these are
+warnings, but under ``pytest-xdist --dist=loadscope`` a stray finalizer can
+land on an unrelated test's teardown and escalate to a collected ERROR,
+failing the whole run non-deterministically (agent_core#287). Building buses
+through this factory guarantees every one is stopped — and its connection
+closed — inside the test's own event loop.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from pathlib import Path
+
+import pytest_asyncio
+
+from agent_core.bus.core import Bus
+from agent_core.bus.http_host import HTTPHost
+from agent_core.bus.runner import build_bus_from_config
+
+BusFactory = Callable[[Path], Awaitable[tuple[Bus, HTTPHost | None]]]
+
+
+@pytest_asyncio.fixture
+async def build_bus() -> AsyncIterator[BusFactory]:
+    """Return a ``build_bus_from_config`` wrapper that tears down every bus.
+
+    Use exactly like ``build_bus_from_config``::
+
+        bus, http = await build_bus(config_path)
+
+    Every bus (and its HTTP host, if any) produced by the returned factory is
+    stopped on fixture teardown. ``Bus.stop`` / ``HTTPHost.stop`` are safe to
+    call when never started, and ``Persistence.close`` is idempotent, so this
+    coexists with tests that also stop their bus explicitly.
+    """
+    created: list[tuple[Bus, HTTPHost | None]] = []
+
+    async def _factory(path: Path) -> tuple[Bus, HTTPHost | None]:
+        bus, http = await build_bus_from_config(path)
+        created.append((bus, http))
+        return bus, http
+
+    yield _factory
+
+    for bus, http in created:
+        if http is not None:
+            await http.stop()
+        await bus.stop()

--- a/packages/core/tests/test_bus_daemon_integration.py
+++ b/packages/core/tests/test_bus_daemon_integration.py
@@ -18,11 +18,10 @@ import pytest
 from fastmcp import Client
 
 from agent_core.bus.envelope import TextMessagePayload
-from agent_core.bus.runner import build_bus_from_config
 
 
 @pytest.mark.asyncio
-async def test_round_trip_via_real_http(tmp_path):
+async def test_round_trip_via_real_http(tmp_path, build_bus):
     cfg = tmp_path / "agent_core.yaml"
     cfg.write_text(
         f"""
@@ -44,7 +43,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:

--- a/packages/core/tests/test_bus_daemon_push_integration.py
+++ b/packages/core/tests/test_bus_daemon_push_integration.py
@@ -25,7 +25,7 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_push_notification_arrives_on_real_mcp_session(tmp_path):
+async def test_push_notification_arrives_on_real_mcp_session(tmp_path, build_bus):
     """Realistic flow: real bus, real FastMCP HTTP host, real mcp.client connection."""
 
     pytest.importorskip("uvicorn")
@@ -36,7 +36,6 @@ async def test_push_notification_arrives_on_real_mcp_session(tmp_path):
     from pydantic import BaseModel
 
     from agent_core.bus.envelope import TextMessagePayload
-    from agent_core.bus.runner import build_bus_from_config
 
     cfg = tmp_path / "agent_core.yaml"
     cfg.write_text(
@@ -59,7 +58,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
 
     # Permissive notification model so the client doesn't drop the

--- a/packages/core/tests/test_bus_tail_runner.py
+++ b/packages/core/tests/test_bus_tail_runner.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-from agent_core.bus.runner import build_bus_from_config
 from agent_core.bus_tail.endpoint import BusTailMCPEndpoint
 
 
@@ -17,7 +16,7 @@ def _write_yaml(tmp_path: Path, contents: str) -> Path:
 
 
 @pytest.mark.asyncio
-async def test_runner_registers_bus_tail_mcp_from_yaml(tmp_path: Path):
+async def test_runner_registers_bus_tail_mcp_from_yaml(tmp_path: Path, build_bus):
     storage = (tmp_path / "bus.sqlite").as_posix()
     cfg = _write_yaml(
         tmp_path,
@@ -31,7 +30,7 @@ endpoints:
       mount: /mcp/bus-tail
 """,
     )
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     try:
         ep = bus._endpoints_by_name["bus-tail"].endpoint
         assert isinstance(ep, BusTailMCPEndpoint)
@@ -41,7 +40,7 @@ endpoints:
 
 
 @pytest.mark.asyncio
-async def test_runner_mounts_bus_tail_on_http_host(tmp_path: Path):
+async def test_runner_mounts_bus_tail_on_http_host(tmp_path: Path, build_bus):
     storage = (tmp_path / "bus.sqlite").as_posix()
     cfg = _write_yaml(
         tmp_path,
@@ -53,7 +52,7 @@ endpoints:
     type: builtin.bus_tail_mcp
 """,
     )
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     try:
         assert http_host is not None
         mount_paths = {m.mount for m in http_host._mounts}
@@ -63,7 +62,7 @@ endpoints:
 
 
 @pytest.mark.asyncio
-async def test_runner_default_yaml_omits_bus_tail(tmp_path: Path):
+async def test_runner_default_yaml_omits_bus_tail(tmp_path: Path, build_bus):
     storage = (tmp_path / "bus.sqlite").as_posix()
     cfg = _write_yaml(
         tmp_path,
@@ -73,7 +72,7 @@ bus:
 endpoints: []
 """,
     )
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     try:
         names = list(bus._endpoints_by_name.keys())
         assert "bus-tail" not in names
@@ -82,7 +81,7 @@ endpoints: []
 
 
 @pytest.mark.asyncio
-async def test_runner_uses_default_mount_when_omitted(tmp_path: Path):
+async def test_runner_uses_default_mount_when_omitted(tmp_path: Path, build_bus):
     storage = (tmp_path / "bus.sqlite").as_posix()
     cfg = _write_yaml(
         tmp_path,
@@ -94,7 +93,7 @@ endpoints:
     type: builtin.bus_tail_mcp
 """,
     )
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     try:
         ep = bus._endpoints_by_name["bus-tail"].endpoint
         assert ep.mount == "/mcp/bus-tail"

--- a/packages/core/tests/test_handoff_enqueue_integration.py
+++ b/packages/core/tests/test_handoff_enqueue_integration.py
@@ -6,12 +6,11 @@ import json
 import pytest
 
 from agent_core.bus.envelope import EventPayload
-from agent_core.bus.runner import build_bus_from_config
 from agent_core.hooks.tools.handoff_writer import HandoffWriter
 
 
 @pytest.mark.asyncio
-async def test_enqueue_hook_to_daemon_end_to_end(tmp_path, monkeypatch):
+async def test_enqueue_hook_to_daemon_end_to_end(tmp_path, monkeypatch, build_bus):
     # Real Claude Code stores transcripts under ``~/.claude/projects/<...>/`` —
     # NOT under any agent vault. Mirror that topology here so the test catches
     # the case where the daemon rejects transcript_path simply for not being
@@ -45,7 +44,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:

--- a/packages/core/tests/test_handoff_jobs_endpoint.py
+++ b/packages/core/tests/test_handoff_jobs_endpoint.py
@@ -8,7 +8,6 @@ import httpx
 import pytest
 
 from agent_core.bus.envelope import EventPayload
-from agent_core.bus.runner import build_bus_from_config
 from agent_core.endpoints.handoff_jobs import (
     HandoffJobRequest,
     HandoffJobsEndpoint,
@@ -17,7 +16,7 @@ from agent_core.endpoints.handoff_jobs import (
 
 
 @pytest.mark.asyncio
-async def test_handoff_jobs_endpoint_writes_status_and_publishes_ready(tmp_path, monkeypatch):
+async def test_handoff_jobs_endpoint_writes_status_and_publishes_ready(tmp_path, monkeypatch, build_bus):
     # Real Claude Code transcripts live under ~/.claude/projects, NOT inside
     # any agent vault — mirror that here so tests don't paper over the
     # cross-root validation.
@@ -49,7 +48,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:
@@ -122,7 +121,7 @@ endpoints:
 
 
 @pytest.mark.asyncio
-async def test_handoff_jobs_endpoint_writes_extractor_output(tmp_path, monkeypatch):
+async def test_handoff_jobs_endpoint_writes_extractor_output(tmp_path, monkeypatch, build_bus):
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
     transcript_root = tmp_path / "claude_projects"
@@ -152,7 +151,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:
@@ -196,7 +195,7 @@ endpoints:
 
 
 @pytest.mark.asyncio
-async def test_handoff_jobs_endpoint_rejects_path_outside_vault_root(tmp_path):
+async def test_handoff_jobs_endpoint_rejects_path_outside_vault_root(tmp_path, build_bus):
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
     transcript_path = vault_root / "transcript.jsonl"
@@ -221,7 +220,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:
@@ -250,7 +249,7 @@ endpoints:
 
 @pytest.mark.asyncio
 async def test_handoff_publishes_to_mailbox_when_distinct_from_agent_name(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, build_bus
 ):
     # Real configs split agent identity (display name like "Pepper" or
     # "testbot") from bus routing (endpoint name like "pepper" or
@@ -287,7 +286,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:
@@ -356,7 +355,7 @@ endpoints:
 
 @pytest.mark.asyncio
 async def test_handoff_pepper_capital_p_identity_routes_to_lowercase_mailbox(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, build_bus
 ):
     # Pepper-shaped regression: real Pepper config has agent_name="Pepper"
     # (capitalized — her display identity, what she calls herself in SOUL.md
@@ -396,7 +395,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:
@@ -467,7 +466,7 @@ endpoints:
 
 
 @pytest.mark.asyncio
-async def test_handoff_jobs_endpoint_rejects_transcript_outside_transcript_root(tmp_path):
+async def test_handoff_jobs_endpoint_rejects_transcript_outside_transcript_root(tmp_path, build_bus):
     # transcript_path must live under transcript_root (default: ~/.claude/projects/),
     # not vault_root. Caller can override transcript_root explicitly. This test
     # locks in that an explicit transcript_root rejects a transcript that
@@ -499,7 +498,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:
@@ -575,7 +574,7 @@ async def test_extract_handoff_propagates_exception_on_sdk_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_worker_retries_then_marks_failed(tmp_path, monkeypatch):
+async def test_worker_retries_then_marks_failed(tmp_path, monkeypatch, build_bus):
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
     transcript_root = tmp_path / "claude_projects"
@@ -612,7 +611,7 @@ endpoints:
         attempts["count"] += 1
         raise RuntimeError("forced extract failure")
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:
@@ -818,7 +817,7 @@ def test_read_transcript_tail_handles_file_with_no_trailing_newline(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_handoff_worker_uses_tail_for_oversized_transcripts(tmp_path, monkeypatch):
+async def test_handoff_worker_uses_tail_for_oversized_transcripts(tmp_path, monkeypatch, build_bus):
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
     transcript_root = tmp_path / "claude_projects"
@@ -853,7 +852,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     received_lengths: list[int] = []
@@ -944,7 +943,7 @@ def test_capture_subprocess_stderr_falls_back_to_repr_when_no_chain():
 
 
 @pytest.mark.asyncio
-async def test_handoff_worker_marks_failed_when_sdk_raises(tmp_path, monkeypatch):
+async def test_handoff_worker_marks_failed_when_sdk_raises(tmp_path, monkeypatch, build_bus):
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
     transcript_root = tmp_path / "claude_projects"
@@ -975,7 +974,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:
@@ -1023,7 +1022,7 @@ endpoints:
 
 
 @pytest.mark.asyncio
-async def test_handoff_worker_does_not_overwrite_handoff_md_when_failed(tmp_path, monkeypatch):
+async def test_handoff_worker_does_not_overwrite_handoff_md_when_failed(tmp_path, monkeypatch, build_bus):
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
     transcript_root = tmp_path / "claude_projects"
@@ -1057,7 +1056,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:
@@ -1102,7 +1101,7 @@ endpoints:
 
 
 @pytest.mark.asyncio
-async def test_handoff_worker_truncates_stderr_in_status_error_field(tmp_path, monkeypatch):
+async def test_handoff_worker_truncates_stderr_in_status_error_field(tmp_path, monkeypatch, build_bus):
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
     transcript_root = tmp_path / "claude_projects"
@@ -1133,7 +1132,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:
@@ -1184,7 +1183,7 @@ endpoints:
 
 
 @pytest.mark.asyncio
-async def test_handoff_worker_writes_per_job_log_on_sdk_failure(tmp_path, monkeypatch):
+async def test_handoff_worker_writes_per_job_log_on_sdk_failure(tmp_path, monkeypatch, build_bus):
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
     transcript_root = tmp_path / "claude_projects"
@@ -1216,7 +1215,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     try:
@@ -1268,7 +1267,7 @@ endpoints:
 
 
 @pytest.mark.asyncio
-async def test_post_job_dedupes_when_transcript_unchanged(tmp_path, monkeypatch):
+async def test_post_job_dedupes_when_transcript_unchanged(tmp_path, monkeypatch, build_bus):
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
     transcript_root = tmp_path / "claude_projects"
@@ -1299,7 +1298,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     extract_calls = 0
@@ -1356,7 +1355,7 @@ endpoints:
 
 
 @pytest.mark.asyncio
-async def test_post_job_creates_new_job_when_transcript_grows(tmp_path, monkeypatch):
+async def test_post_job_creates_new_job_when_transcript_grows(tmp_path, monkeypatch, build_bus):
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
     transcript_root = tmp_path / "claude_projects"
@@ -1387,7 +1386,7 @@ endpoints:
         encoding="utf-8",
     )
 
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     await http_host.start()
     extract_calls = 0

--- a/packages/core/tests/test_mcp_audit_integration.py
+++ b/packages/core/tests/test_mcp_audit_integration.py
@@ -8,8 +8,6 @@ from pathlib import Path
 import pytest
 from fastmcp import Client
 
-from agent_core.bus.runner import build_bus_from_config
-
 _TWO_ENDPOINT_YAML = """\
 bus:
   storage_path: "{storage}"
@@ -50,14 +48,14 @@ def _write(path: Path, body: str) -> Path:
 
 
 @pytest.mark.asyncio
-async def test_audit_writer_is_singleton_across_endpoints(tmp_path: Path):
+async def test_audit_writer_is_singleton_across_endpoints(tmp_path: Path, build_bus):
     storage = tmp_path / "bus.sqlite"
     audit_root = tmp_path / "audit"
     cfg = _write(
         tmp_path / "config.yaml",
         _TWO_ENDPOINT_YAML.format(storage=storage.as_posix(), audit_root=audit_root.as_posix()),
     )
-    bus, _http = await build_bus_from_config(cfg)
+    bus, _http = await build_bus(cfg)
     await bus.start()
     try:
         endpoints = list(bus._endpoints_by_name.values())
@@ -79,14 +77,14 @@ async def test_audit_writer_is_singleton_across_endpoints(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_audit_disabled_emits_nothing(tmp_path: Path):
+async def test_audit_disabled_emits_nothing(tmp_path: Path, build_bus):
     storage = tmp_path / "bus.sqlite"
     audit_root = tmp_path / "audit"
     cfg = _write(
         tmp_path / "config.yaml",
         _DISABLED_YAML.format(storage=storage.as_posix(), audit_root=audit_root.as_posix()),
     )
-    bus, _http = await build_bus_from_config(cfg)
+    bus, _http = await build_bus(cfg)
     await bus.start()
     try:
         endpoints = list(bus._endpoints_by_name.values())

--- a/packages/core/tests/test_mcp_audit_runner.py
+++ b/packages/core/tests/test_mcp_audit_runner.py
@@ -22,12 +22,12 @@ endpoints: []
 
 
 @pytest.mark.asyncio
-async def test_runner_constructs_writer_when_mcp_audit_block_missing(tmp_path: Path):
+async def test_runner_constructs_writer_when_mcp_audit_block_missing(tmp_path: Path, build_bus):
     cfg = _write_yaml(
         tmp_path / "config.yaml",
         _BASE_YAML.format(storage=(tmp_path / "bus.sqlite").as_posix()),
     )
-    bus, _http = await build_bus_from_config(cfg)
+    bus, _http = await build_bus(cfg)
     # Block missing → defaults; writer is constructed.
     # We can't reach RunnerServices directly post-build, but the writer
     # was passed to BuiltinRuntimePlugin which would have attached it to
@@ -37,12 +37,12 @@ async def test_runner_constructs_writer_when_mcp_audit_block_missing(tmp_path: P
 
 
 @pytest.mark.asyncio
-async def test_runner_constructs_no_writer_when_disabled(tmp_path: Path):
+async def test_runner_constructs_no_writer_when_disabled(tmp_path: Path, build_bus):
     yaml_body = _BASE_YAML.format(storage=(tmp_path / "bus.sqlite").as_posix()) + (
         "mcp_audit:\n  enabled: false\n"
     )
     cfg = _write_yaml(tmp_path / "config.yaml", yaml_body)
-    bus, _http = await build_bus_from_config(cfg)
+    bus, _http = await build_bus(cfg)
     # With one ClaudeCodeMCPEndpoint and audit disabled, no audit dir
     # should appear under ~/.agent-core/bus/mcp-audit. Validated via the
     # integration test in Task 6 — here we just assert build succeeded.
@@ -50,7 +50,7 @@ async def test_runner_constructs_no_writer_when_disabled(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_runner_uses_configured_log_root_and_timezone(tmp_path: Path):
+async def test_runner_uses_configured_log_root_and_timezone(tmp_path: Path, build_bus):
     custom_root = tmp_path / "custom" / "audit"
     yaml_body = _BASE_YAML.format(storage=(tmp_path / "bus.sqlite").as_posix()) + (
         f"mcp_audit:\n"
@@ -60,7 +60,7 @@ async def test_runner_uses_configured_log_root_and_timezone(tmp_path: Path):
         f"  skip_tools: [\"list_pending\"]\n"
     )
     cfg = _write_yaml(tmp_path / "config.yaml", yaml_body)
-    bus, _http = await build_bus_from_config(cfg)
+    bus, _http = await build_bus(cfg)
     assert bus is not None
     # No endpoints in this config means no writer activation, but the
     # build itself must accept the block. Behavioral verification of

--- a/packages/core/tests/test_plugins.py
+++ b/packages/core/tests/test_plugins.py
@@ -67,7 +67,7 @@ def _base_hook():
 
 class TestRunnerPluginHooks:
     async def test_resolve_endpoint_class_path(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, build_bus
     ):
         Hook = _base_hook()
 
@@ -84,11 +84,11 @@ class TestRunnerPluginHooks:
         config = {"endpoints": [{"type": "plugin.stub.Endpoint", "name": "plug", "params": {}}]}
         p = tmp_path / "plugin-endpoint.yaml"
         p.write_text(yaml.dump(config), encoding="utf-8")
-        bus, _ = await build_bus_from_config(p)
+        bus, _ = await build_bus(p)
         assert "plug" in bus._endpoints_by_name
 
     async def test_endpoint_requires_specific_resolver(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, build_bus
     ):
         Hook = _base_hook()
 
@@ -113,12 +113,12 @@ class TestRunnerPluginHooks:
         config = {"endpoints": [{"type": "plugin.stub.Endpoint", "name": "plug", "params": {}}]}
         p = tmp_path / "plugin-precedence.yaml"
         p.write_text(yaml.dump(config), encoding="utf-8")
-        bus, _ = await build_bus_from_config(p)
+        bus, _ = await build_bus(p)
         spec = bus._endpoints_by_name["plug"]
         assert isinstance(spec.endpoint, _SpecificEndpoint)
 
     async def test_resolve_bus_hook_class_and_configure_called(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, build_bus
     ):
         seen: list[str] = []
         Hook = _base_hook()
@@ -150,7 +150,7 @@ class TestRunnerPluginHooks:
         }
         p = tmp_path / "plugin-bus-hook.yaml"
         p.write_text(yaml.dump(config), encoding="utf-8")
-        await build_bus_from_config(p)
+        bus, _ = await build_bus(p)
         assert seen == ["pre_publish"]
 
     async def test_validate_config_can_reject(
@@ -174,7 +174,7 @@ class TestRunnerPluginHooks:
             await build_bus_from_config(p)
 
     async def test_reserved_endpoint_params_pop_before_construction(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, build_bus
     ):
         """Plugin-declared reserved params don't reach the endpoint __init__.
 
@@ -225,7 +225,7 @@ class TestRunnerPluginHooks:
         }
         p = tmp_path / "reserved-params.yaml"
         p.write_text(yaml.dump(config), encoding="utf-8")
-        bus, _ = await build_bus_from_config(p)
+        bus, _ = await build_bus(p)
         assert "strict" in bus._endpoints_by_name
         assert captured_kwargs == {"allowed_only": "yes"}
 
@@ -256,7 +256,7 @@ class TestPipelinePluginHooks:
 
 
 class TestEntrypointPluginIntegration:
-    async def test_alias_endpoint_resolves_without_monkeypatch(self, tmp_path: Path):
+    async def test_alias_endpoint_resolves_without_monkeypatch(self, tmp_path: Path, build_bus):
         config = {
             "endpoints": [
                 {
@@ -268,7 +268,7 @@ class TestEntrypointPluginIntegration:
         }
         p = tmp_path / "alias-endpoint.yaml"
         p.write_text(yaml.dump(config), encoding="utf-8")
-        bus, _ = await build_bus_from_config(p)
+        bus, _ = await build_bus(p)
         assert "stub-alias" in bus._endpoints_by_name
 
     def test_alias_hook_tool_resolves_without_monkeypatch(self, tmp_path: Path):

--- a/packages/core/tests/test_runner_http_host.py
+++ b/packages/core/tests/test_runner_http_host.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from agent_core.bus.runner import build_bus_from_config
 from agent_core.endpoints.claude_code_mcp import ClaudeCodeMCPEndpoint
 
 
 @pytest.mark.asyncio
-async def test_runner_returns_none_http_host_when_no_mcp_endpoints(tmp_path):
+async def test_runner_returns_none_http_host_when_no_mcp_endpoints(tmp_path, build_bus):
     """If no MCPHostable endpoints are registered, http_host is None."""
     cfg = tmp_path / "agent_core.yaml"
     cfg.write_text(
@@ -22,13 +21,13 @@ endpoints:
 """,
         encoding="utf-8",
     )
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is None
     assert "stub" in bus._endpoints_by_name
 
 
 @pytest.mark.asyncio
-async def test_runner_constructs_http_host_when_mcp_endpoints_present(tmp_path):
+async def test_runner_constructs_http_host_when_mcp_endpoints_present(tmp_path, build_bus):
     """One ClaudeCodeMCPEndpoint → HTTPHost is built with that mount."""
     cfg = tmp_path / "agent_core.yaml"
     cfg.write_text(
@@ -46,14 +45,14 @@ endpoints:
 """,
         encoding="utf-8",
     )
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     assert len(http_host._mounts) == 1
     assert http_host._mounts[0].mount == "/mcp/agent-test"
 
 
 @pytest.mark.asyncio
-async def test_runner_constructs_http_host_with_multiple_mcp_endpoints(tmp_path):
+async def test_runner_constructs_http_host_with_multiple_mcp_endpoints(tmp_path, build_bus):
     """Two CC endpoints → both mounted on the same HTTPHost."""
     cfg = tmp_path / "agent_core.yaml"
     cfg.write_text(
@@ -74,14 +73,14 @@ endpoints:
 """,
         encoding="utf-8",
     )
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     mounts = sorted(m.mount for m in http_host._mounts)
     assert mounts == ["/mcp/agent-deb", "/mcp/agent-pepper"]
 
 
 @pytest.mark.asyncio
-async def test_runner_claude_code_mcp_accepts_auto_ack_params(tmp_path):
+async def test_runner_claude_code_mcp_accepts_auto_ack_params(tmp_path, build_bus):
     """Issue #12: YAML params for auto-ack / missing-ack must construct (no BusBootError)."""
     cfg = tmp_path / "agent_core.yaml"
     cfg.write_text(
@@ -103,7 +102,7 @@ endpoints:
 """,
         encoding="utf-8",
     )
-    bus, http_host = await build_bus_from_config(cfg)
+    bus, http_host = await build_bus(cfg)
     assert http_host is not None
     spec = bus._endpoints_by_name["agent-ack"]
     ep = spec.endpoint

--- a/packages/core/tests/test_scheduler_integration.py
+++ b/packages/core/tests/test_scheduler_integration.py
@@ -21,7 +21,6 @@ from agent_core.bus.envelope import (
     TextMessagePayload,
     ToolInvocationPayload,
 )
-from agent_core.bus.runner import build_bus_from_config
 
 
 def _config_yaml(tmp_path, jobs_yaml: str | None = None) -> str:
@@ -48,7 +47,7 @@ def _config_yaml(tmp_path, jobs_yaml: str | None = None) -> str:
 
 
 @pytest.mark.asyncio
-async def test_seed_job_fires_to_stub(tmp_path):
+async def test_seed_job_fires_to_stub(tmp_path, build_bus):
     """A 1-second interval seed job fires and the stub receives the envelope."""
     jobs_path = tmp_path / "jobs.yaml"
     jobs_path.write_text(
@@ -68,7 +67,7 @@ async def test_seed_job_fires_to_stub(tmp_path):
     cfg = tmp_path / "agent_core.yaml"
     cfg.write_text(_config_yaml(tmp_path, jobs_yaml=str(jobs_path)), encoding="utf-8")
 
-    bus, _ = await build_bus_from_config(cfg)
+    bus, _ = await build_bus(cfg)
     await bus.start()
     try:
         stub = bus._endpoints_by_name["agent-test"].endpoint
@@ -92,12 +91,12 @@ async def test_seed_job_fires_to_stub(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_dynamic_create_job_via_toolinvocation(tmp_path):
+async def test_dynamic_create_job_via_toolinvocation(tmp_path, build_bus):
     """Stub sends a create_job ToolInvocation; scheduler creates and fires the job."""
     cfg = tmp_path / "agent_core.yaml"
     cfg.write_text(_config_yaml(tmp_path), encoding="utf-8")
 
-    bus, _ = await build_bus_from_config(cfg)
+    bus, _ = await build_bus(cfg)
     await bus.start()
     try:
         stub = bus._endpoints_by_name["agent-test"].endpoint
@@ -147,11 +146,11 @@ async def test_dynamic_create_job_via_toolinvocation(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_delete_job_stops_fires(tmp_path):
+async def test_delete_job_stops_fires(tmp_path, build_bus):
     cfg = tmp_path / "agent_core.yaml"
     cfg.write_text(_config_yaml(tmp_path), encoding="utf-8")
 
-    bus, _ = await build_bus_from_config(cfg)
+    bus, _ = await build_bus(cfg)
     await bus.start()
     try:
         stub = bus._endpoints_by_name["agent-test"].endpoint


### PR DESCRIPTION
Fixes #287.

## Problem

Tests that built a bus via `build_bus_from_config()` but never called `bus.stop()` leaked the bus's aiosqlite persistence connection. Its finalizer then ran **after** the test's event loop had closed, raising `RuntimeError: Event loop is closed` at teardown. Individually a warning — but under `pytest-xdist --dist=loadscope` a stray finalizer could land on an unrelated test's teardown and escalate to a **collected ERROR**, failing the whole run non-deterministically.

This was the dominant cause of foreman role pushes dying at the pre-push hook (which runs the full suite on every push, including Planner/SpecFix roles that only edit spec docs). The role's actual change was irrelevant — the suite failed under it. Same class as the `test_cli_run` flake fixed in #283.

## Fix

- New `build_bus` fixture (`packages/core/tests/conftest.py`): wraps `build_bus_from_config`, tracks every `(bus, http)` it creates, and stops them all — closing their connections — inside the test's own event loop on teardown. `Bus.stop`/`HTTPHost.stop` no-op safely when never started and `Persistence.close` is idempotent, so it coexists with tests that also stop their bus.
- Routed all bus-building test call sites (13 files) through the fixture. Error-path builds wrapped in `pytest.raises` produce no bus and stay on the direct `build_bus_from_config` call.

## Verification

- Full core suite (`-n auto --dist=loadscope`, pytest-randomly) **green across 5 seeds**.
- **Zero** cross-platform `Event loop is closed`: excluding the uvicorn/subprocess tests (Windows-only `ProactorEventLoop` transport finalizer noise, which does not occur on the Linux CI/foreman path) leaves the count at 0 — i.e. every bus/persistence connection now closes cleanly.
- `just check` passes: **1538 passed**, coverage 89.38% (> 85% floor), ruff + mypy + lint-imports clean.

🪶 Built by Wren.
