### PR TITLE
ci: never measure coverage on test dirs (floor 85→75, source-only)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,12 @@ testpaths = [
     "packages/agent-core-busproxy/tests",
 ]
 asyncio_mode = "auto"
-addopts = "--import-mode=importlib -m 'not slow' --cov=packages --cov-branch --cov-report=term --cov-report=xml --cov-fail-under=85 -n auto --dist=loadscope"
+# --cov-fail-under=75: whole-repo floor on SOURCE-only coverage (test dirs are
+# omitted — see [tool.coverage.run]). Source is ~80% in the fast lane (slow
+# real-I/O tests are deselected here and cover more), so 75 is a stable backstop
+# with headroom; the diff-cover patch gate (80% of changed lines) does the real
+# per-change enforcement. Was 85 when test files inflated the measured total.
+addopts = "--import-mode=importlib -m 'not slow' --cov=packages --cov-branch --cov-report=term --cov-report=xml --cov-fail-under=75 -n auto --dist=loadscope"
 # Google's "small test" cap. Anything legitimately slower belongs in the
 # slow-marker lane (which the addopts above filters out by default).
 # Override per-test via @pytest.mark.timeout(N) with a justification.
@@ -134,9 +139,15 @@ markers = [
 
 [tool.coverage.run]
 # Exclude vendored code + generated stubs from coverage measurement.
+# Test files are NOT measured: coverage should reflect how well *source* is
+# exercised, not whether test code ran. Measuring test dirs also broke the
+# patch-coverage (diff-cover) gate — a slow-marked test that the default lane
+# skips showed as "uncovered", failing PRs whose *source* was well-tested
+# (agent_core#296).
 omit = [
     "*/vendor/*",
     "*/.venv/*",
     "*/__pycache__/*",
+    "*/tests/*",
 ]
 


### PR DESCRIPTION
Never measure coverage on test dirs — it was measuring test files as source.

Two problems it caused:
- inflated the whole-repo total to ~89% (test files run ~100%), hiding that *source* coverage is ~80% (fast lane);
- broke the diff-cover patch gate: a slow-marked test the default lane skips showed as "uncovered", failing PRs whose source was well-tested — this is why **#296 hung in Merging**.

Omit `*/tests/*` from coverage; drop the whole-repo floor 85→75 to match source-only reality (stable headroom; the diff-cover 80%-of-changed-lines gate does the real per-change enforcement). Verified: single-threaded `just check` green at 80% source through the hook.
