### PR TITLE
fix(discord): evict missing-timestamp typing orphans regardless of host uptime

### DIFF
--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -445,10 +445,17 @@ class DiscordEndpoint:
                 while message_id in self._awaiting_reply_ids:
                     # TTL safety net (#84): orphan entries (no explicit cleanup
                     # fired, agent dismissed without reply, cache miss) evict
-                    # after _TYPING_TTL_SECONDS. Missing-timestamp self-heals
-                    # via `get(mid, 0)` → huge delta → immediate eviction.
-                    ts = self._awaiting_reply_ids_timestamps.get(message_id, 0)
-                    if time.monotonic() - ts > self._TYPING_TTL_SECONDS:
+                    # after _TYPING_TTL_SECONDS. A missing timestamp means the
+                    # entry is an orphan → evict immediately.
+                    #
+                    # Detect "missing" with an explicit `is None`, NOT `get(mid, 0)`
+                    # + `monotonic() - 0 > TTL`: time.monotonic()'s epoch is
+                    # arbitrary (~boot), so on a freshly-booted host monotonic()
+                    # can be < TTL and `monotonic() - 0 > TTL` is False — wedging
+                    # the orphan in the set forever (a host-uptime-dependent hang,
+                    # surfaced on fresh CI runners).
+                    ts = self._awaiting_reply_ids_timestamps.get(message_id)
+                    if ts is None or time.monotonic() - ts > self._TYPING_TTL_SECONDS:
                         self._awaiting_reply_ids.discard(message_id)
                         self._awaiting_reply_ids_timestamps.pop(message_id, None)
                         break


### PR DESCRIPTION
Real correctness bug the deflaking surfaced (not just a flaky test).

`_typing_while_pending` self-healed a missing timestamp via `get(mid, 0)` then `monotonic() - 0 > TTL`. `time.monotonic()`'s epoch is arbitrary (~boot), so on a **freshly-booted host** `monotonic()` itself can be < TTL (90s) → the condition is False → the orphan is **never evicted** and the Discord typing indicator wedges forever. Host-uptime-dependent: fine on long-running boxes, hangs on fresh CI runners (surfaced `test_typing_evicts_immediately_on_missing_timestamp_self_heal` as a TimeoutError under #332's deterministic gate).

Fix: detect a missing timestamp explicitly (`ts is None`) and evict immediately; keep the elapsed-vs-TTL check only for entries that have a timestamp. Verified: typing-TTL 10/10, full single-threaded gate green.
