### PR TITLE
ci: run the coverage floor in CI only, not the pre-push gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,7 @@
 #!/bin/sh
-# Pre-push quality gate: run the same fast gate CI runs.
+# Pre-push quality gate: fast presubmit lane — lint + types + contracts + tests,
+# WITHOUT the coverage floor. The 85% coverage gate runs in CI (postsubmit), not
+# here; blocking a push on a flaky coverage % is the anti-pattern. See the
+# `check-fast` recipe rationale in the justfile.
 # Emergency bypass (use sparingly): git push --no-verify
-exec just check
+exec just check-fast

--- a/justfile
+++ b/justfile
@@ -16,8 +16,17 @@ discord-tests := "packages/agent-core-discord/tests"
 default:
     @just --list
 
-# Composite gate (recommended before push)
+# Full gate — matches CI (postsubmit). Includes the coverage floor via `test`.
 check: lint typecheck contracts test
+
+# Pre-push gate (presubmit): the same checks WITHOUT the coverage floor.
+# Coverage (--cov-fail-under=85, set in pyproject addopts) is enforced in CI,
+# NOT at pre-push. A coverage percentage is a flaky number to block a commit on:
+# it dips whenever a parallel xdist worker hiccups on a real-I/O test, failing an
+# otherwise-green push (and, for foreman roles, Failing the ticket). Presubmit
+# stays fast + deterministic; CI (`just check`) plus the diff-cover gate keep the
+# coverage floor enforced before merge. Used by .githooks/pre-push.
+check-fast: lint typecheck contracts test-fast
 
 # Developer convenience: apply lint auto-fixes + formatter
 fix:


### PR DESCRIPTION
## Problem
Foreman roles end every phase with `git push` → pre-push hook `just check` → `test` = `pytest` with `--cov-fail-under=85` (pyproject addopts) under `-n auto` + pytest-randomly. Coverage under parallel xdist is a **flaky signal**: when a worker hiccups on a real-I/O test, the tests it held stop contributing coverage, the total dips under 85, and pytest exits non-zero **with every test still passing**. That intermittently Failed foreman tickets on a green tree (observed on a docs-only spec branch, agent_core#296).

## Fix (Google presubmit/postsubmit split)
- new `check-fast` recipe = `lint + typecheck + contracts + test-fast` (no coverage)
- `.githooks/pre-push` runs `check-fast`
- `just check` (full coverage) still runs in **CI**, which — with the existing diff-cover 80% patch gate — keeps the coverage floor enforced before merge.

Blocking a *commit* on a flaky coverage % is the anti-pattern; coverage belongs in postsubmit. Presubmit stays fast + deterministic.

## Verification
Pushing this branch ran the new `check-fast` hook end-to-end: **1591 passed, 5 skipped in 30.72s** (vs ~110–230s for the coverage run). CI (`just check`) will run the full coverage gate on this PR.

Follow-ups (tracked separately): deflake the aiosqlite teardown leak; move the large real-I/O bus tests out of the fast presubmit lane.
