### PR TITLE
ci: deterministic single-threaded coverage + patch-coverage in the pre-push gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,7 +1,8 @@
 #!/bin/sh
-# Pre-push quality gate: fast presubmit lane — lint + types + contracts + tests,
-# WITHOUT the coverage floor. The 85% coverage gate runs in CI (postsubmit), not
-# here; blocking a push on a flaky coverage % is the anti-pattern. See the
-# `check-fast` recipe rationale in the justfile.
-# Emergency bypass (use sparingly): git push --no-verify
-exec just check-fast
+# Pre-push quality gate: the full `just check` — lint, types, contracts,
+# deterministic-coverage tests (whole-repo 85% floor) + patch coverage (80% of
+# changed lines). Coverage runs single-threaded so the number is stable (no flaky
+# xdist dips), and both coverage checks run here so a worker catches under-tested
+# code before it pushes. Humans can iterate with `just check-fast` (parallel, no
+# coverage). Emergency bypass (use sparingly): git push --no-verify
+exec just check

--- a/justfile
+++ b/justfile
@@ -16,16 +16,16 @@ discord-tests := "packages/agent-core-discord/tests"
 default:
     @just --list
 
-# Full gate — matches CI (postsubmit). Includes the coverage floor via `test`.
-check: lint typecheck contracts test
+# Robot / pre-push gate (also what CI runs): lint + types + contracts +
+# deterministic-coverage tests (whole-repo 85% floor) + patch coverage (80% of
+# changed lines). Both coverage checks run HERE so a worker catches under-tested
+# code BEFORE it pushes — not after, in CI. Coverage runs single-threaded (see
+# `test`) so the number can't flake. Used by .githooks/pre-push.
+check: lint typecheck contracts test patch-cov
 
-# Pre-push gate (presubmit): the same checks WITHOUT the coverage floor.
-# Coverage (--cov-fail-under=85, set in pyproject addopts) is enforced in CI,
-# NOT at pre-push. A coverage percentage is a flaky number to block a commit on:
-# it dips whenever a parallel xdist worker hiccups on a real-I/O test, failing an
-# otherwise-green push (and, for foreman roles, Failing the ticket). Presubmit
-# stays fast + deterministic; CI (`just check`) plus the diff-cover gate keep the
-# coverage floor enforced before merge. Used by .githooks/pre-push.
+# Fast iteration gate (humans): the same checks but tests run parallel and
+# WITHOUT coverage, so it's quick. It does NOT enforce the coverage floors —
+# run `check` (or just push; the pre-push hook runs `check`) before a PR.
 check-fast: lint typecheck contracts test-fast
 
 # Developer convenience: apply lint auto-fixes + formatter
@@ -55,9 +55,21 @@ typecheck:
 contracts:
     uv run --no-sync lint-imports
 
-# Tests (full suite, coverage + 85% gate — matches CI)
+# Patch-coverage gate: >=80% of the lines THIS branch changed must be covered.
+# Catches under-tested new code — the gap the whole-repo floor misses, since a
+# few weak lines barely move a big project's total. Reads coverage.xml produced
+# by `test`; compares against origin/main.
+patch-cov:
+    uv run --no-sync diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
+
+# Full-suite tests WITH coverage, run SINGLE-THREADED (-n 0) so the coverage
+# number is deterministic. Coverage under parallel xdist flakes: a worker that
+# hiccups on a real-I/O test drops the % below the floor even when every test
+# passes; single-process removes that race. Enforces the whole-repo 85% floor
+# (--cov-fail-under, pyproject addopts). Slower than parallel — use `test-fast`
+# for quick iteration.
 test:
-    uv run --no-sync pytest -q
+    uv run --no-sync pytest -n 0 -q
 
 # Fast inner-loop run: full suite, NO coverage instrumentation.
 # Branch-coverage doubles wall time (~230s -> ~110s) and adds no signal


### PR DESCRIPTION
Refines #328. That change removed **all** coverage from the pre-push gate to kill a flaky failure; this puts **both** coverage checks back on the robot's local gate — without re-introducing the flake.

## What changed
- **`test` runs single-threaded (`-n 0`).** The flake was coverage under parallel xdist: a worker that hiccups on a real-I/O test drops the whole-repo % below the floor even when every test passes. Single-process removes that race → the **whole-repo 85% floor is deterministic**.
- **New `patch-cov` recipe** = `diff-cover --fail-under=80` — >=80% of the lines *this branch changed* must be covered. Previously patch coverage ran only in CI, **after** the worker had pushed and exited (that's how agent_core#296 shipped under-tested and hung in Merging). Now the worker catches it **before** pushing.
- **`check`** = lint + typecheck + contracts + `test` + `patch-cov`; the **pre-push hook runs `check`**. `check-fast` (parallel, no coverage) stays for human iteration.

## Verified live
Pushing this branch ran the new hook end-to-end: **coverage 89.64% (>=85 ✅), 1591 passed in 100s single-threaded**, diff-cover wired (trivially passes — no code lines changed here).

The underlying flaky test (aiosqlite teardown leak) is fixed separately in #329 so the parallel `test-fast` run is clean too.
