### PR TITLE
test(discord): deflake typing-TTL eviction tests (wait, don't sleep)

### DIFF
--- a/packages/agent-core-discord/tests/test_typing_ttl.py
+++ b/packages/agent-core-discord/tests/test_typing_ttl.py
@@ -39,8 +39,10 @@ async def test_typing_evicts_after_ttl_when_no_cleanup_fires(monkeypatch):
     ep._awaiting_reply_ids_timestamps["m-old"] = time.monotonic() - 100.0
     try:
         task = asyncio.create_task(ep._typing_while_pending(ch, "m-old"))
-        await asyncio.sleep(0.3)
-        assert task.done()
+        # Deterministic: wait for the loop to evict + exit, rather than sleeping a
+        # fixed wall-clock guess (which flakes under load). Times out (and fails)
+        # if the loop genuinely hangs.
+        await asyncio.wait_for(task, timeout=2.0)
         assert "m-old" not in ep._awaiting_reply_ids
         assert "m-old" not in ep._awaiting_reply_ids_timestamps
     finally:
@@ -80,8 +82,10 @@ async def test_typing_evicts_immediately_on_missing_timestamp_self_heal(monkeypa
     # Deliberately do NOT set _awaiting_reply_ids_timestamps["m-slipped"].
     try:
         task = asyncio.create_task(ep._typing_while_pending(ch, "m-slipped"))
-        await asyncio.sleep(0.3)
-        assert task.done()
+        # Deterministic: wait for eviction + loop exit rather than sleeping a
+        # fixed guess (this test flaked under load — #332's single-threaded gate
+        # surfaced it). Times out (and fails) if eviction never happens.
+        await asyncio.wait_for(task, timeout=2.0)
         assert "m-slipped" not in ep._awaiting_reply_ids
     finally:
         await ep.stop()


### PR DESCRIPTION
Deflake the discord typing-TTL eviction tests surfaced red on main by #332.

They slept a fixed 0.3s then asserted `task.done()` — a wall-clock guess that the background polling loop had evicted + exited. Under load the loop had not ticked yet → `assert False`. Replaced with `asyncio.wait_for(task, timeout=2.0)` — waits for the real completion (deterministic), still fails via timeout if eviction never happens.

Verified 10/10 green under randomized order locally; full single-threaded `just check` passed through the pre-push hook.
