### PR TITLE
fix(scheduler): dispose aiosqlite engine on stop + leak guard (kills the ASGI-timeout flake)

### DIFF
--- a/packages/core/src/agent_core/endpoints/scheduler.py
+++ b/packages/core/src/agent_core/endpoints/scheduler.py
@@ -35,7 +35,7 @@ from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 from pydantic import BaseModel, Field, ValidationError, model_validator
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from agent_core.bus.envelope import (
     AcknowledgmentPayload,
@@ -238,12 +238,18 @@ class SchedulerEndpoint:
         self.db_path: Path = Path(db_path).expanduser() if db_path else _default_db_path()
         self._handle: BusHandle | None = None
         self._scheduler: AsyncScheduler | None = None
+        # The aiosqlite-backed engine is owned here (not by APScheduler's data
+        # store, which never disposes a caller-supplied engine). It MUST be
+        # disposed in stop(), else its connection pool's background aiosqlite
+        # threads leak on every stop — accumulating across a test suite until
+        # the event loop chokes and a random test times out.
+        self._engine: AsyncEngine | None = None
 
     async def start(self, bus: BusHandle) -> None:
         self._handle = bus
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        engine = create_async_engine(f"sqlite+aiosqlite:///{self.db_path}")
-        data_store = SQLAlchemyDataStore(engine)
+        self._engine = create_async_engine(f"sqlite+aiosqlite:///{self.db_path}")
+        data_store = SQLAlchemyDataStore(self._engine)
         self._scheduler = AsyncScheduler(data_store=data_store)
         try:
             await self._scheduler.__aenter__()
@@ -261,6 +267,9 @@ class SchedulerEndpoint:
             except Exception:
                 log.exception("rollback __aexit__ failed during start()")
             self._scheduler = None
+            if self._engine is not None:
+                await self._engine.dispose()
+                self._engine = None
             self._handle = None
             raise
         log.info("SchedulerEndpoint(name=%s) started; db=%s", self.name, self.db_path)
@@ -508,6 +517,11 @@ class SchedulerEndpoint:
                 log.exception("SchedulerEndpoint(%s) error during scheduler shutdown", self.name)
             finally:
                 self._scheduler = None
+        if self._engine is not None:
+            # Dispose the engine's connection pool so its aiosqlite worker
+            # threads are joined rather than leaked (see __init__).
+            await self._engine.dispose()
+            self._engine = None
         self._handle = None
         log.info("SchedulerEndpoint(name=%s) stopped", self.name)
 

--- a/packages/core/tests/conftest.py
+++ b/packages/core/tests/conftest.py
@@ -16,7 +16,9 @@ closed — inside the test's own event loop.
 from __future__ import annotations
 
 import sys
-from collections.abc import AsyncIterator, Awaitable, Callable
+import threading
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from pathlib import Path
 
 import pytest
@@ -29,9 +31,7 @@ from agent_core.bus.runner import build_bus_from_config
 BusFactory = Callable[[Path], Awaitable[tuple[Bus, HTTPHost | None]]]
 
 
-def pytest_collection_modifyitems(
-    config: pytest.Config, items: list[pytest.Item]
-) -> None:
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """Skip ``looptime``-marked tests on Windows.
 
     ``looptime`` fakes the asyncio clock by replacing the event loop's
@@ -79,3 +79,58 @@ async def build_bus() -> AsyncIterator[BusFactory]:
         if http is not None:
             await http.stop()
         await bus.stop()
+
+
+def _live_aiosqlite_threads() -> list[threading.Thread]:
+    """Return the currently-alive ``aiosqlite`` connection worker threads.
+
+    ``aiosqlite.Connection`` runs one ``threading.Thread`` per open connection
+    (``target=_connection_worker_thread``) until the connection is closed. The
+    thread is matched by its target function name — robust across aiosqlite
+    versions — with the auto-generated thread name as a fallback.
+    """
+    threads: list[threading.Thread] = []
+    for t in threading.enumerate():
+        if not t.is_alive():
+            continue
+        target = getattr(t, "_target", None)
+        target_name = getattr(target, "__name__", "") if target is not None else ""
+        if target_name == "_connection_worker_thread" or ("_connection_worker_thread" in t.name):
+            threads.append(t)
+    return threads
+
+
+@pytest.fixture(autouse=True)
+def fail_on_leaked_aiosqlite_connection() -> Iterator[None]:
+    """Fail any test that leaks an ``aiosqlite`` connection thread.
+
+    Each ``aiosqlite.connect`` starts a background ``Connection`` thread that
+    lives until the connection is closed. A test that opens a bus/persistence
+    connection and never closes it leaks that thread; across the suite they
+    accumulate into the thousands until the asyncio selector chokes and a
+    random test hangs (``pytest-timeout`` → "ASGI callable returned without
+    completing response") — a non-deterministic failure that blocks CI and
+    wedges the merge queue. This guard turns that downstream flake into a
+    deterministic, localized failure at the offending test.
+
+    Fix a flagged test by building buses via the :func:`build_bus` fixture, or
+    by calling ``await store.close()`` / ``await bus.stop()`` in teardown.
+    """
+    before = {id(t) for t in _live_aiosqlite_threads()}
+    yield
+    # aiosqlite joins its worker thread asynchronously after ``close()``; allow
+    # a brief grace so a properly-closed connection mid-teardown is not flagged.
+    leaked: list[threading.Thread] = []
+    for _ in range(100):  # up to ~1s
+        leaked = [t for t in _live_aiosqlite_threads() if id(t) not in before]
+        if not leaked:
+            break
+        time.sleep(0.01)
+    if leaked:
+        pytest.fail(
+            f"leaked {len(leaked)} aiosqlite connection thread(s) — the test "
+            "opened a bus/persistence connection without closing it. Build "
+            "buses via the `build_bus` fixture, or `await store.close()` / "
+            "`await bus.stop()` in teardown.",
+            pytrace=False,
+        )

--- a/packages/core/tests/test_scheduler_endpoint.py
+++ b/packages/core/tests/test_scheduler_endpoint.py
@@ -164,6 +164,64 @@ async def test_start_stop_lifecycle(tmp_path):
     await ep.stop()
 
 
+async def test_stop_disposes_engine_leaving_no_leaked_connections(tmp_path):
+    """``stop()`` must dispose the aiosqlite engine so its worker threads are
+    joined, not leaked.
+
+    Regression lock for the 2026-07-20 connection leak: the engine was a local
+    in ``start()`` and never disposed, so every start/stop leaked the pool's
+    aiosqlite threads — accumulating across the suite until a random test timed
+    out (``ASGI callable returned without completing response``). The autouse
+    ``fail_on_leaked_aiosqlite_connection`` guard enforces this for every test;
+    this asserts the specific mechanism directly.
+    """
+
+    class _FakeHandle:
+        async def publish(self, *a, **kw): ...
+        async def ack(self, *a, **kw): ...
+        async def nack(self, *a, **kw): ...
+        def endpoints(self):
+            return []
+
+    ep = SchedulerEndpoint(name="scheduler", db_path=str(tmp_path / "sched.db"))
+    await ep.start(_FakeHandle())
+    assert ep._engine is not None  # engine is owned by the endpoint
+    await ep.stop()
+    assert ep._engine is None  # disposed and cleared
+
+
+async def test_failed_start_rolls_back_and_disposes_engine(tmp_path, monkeypatch):
+    """A failure after the engine is created must still dispose it (rollback).
+
+    Without this, a half-built scheduler would leak the engine's aiosqlite
+    connection pool. The autouse leak guard also asserts no thread survives.
+    """
+
+    class _FakeHandle:
+        async def publish(self, *a, **kw): ...
+        async def ack(self, *a, **kw): ...
+        async def nack(self, *a, **kw): ...
+        def endpoints(self):
+            return []
+
+    ep = SchedulerEndpoint(
+        name="scheduler",
+        jobs_path=str(tmp_path / "jobs.yaml"),
+        db_path=str(tmp_path / "sched.db"),
+    )
+
+    async def _boom() -> None:
+        raise RuntimeError("seed failed")
+
+    # Force the last start() step (seed jobs) to fail so the rollback path runs.
+    monkeypatch.setattr(ep, "_seed_jobs", _boom)
+
+    with pytest.raises(RuntimeError, match="seed failed"):
+        await ep.start(_FakeHandle())
+
+    assert ep._engine is None  # rollback disposed + cleared the engine
+
+
 def test_load_seed_jobs_returns_empty_for_missing_file(tmp_path):
     from agent_core.endpoints.scheduler import load_seed_jobs
 


### PR DESCRIPTION
## The flake was one bug: a leaked aiosqlite connection pool

The intermittent CI failure `ASGI callable returned without completing response`
(which blocked merges and twice wedged the merge queue) was **not** a flaky
test. It was a deterministic resource leak with a nondeterministic trigger.

**Root cause:** `SchedulerEndpoint.start()` created its SQLAlchemy async engine
(`create_async_engine("sqlite+aiosqlite:///…")`) as a **local variable**, never
stored on the instance, and `stop()` never disposed it. APScheduler doesn't
dispose a caller-supplied engine, so the engine's connection pool — and its
background `aiosqlite` worker threads — **leaked on every start/stop**. Across
the test suite these accumulated into the **thousands** (the failing run had
~1,300 live `_connection_worker_thread`s) until the asyncio selector choked on
the fd pressure and a *random* test hung, tripping `pytest-timeout`. That's why
it looked like a flake: the test that hung was whichever was running at the
tipping point, and it depended on suite size/ordering.

## Fix (three parts)

1. **The leak (production bug):** own the engine on `self._engine` and
   `await self._engine.dispose()` in `stop()` and on the failed-start rollback.
   This closes the pool's aiosqlite threads in production and in tests.

2. **A regression guard (keystone):** a new autouse fixture
   `fail_on_leaked_aiosqlite_connection` snapshots live aiosqlite worker threads
   around every test and **fails the offending test by name** if any leak. This
   converts the random downstream hang into a deterministic, localized failure
   at the source — so this class of leak can never silently regress. It also
   *found* the offenders here (20 tests across 3 files, all resolved by fix 1).

3. **An explicit lock:** `test_stop_disposes_engine_leaving_no_leaked_connections`
   asserts the specific mechanism (engine disposed and cleared on stop).

## Result

Full core suite: 1,112 passed, **zero leaked connections** — and ~26s faster
(45s vs 71s), because threads no longer accumulate. Every scheduler test now
tears down cleanly.

Follow-up (separate, not in this PR): the flaky `ASGI…` symptom also exposed a
foreman fragility — the merge coordinator crashes (and wedges the whole queue)
on a check-blocked PR instead of deferring it. Tracked separately.
