### PR TITLE
feat: add BusHandle.spawn() tracked-task API for issue #290

### DIFF
--- a/packages/core/src/agent_core/bus/core.py
+++ b/packages/core/src/agent_core/bus/core.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import random
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -136,12 +137,29 @@ class Bus:
         }
         self._store: Persistence | None = None
         self._started = False
+        self._handles: dict[str, BusHandle] = {}
 
     def _require_store(self) -> Persistence:
         if self._store is None:
             msg = "Bus persistence store is not initialized"
             raise RuntimeError(msg)
         return self._store
+
+    def _make_task_failure_hook(self, endpoint_name: str) -> Callable[[BaseException], None]:
+        """Factory: produces a per-endpoint logging hook.
+
+        T3/T4 replaces the body of this factory with a supervisor call without
+        changing BusHandle.
+        """
+
+        def _hook(exc: BaseException) -> None:
+            log.error(
+                "endpoint %r: background task raised (endpoint may need restart)",
+                endpoint_name,
+                exc_info=exc,
+            )
+
+        return _hook
 
     def register(self, spec: EndpointSpec) -> None:
         if spec.name in self._endpoints_by_name:
@@ -208,7 +226,12 @@ class Bus:
         started_specs: list[EndpointSpec] = []
         try:
             for spec in self._endpoints_by_name.values():
-                handle = BusHandle(self, spec.name)
+                handle = BusHandle(
+                    self,
+                    spec.name,
+                    on_task_failure=self._make_task_failure_hook(spec.name),
+                )
+                self._handles[spec.name] = handle
                 await spec.endpoint.start(handle)
                 started_specs.append(spec)
                 await self.drain_for(spec.name)
@@ -218,6 +241,9 @@ class Bus:
                     await spec.endpoint.stop()
                 except Exception:
                     log.exception("error stopping endpoint %s during failed start", spec.name)
+                rollback_handle = self._handles.get(spec.name)
+                if rollback_handle is not None:
+                    await rollback_handle._drain_tasks()
             await self._store.close()
             self._store = None
             raise
@@ -233,6 +259,9 @@ class Bus:
                 await spec.endpoint.stop()
             except Exception:
                 log.exception("error stopping endpoint %s", spec.name)
+            handle = self._handles.get(spec.name)
+            if handle is not None:
+                await handle._drain_tasks()
         if self._store is not None:
             await self._store.close()
         self._started = False
@@ -302,7 +331,9 @@ class Bus:
                 # Transient failure — backoff-requeue or dead-letter if exhausted.
                 row = await store.row(envelope.id)
                 if row is None:
-                    log.warning("envelope %s not found after mark_in_flight; skipping requeue", envelope.id)
+                    log.warning(
+                        "envelope %s not found after mark_in_flight; skipping requeue", envelope.id
+                    )
                     return
                 attempt = row["delivery_count"]  # already incremented by mark_in_flight
                 if attempt >= self.config.max_delivery_attempts:

--- a/packages/core/src/agent_core/bus/handle.py
+++ b/packages/core/src/agent_core/bus/handle.py
@@ -7,13 +7,18 @@ spoof each other regardless of what they put in the envelope.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from typing import TYPE_CHECKING, Any
 
 from agent_core.bus.envelope import EndpointInfo, Envelope
 
 if TYPE_CHECKING:
     from agent_core.bus.core import Bus
     from agent_core.bus.persistence import Persistence
+
+log = logging.getLogger(__name__)
 
 
 class BusHandle:
@@ -24,9 +29,18 @@ class BusHandle:
     Endpoints never need to know their own name; the handle knows for them.
     """
 
-    def __init__(self, bus: Bus, endpoint_name: str):
+    def __init__(
+        self,
+        bus: Bus,
+        endpoint_name: str,
+        on_task_failure: Callable[[BaseException], None] | None = None,
+    ) -> None:
         self._bus = bus
         self._endpoint_name = endpoint_name
+        self._tasks: set[asyncio.Task] = set()
+        self._on_task_failure = (
+            on_task_failure if on_task_failure is not None else self._default_failure
+        )
 
     async def publish(self, envelope: Envelope, to: str | list[str] | None = None) -> None:
         """Send an envelope. The bus stamps `from_` to this endpoint's name,
@@ -62,3 +76,52 @@ class BusHandle:
         directly.
         """
         return self._bus._require_store()
+
+    def spawn(
+        self,
+        coro: Coroutine[Any, Any, None],
+        *,
+        name: str | None = None,
+    ) -> asyncio.Task:
+        """Create and track a background asyncio task.
+
+        The task is registered in this handle's internal set. On completion,
+        the task is removed from the set. If the task raises an exception
+        (other than CancelledError), the injected failure hook is called
+        exactly once — the event loop is not crashed.
+        """
+        task = asyncio.create_task(coro, name=name)
+        self._tasks.add(task)
+        task.add_done_callback(self._task_done)
+        return task
+
+    def _task_done(self, task: asyncio.Task) -> None:
+        """Done callback: remove task from set and route non-cancellation exceptions."""
+        self._tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            self._on_task_failure(exc)
+
+    def _default_failure(self, exc: BaseException) -> None:
+        """Default failure hook: log the exception as an error."""
+        log.error(
+            "endpoint %r: background task raised (endpoint may need restart)",
+            self._endpoint_name,
+            exc_info=exc,
+        )
+
+    async def _drain_tasks(self) -> None:
+        """Cancel and await all outstanding tracked tasks.
+
+        Called by the bus on endpoint stop (and start-rollback). CancelledError
+        from draining is NOT routed to the failure hook.
+        """
+        tasks = list(self._tasks)
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._tasks.clear()

--- a/packages/core/tests/bus/test_handle.py
+++ b/packages/core/tests/bus/test_handle.py
@@ -1,5 +1,6 @@
 """Tests for BusHandle — the per-endpoint surface to the bus."""
 
+import asyncio
 from datetime import UTC, datetime
 
 from agent_core.bus.envelope import EndpointInfo, Envelope, TextMessagePayload
@@ -108,3 +109,70 @@ class TestBusHandleEndpoints:
         infos.clear()
         # Mutating the returned list must not affect later calls.
         assert len(handle.endpoints()) == 2
+
+
+class TestBusHandleSpawn:
+    async def test_spawn_complete_removes_from_task_set(self):
+        """Completed task is removed from the internal tracked set."""
+        handle = BusHandle(_RecordingBus(), "x")
+
+        async def _noop() -> None:
+            pass
+
+        task = handle.spawn(_noop())
+        await asyncio.gather(task, return_exceptions=True)
+        assert task not in handle._tasks
+
+    async def test_spawn_raise_invokes_failure_hook_exactly_once(self):
+        """Task raising invokes the injected hook exactly once."""
+        failures: list[BaseException] = []
+        handle = BusHandle(_RecordingBus(), "x", on_task_failure=failures.append)
+
+        async def _boom() -> None:
+            raise ValueError("oops")
+
+        task = handle.spawn(_boom())
+        await asyncio.gather(task, return_exceptions=True)
+        assert len(failures) == 1
+        assert isinstance(failures[0], ValueError)
+
+    async def test_spawn_raise_does_not_propagate_to_loop(self):
+        """Exception in a spawned task does NOT bubble to the event loop."""
+        handle = BusHandle(_RecordingBus(), "x", on_task_failure=lambda _: None)
+
+        async def _boom() -> None:
+            raise RuntimeError("contained")
+
+        task = handle.spawn(_boom())
+        await asyncio.gather(task, return_exceptions=True)
+        assert task.done() and not task.cancelled()
+
+    async def test_drain_cancels_task_and_hook_not_fired(self):
+        """CancelledError on shutdown is not treated as a failure."""
+        failures: list[BaseException] = []
+        handle = BusHandle(_RecordingBus(), "x", on_task_failure=failures.append)
+
+        async def _hang() -> None:
+            await asyncio.sleep(1000)
+
+        task = handle.spawn(_hang())
+        await handle._drain_tasks()
+        assert task.cancelled()
+        assert failures == []
+
+    async def test_drain_cancels_all_pending_tasks_and_clears_set(self):
+        """_drain_tasks() cancels every outstanding task and empties the set."""
+        handle = BusHandle(_RecordingBus(), "x")
+        started = asyncio.Event()
+
+        async def _long() -> None:
+            started.set()
+            await asyncio.sleep(1000)
+
+        t1 = handle.spawn(_long())
+        t2 = handle.spawn(_long())
+        await started.wait()
+        await handle._drain_tasks()
+        assert t1.cancelled()
+        assert t2.cancelled()
+        assert len(handle._tasks) == 0


### PR DESCRIPTION
Implements #290 — the **API half** of the tracked-task work (call-site migration is #291).

Adds `BusHandle.spawn()` so endpoints create background asyncio tasks that the bus tracks, cancels, and awaits on stop — closing the task-leak class.

## What it does
- `BusHandle.spawn(coro, *, name=None) -> asyncio.Task` — registers the task in a per-endpoint set; a done-callback removes it and routes any non-`CancelledError` exception to an injected **failure hook exactly once**; the loop is never crashed.
- `_drain_tasks()` — cancels + awaits all tracked tasks on endpoint stop (idempotent; `CancelledError` from draining is not treated as a failure).
- **DIP wiring** in `core.py`: the bus injects a logging failure-hook closure per endpoint `BusHandle` and drains it on stop (including the partial-start rollback path). T3's `EndpointSupervisor` can substitute its own hook later without touching `BusHandle`.

## Scope
API only. Leaky `create_task` call sites (inbound `_bus_publish_adapter`, voice, discord) are **#291**. Nothing migrated here.

## Quality
- TDD, 5 spawn tests (complete→removed, raise→hook-fires-once via counter, drain→cancelled+no-hook, loop-safety, multi-task clear). Full pre-push suite: **1571 passed, 89.56% cov**.
- Adversarial concurrency review: **LAND** — verified the `task.exception()`-on-cancelled guard, exactly-once hook, CancelledError-not-routed, drain idempotency, and set-mutation safety.

## Context
Hand-built by Wren per Jeff — foreman's Worker kept hitting the 1800s wall-clock on this ticket (agent_core's slow baseline suite eats the budget before implementation starts). Spec: `docs/superpowers/specs/foreman-issue-290-spec.md`.
