### PR TITLE
fix: 6 HIGH findings from the adversarial review (leaks, fragility, footguns)

### DIFF
--- a/packages/agent-core-hatchery/src/agent_core_hatchery/cli.py
+++ b/packages/agent-core-hatchery/src/agent_core_hatchery/cli.py
@@ -79,6 +79,15 @@ def hatch_being(
     typer.echo(f"Report: {report_path}")
     typer.echo("🐣")
 
+    if daemon_check_status == "start_failed":
+        typer.secho(
+            "✗  Daemon FAILED to restart after hatch — the fleet may be OFFLINE. "
+            "Run `agent-core daemon start` now.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
     if daemon_check_status == "reachable_but_missing":
         typer.secho(
             "⚠  Daemon probe: endpoint not registered after reload. See HATCHING-REPORT.md.",

--- a/packages/agent-core-hatchery/src/agent_core_hatchery/daemon_probe.py
+++ b/packages/agent-core-hatchery/src/agent_core_hatchery/daemon_probe.py
@@ -51,17 +51,23 @@ def _stop_daemon(runner=subprocess.run) -> None:
         pass  # agent-core not on PATH or daemon already stopped — probe decides outcome
 
 
-def _start_daemon(runner=subprocess.run) -> None:
-    """Best-effort daemon start. Never raises; failures are absorbed."""
+def _start_daemon(runner=subprocess.run) -> bool:
+    """Start the daemon. Returns True iff the start command exited 0.
+
+    Unlike ``_stop_daemon``, a failed START is NOT best-effort: the daemon was
+    just stopped, so a failure here leaves the whole fleet offline. The result
+    is returned (not swallowed) so the caller can surface it loudly.
+    """
     try:
-        runner(
+        proc = runner(
             ["agent-core", "daemon", "start"],
             check=False,
             capture_output=True,
             timeout=15,
         )
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):
-        pass
+        return False
+    return proc.returncode == 0
 
 
 def _probe_endpoint(
@@ -119,7 +125,11 @@ def reload_and_probe(
     host, port = read_daemon_http_config(daemon_config_dir)
 
     _stop_daemon(runner)
-    _start_daemon(runner)
+    if not _start_daemon(runner):
+        # The daemon was stopped but could not be brought back up — the whole
+        # fleet is offline. Surface as a hard failure, not a soft "unreachable"
+        # (which reads as "daemon up, endpoint will register shortly").
+        return "start_failed"
 
     return _probe_endpoint(
         host,

--- a/packages/agent-core-hatchery/src/agent_core_hatchery/hatcher.py
+++ b/packages/agent-core-hatchery/src/agent_core_hatchery/hatcher.py
@@ -26,6 +26,12 @@ class VaultExistsError(Exception):
     """Raised when default-mode hatch is attempted against an existing vault."""
 
 
+class HatchError(RuntimeError):
+    """Raised when a hatch cannot complete because a required subsystem is
+    unavailable — surfaced as a clear, actionable message rather than a cryptic
+    ImportError deep in the build."""
+
+
 @dataclass
 class HatchResult:
     vault_root: Path
@@ -261,10 +267,22 @@ class Hatcher:
                 daemon_config_dir=self._config.resolved_daemon_config_dir(),
             )
         else:
-            # C2-2 (#316): not yet merged. This lazy import resolves once #316 lands.
+            # C2-2 (#316): not yet merged. Fail with a clear, actionable error
+            # instead of a bare ImportError surfacing after the venv is built —
+            # a real (non-injected) hatch cannot complete until #316 lands.
             # Expected module path: agent_core.venv.mcp_config (confirm on merge).
             # Expected contract: generate_mcp_json(target, *, vault_root, ...) -> Path
-            from agent_core.venv.mcp_config import generate_mcp_json  # type: ignore[import]
+            try:
+                from agent_core.venv.mcp_config import (  # type: ignore[import-not-found]
+                    generate_mcp_json,
+                )
+            except ImportError as exc:
+                raise HatchError(
+                    "Cannot generate the being's .mcp.json: the canonical "
+                    "generator agent_core.venv.mcp_config (C2-2, #316) is not "
+                    "yet available, so a real hatch cannot complete. Inject "
+                    "_mcp_json_gen to hatch before #316 merges."
+                ) from exc
             path = generate_mcp_json(
                 self._config.being_name_lower,
                 vault_root=self._config.resolved_vault_root(),

--- a/packages/agent-core-hatchery/src/agent_core_hatchery/report.py
+++ b/packages/agent-core-hatchery/src/agent_core_hatchery/report.py
@@ -9,7 +9,13 @@ from typing import Literal
 from agent_core_hatchery.config import HatchConfig
 from agent_core_hatchery.hatcher import HatchResult
 
-DaemonCheckStatus = Literal["reachable_and_registered", "reachable_but_missing", "unreachable", "skipped"]
+DaemonCheckStatus = Literal[
+    "reachable_and_registered",
+    "reachable_but_missing",
+    "unreachable",
+    "start_failed",
+    "skipped",
+]
 
 
 def write_hatching_report(
@@ -36,6 +42,11 @@ def write_hatching_report(
         parts.append("- ⚠ Daemon reachable but endpoint NOT visible — fragment merge may have failed. Check daemon logs.\n")
     elif daemon_check_status == "unreachable":
         parts.append("- ⚠ Daemon healthcheck unreachable — endpoint will register on next daemon start.\n")
+    elif daemon_check_status == "start_failed":
+        parts.append(
+            "- ✗ Daemon FAILED to restart after hatch — the fleet may be OFFLINE. "
+            "Run `agent-core daemon start` now and check the daemon logs.\n"
+        )
     else:
         parts.append("- — daemon check skipped.\n")
 
@@ -56,7 +67,7 @@ def write_hatching_report(
         )
         step_idx += 1
 
-    if daemon_check_status in ("unreachable", "reachable_but_missing"):
+    if daemon_check_status in ("unreachable", "reachable_but_missing", "start_failed"):
         parts.append(
             f"{step_idx}. **ACTION REQUIRED.** Restart the agent-core daemon and verify the new endpoint registers. "
             f"`agent-core endpoints list` should include `{config.endpoint_name}`.\n\n"

--- a/packages/agent-core-hatchery/tests/test_daemon_probe.py
+++ b/packages/agent-core-hatchery/tests/test_daemon_probe.py
@@ -208,3 +208,56 @@ class TestReloadAndProbe:
 
         result = reload_and_probe(cfg)
         assert result == "unreachable"
+
+
+class TestStartFailureSurfacing:
+    """Adversarial review #6: a failed daemon start (fleet offline) must be a
+    hard, distinct outcome — not swallowed like a best-effort stop."""
+
+    def test_start_returns_false_on_nonzero_returncode(self) -> None:
+        def runner(cmd, **kw):
+            class _R:
+                returncode = 3
+
+            return _R()
+
+        assert _start_daemon(runner=runner) is False
+
+    def test_start_returns_true_on_success(self) -> None:
+        def runner(cmd, **kw):
+            class _R:
+                returncode = 0
+
+            return _R()
+
+        assert _start_daemon(runner=runner) is True
+
+    def test_start_returns_false_on_exception(self) -> None:
+        def runner(cmd, **kw):
+            raise FileNotFoundError("agent-core not on PATH")
+
+        assert _start_daemon(runner=runner) is False
+
+    def test_reload_and_probe_reports_start_failed_when_start_fails(self, tmp_path) -> None:
+        from agent_core_hatchery.config import HatchConfig
+
+        cfg_dir = tmp_path / ".agent-core"
+        cfg_dir.mkdir()
+        (cfg_dir / "agent_core.yaml").write_text(
+            "http:\n  bind_host: 127.0.0.1\n  bind_port: 8789\n"
+        )
+        cfg = HatchConfig(
+            being_name="TestBeing",
+            primary_human_name="Tester",
+            vault_root=str(tmp_path),
+            daemon_config_dir=str(cfg_dir),
+        )
+
+        def runner(cmd, **kw):
+            # stop succeeds, start fails — daemon left down.
+            class _R:
+                returncode = 0 if cmd[-1] == "stop" else 1
+
+            return _R()
+
+        assert reload_and_probe(cfg, runner=runner) == "start_failed"

--- a/packages/agent-core-hatchery/tests/test_hatcher_basic.py
+++ b/packages/agent-core-hatchery/tests/test_hatcher_basic.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 from agent_core_hatchery.config import HatchConfig
-from agent_core_hatchery.hatcher import HatchError, Hatcher, VaultExistsError
+from agent_core_hatchery.hatcher import Hatcher, HatchError, VaultExistsError
 
 
 def _noop_venv_builder(target: str) -> Path:

--- a/packages/agent-core-hatchery/tests/test_hatcher_basic.py
+++ b/packages/agent-core-hatchery/tests/test_hatcher_basic.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 from agent_core_hatchery.config import HatchConfig
-from agent_core_hatchery.hatcher import Hatcher, VaultExistsError
+from agent_core_hatchery.hatcher import HatchError, Hatcher, VaultExistsError
 
 
 def _noop_venv_builder(target: str) -> Path:
@@ -167,3 +167,25 @@ def test_no_gendered_pronouns_in_rendered_vault(tmp_path):
         "Gendered pronoun(s) found in rendered vault (fix #81):\n"
         + "\n".join(violations[:20])
     )
+
+
+def test_hatch_without_injected_mcp_gen_fails_clearly(tmp_path):
+    """The real (non-injected) hatch path must fail with a clear HatchError.
+
+    ``_generate_mcp_json`` lazy-imports agent_core.venv.mcp_config (C2-2, #316),
+    which is not yet merged — so a real hatch cannot complete. Every other test
+    injects ``_mcp_json_gen``, hiding this; this drives the real path and pins a
+    clear, actionable error instead of a cryptic post-venv ImportError.
+    Adversarial review finding #5.
+    """
+    cfg = HatchConfig(
+        being_name="TestBeing",
+        primary_human_name="Tester",
+        vault_root=str(tmp_path),
+        daemon_config_dir=str(tmp_path / ".agent-core"),
+    )
+    # Inject only the venv builder to isolate the mcp path; leave _mcp_json_gen
+    # unset so the real generator import is exercised.
+    hatcher = Hatcher(cfg, _venv_builder=_noop_venv_builder)
+    with pytest.raises(HatchError, match="#316"):
+        hatcher.hatch()

--- a/packages/agent-core-voice/src/agent_core_voice/endpoint.py
+++ b/packages/agent-core-voice/src/agent_core_voice/endpoint.py
@@ -567,44 +567,65 @@ class VoiceEndpoint:
             )
             return
 
-        # Derive metadata from the madrigal Result. Timings list gives us
-        # per-chunk wall times — sum for elapsed_s, count for chunks.
-        timings = result.timings or []
-        elapsed_s = float(sum(timings))
-        sample_rate = int(result.sample_rate_hz)
-        chunks = max(1, len(timings))  # at least one chunk even on cache hit
+        # Reply-emitting tail. Everything here — stat(), model_dump(), envelope
+        # construction, publish — must still yield a terminal reply on failure:
+        # this runs in a spawned task, so an unhandled exception dies silently
+        # and the requesting agent waits forever. Route any failure through
+        # _publish_failed, and guard (don't assert) a torn-down handle.
+        try:
+            # Derive metadata from the madrigal Result. Timings list gives us
+            # per-chunk wall times — sum for elapsed_s, count for chunks.
+            timings = result.timings or []
+            elapsed_s = float(sum(timings))
+            sample_rate = int(result.sample_rate_hz)
+            chunks = max(1, len(timings))  # at least one chunk even on cache hit
 
-        ready_payload = SynthesisReadyPayload(
-            wav_path=str(wav_path),
-            file_size_bytes=wav_path.stat().st_size,
-            duration_s=duration_s,
-            elapsed_s=elapsed_s,
-            sample_rate_hz=sample_rate,
-            cache_hit=bool(result.cache_hit),
-            chunks=chunks,
-            retain_until=retain_until_iso(retain_s=retain_s),
-        )
+            ready_payload = SynthesisReadyPayload(
+                wav_path=str(wav_path),
+                file_size_bytes=wav_path.stat().st_size,
+                duration_s=duration_s,
+                elapsed_s=elapsed_s,
+                sample_rate_hz=sample_rate,
+                cache_hit=bool(result.cache_hit),
+                chunks=chunks,
+                retain_until=retain_until_iso(retain_s=retain_s),
+            )
 
-        import uuid as _uuid
+            import uuid as _uuid
 
-        from agent_core.bus.envelope import Envelope as BusEnvelope
-        from agent_core.bus.envelope import EventPayload
+            from agent_core.bus.envelope import Envelope as BusEnvelope
+            from agent_core.bus.envelope import EventPayload
 
-        ready = BusEnvelope(
-            id=_uuid.uuid4().hex,
-            correlation_id=envelope.correlation_id,
-            in_reply_to=envelope.id,
-            to=envelope.from_,
-            kind="Event",
-            payload=EventPayload(
-                type="SynthesisReady",
-                data=ready_payload.model_dump(),
-            ),
-            created_at=datetime.now(UTC),
-        )
+            ready = BusEnvelope(
+                id=_uuid.uuid4().hex,
+                correlation_id=envelope.correlation_id,
+                in_reply_to=envelope.id,
+                to=envelope.from_,
+                kind="Event",
+                payload=EventPayload(
+                    type="SynthesisReady",
+                    data=ready_payload.model_dump(),
+                ),
+                created_at=datetime.now(UTC),
+            )
 
-        assert self._handle is not None
-        await self._handle.publish(ready)
+            if self._handle is None:
+                # The endpoint was stopped before we could reply; there is no
+                # channel left to publish on. Log rather than raise.
+                log.warning(
+                    "voice handle torn down before SynthesisReady for %s; cannot reply",
+                    envelope.id,
+                )
+                return
+            await self._handle.publish(ready)
+        except Exception as exc:
+            log.exception("failed to emit SynthesisReady")
+            await self._publish_failed(
+                envelope,
+                reason="INTERNAL_ERROR",
+                message=f"failed to emit SynthesisReady: {type(exc).__name__}: {exc}",
+                retryable=False,
+            )
 
     async def _publish_failed(
         self,

--- a/packages/agent-core-voice/tests/test_endpoint.py
+++ b/packages/agent-core-voice/tests/test_endpoint.py
@@ -629,3 +629,61 @@ async def test_for_test_backend_skips_construction(
     assert construct_calls == [], (
         "for_test() path must not call QwenTTSBackend even when start() is invoked"
     )
+
+
+async def test_reply_tail_failure_still_publishes_synthesis_failed(
+    tmp_path: Path, ref_wav: Path
+) -> None:
+    """If publishing the SynthesisReady fails, the handler must still emit a
+    terminal SynthesisFailed — not die silently in its spawned task and hang
+    the requesting agent forever. Adversarial review finding #7.
+    """
+    import uuid
+    from datetime import UTC, datetime
+
+    from agent_core.bus.envelope import Envelope, EventPayload
+    from agent_core_voice.envelopes import SynthesisRequestPayload
+
+    class _FailFirstPublishHandle:
+        def __init__(self) -> None:
+            self.published: list[Any] = []
+            self._calls = 0
+
+        async def ack(self, env_id: str) -> None:
+            pass
+
+        async def publish(self, env: Any, to: Any = None) -> None:
+            self._calls += 1
+            if self._calls == 1:
+                raise RuntimeError("bus publish exploded")  # the SynthesisReady
+            self.published.append(env)  # the recovery SynthesisFailed
+
+    ep = VoiceEndpoint.for_test(
+        backend=FakeTTSBackend(),
+        voices={"alice": VoiceInfo(voice_id="alice", ref_wav=ref_wav, ref_text="r")},
+        output_dir=tmp_path / "out",
+        audit_path=tmp_path / "audit.jsonl",
+    )
+    await ep.start(_minimal_handle())
+    handle = _FailFirstPublishHandle()
+    ep._handle = handle  # type: ignore[assignment]
+    ep.register_agent("alice", "alice")
+
+    env_id = str(uuid.uuid4())
+    req_payload = SynthesisRequestPayload(text="hello world")
+    env = Envelope(
+        id=env_id,
+        correlation_id=env_id,
+        to="voice_test",
+        from_="alice",
+        kind="Event",
+        payload=EventPayload(type="SynthesisRequest", data=req_payload.model_dump()),
+        created_at=datetime.now(UTC),
+    )
+
+    # Must not raise despite the reply publish exploding.
+    await ep._handle_synthesis_request(env, req_payload)
+
+    # The caller still got a terminal reply.
+    assert len(handle.published) == 1
+    assert handle.published[0].payload.type == "SynthesisFailed"

--- a/packages/agent-core-webcam/src/agent_core_webcam/endpoint.py
+++ b/packages/agent-core-webcam/src/agent_core_webcam/endpoint.py
@@ -151,7 +151,22 @@ class WebcamEndpoint:
         res = _to_tuple(resolution) if resolution is not None else self.default_resolution
         lock = await self._lock_for(idx)
         async with lock:
-            png_bytes = await asyncio.to_thread(self._backend.capture, idx, res)
+            # Enforce capture_timeout_seconds at the async layer: a hung
+            # backend read (OpenCV's cap.read() is uninterruptible) would
+            # otherwise hold this per-camera lock forever, wedging every future
+            # capture on this camera. wait_for releases the lock and surfaces a
+            # ReadTimeoutError; the orphaned worker thread is the lesser evil
+            # than a permanently-stuck endpoint.
+            try:
+                png_bytes = await asyncio.wait_for(
+                    asyncio.to_thread(self._backend.capture, idx, res),
+                    timeout=self.capture_timeout_seconds,
+                )
+            except TimeoutError as exc:
+                raise ReadTimeoutError(
+                    f"camera {idx} did not return a frame within "
+                    f"{self.capture_timeout_seconds}s"
+                ) from exc
         timestamp = datetime.now(UTC).astimezone()
         try:
             all_cams = await asyncio.to_thread(self._backend.list_cameras)

--- a/packages/agent-core-webcam/tests/test_endpoint_capture_errors.py
+++ b/packages/agent-core-webcam/tests/test_endpoint_capture_errors.py
@@ -158,3 +158,42 @@ async def test_invalid_resolution_returns_clean_error(tmp_path, fake_backend):
     assert "invalid resolution" in result.message.lower()
     line = json.loads(ep.audit_log.path.read_text(encoding="utf-8").strip().splitlines()[-1])
     assert line["data"]["error"].startswith("invalid resolution")
+
+
+async def test_capture_timeout_releases_lock_and_raises(tmp_path):
+    """A hung backend read must time out and release the per-camera lock.
+
+    OpenCV's cap.read() is uninterruptible; without wait_for a hung read holds
+    the per-camera lock forever, wedging every future capture on that camera.
+    Adversarial review finding #4.
+    """
+    import threading
+
+    import pytest
+
+    from agent_core_webcam.protocol import ReadTimeoutError
+
+    release = threading.Event()
+
+    class _HangingBackend:
+        def list_cameras(self):
+            return []
+
+        def capture(self, index, resolution):
+            release.wait(timeout=5.0)  # block until released (safety-capped)
+            return b"never"
+
+    ep = WebcamEndpoint(
+        name="webcam-test",
+        captures_root=tmp_path / "captures",
+        audit_log_path=tmp_path / "audit.jsonl",
+        camera_backend=_HangingBackend(),
+        capture_timeout_seconds=0.05,
+    )
+    try:
+        with pytest.raises(ReadTimeoutError):
+            await ep.capture_frame(camera_index=0, save=False)
+        lock = await ep._lock_for(0)
+        assert not lock.locked()  # lock released despite the hung read
+    finally:
+        release.set()  # let the orphaned worker thread exit

--- a/packages/core/src/agent_core/bus/persistence.py
+++ b/packages/core/src/agent_core/bus/persistence.py
@@ -96,27 +96,37 @@ class Persistence:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         existed = self.path.exists()
         self._conn = await aiosqlite.connect(self.path)
-        await self._conn.execute("PRAGMA journal_mode=WAL")
-        await self._conn.execute("PRAGMA foreign_keys=ON")
-        await self._conn.executescript(_SCHEMA)
-        # Migrate legacy DBs that pre-date the urgency column. Using a
-        # PRAGMA-driven check keeps this idempotent without try/except
-        # OperationalError.
-        self._conn.row_factory = aiosqlite.Row
-        cur = await self._conn.execute("PRAGMA table_info(envelopes)")
-        cols = {row["name"] async for row in cur}
-        await cur.close()
-        if "urgency" not in cols:
-            await self._conn.execute(
-                "ALTER TABLE envelopes ADD COLUMN urgency TEXT NOT NULL DEFAULT 'green'"
-            )
-        if "next_attempt_at" not in cols:
-            await self._conn.execute(
-                "ALTER TABLE envelopes ADD COLUMN next_attempt_at TIMESTAMP"
-            )
-        await self._conn.commit()
-        if not existed and sys.platform != "win32":
-            os.chmod(self.path, 0o600)
+        # connect() must be atomic: any failure after the connection opens
+        # (locked/full/corrupt DB, migration error) must close it, else the
+        # aiosqlite worker thread leaks. Across daemon restarts and the test
+        # suite these accumulate until the event loop chokes and a random test
+        # times out. See the scheduler-engine leak (agent_core #468).
+        try:
+            await self._conn.execute("PRAGMA journal_mode=WAL")
+            await self._conn.execute("PRAGMA foreign_keys=ON")
+            await self._conn.executescript(_SCHEMA)
+            # Migrate legacy DBs that pre-date the urgency column. Using a
+            # PRAGMA-driven check keeps this idempotent without try/except
+            # OperationalError.
+            self._conn.row_factory = aiosqlite.Row
+            cur = await self._conn.execute("PRAGMA table_info(envelopes)")
+            cols = {row["name"] async for row in cur}
+            await cur.close()
+            if "urgency" not in cols:
+                await self._conn.execute(
+                    "ALTER TABLE envelopes ADD COLUMN urgency TEXT NOT NULL DEFAULT 'green'"
+                )
+            if "next_attempt_at" not in cols:
+                await self._conn.execute(
+                    "ALTER TABLE envelopes ADD COLUMN next_attempt_at TIMESTAMP"
+                )
+            await self._conn.commit()
+            if not existed and sys.platform != "win32":
+                os.chmod(self.path, 0o600)
+        except BaseException:
+            await self._conn.close()
+            self._conn = None
+            raise
 
     async def close(self) -> None:
         if self._conn is not None:

--- a/packages/core/tests/bus/test_persistence.py
+++ b/packages/core/tests/bus/test_persistence.py
@@ -248,3 +248,25 @@ class TestBackoffPersistence:
         row = await store.row(env.id)
         assert row["state"] == "pending"
         assert row["next_attempt_at"] is None
+
+
+async def test_connect_is_atomic_and_closes_connection_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """connect() must close the connection if any post-open step raises.
+
+    Otherwise the aiosqlite worker thread leaks; across daemon restarts and the
+    test suite these accumulate until the event loop chokes and a random test
+    times out. Regression sibling of the scheduler-engine leak (agent_core #468).
+    The autouse leak guard additionally asserts no aiosqlite thread survives.
+    """
+    import agent_core.bus.persistence as persist_mod
+
+    # Force the first post-open step (schema apply) to fail.
+    monkeypatch.setattr(persist_mod, "_SCHEMA", "THIS IS NOT VALID SQL;")
+    p = Persistence(tmp_path / "bus.sqlite")
+
+    with pytest.raises(Exception):
+        await p.connect()
+
+    assert p._conn is None  # connection was closed and cleared on failure

--- a/packages/core/tests/bus/test_persistence.py
+++ b/packages/core/tests/bus/test_persistence.py
@@ -260,13 +260,15 @@ async def test_connect_is_atomic_and_closes_connection_on_failure(
     times out. Regression sibling of the scheduler-engine leak (agent_core #468).
     The autouse leak guard additionally asserts no aiosqlite thread survives.
     """
+    import sqlite3
+
     import agent_core.bus.persistence as persist_mod
 
     # Force the first post-open step (schema apply) to fail.
     monkeypatch.setattr(persist_mod, "_SCHEMA", "THIS IS NOT VALID SQL;")
     p = Persistence(tmp_path / "bus.sqlite")
 
-    with pytest.raises(Exception):
+    with pytest.raises(sqlite3.OperationalError):
         await p.connect()
 
     assert p._conn is None  # connection was closed and cleared on failure

--- a/packages/credentials/src/agent_core_credentials/store.py
+++ b/packages/credentials/src/agent_core_credentials/store.py
@@ -41,7 +41,29 @@ class CredentialStore:
         return result
 
     def _open(self) -> PyKeePass:
-        """Open the vault, creating it if it doesn't exist."""
+        """Open the existing vault; raise ``FileNotFoundError`` if it's absent.
+
+        Reads and deletes must NOT create a vault — silently creating an empty
+        ``.kdbx`` on a read masks a missing or misconfigured vault (and can
+        shadow the real one). Only the write path may create; see
+        :meth:`_open_or_create`.
+        """
+        # Validate the master-password config first (a config error is more
+        # fundamental), then require the vault to already exist.
+        password = self._get_password()
+        if not self.vault_path.exists():
+            raise FileNotFoundError(
+                f"credentials vault not found at {self.vault_path}; "
+                "set a credential (or run the init command) to create it"
+            )
+        return PyKeePass(str(self.vault_path), password=password)
+
+    def _open_or_create(self) -> PyKeePass:
+        """Open the vault, creating an empty one if it's absent.
+
+        Only the explicit write path (:meth:`set`) may call this — a missing
+        vault on first write is expected.
+        """
         password = self._get_password()
         if not self.vault_path.exists():
             return create_database(str(self.vault_path), password=password)
@@ -70,8 +92,8 @@ class CredentialStore:
         url: str = "",
         notes: str = "",
     ) -> None:
-        """Store or overwrite a credential."""
-        kp = self._open()
+        """Store or overwrite a credential (creates the vault on first write)."""
+        kp = self._open_or_create()
         existing = kp.find_entries(title=service, first=True)
         if existing:
             existing.username = username

--- a/packages/credentials/tests/test_store.py
+++ b/packages/credentials/tests/test_store.py
@@ -45,7 +45,8 @@ def test_set_and_get(vault):
 
 
 def test_get_missing_returns_none(vault):
-    """Getting a nonexistent service returns None."""
+    """Getting a nonexistent service from an existing vault returns None."""
+    vault.set("seed", "u@test.com", "p")  # create the vault first
     assert vault.get("nonexistent") is None
 
 
@@ -79,8 +80,34 @@ def test_delete_existing(vault):
 
 
 def test_delete_missing_returns_false(vault):
-    """Delete on nonexistent service returns False."""
+    """Delete of a nonexistent service in an existing vault returns False."""
+    vault.set("seed", "u@test.com", "p")  # create the vault first
     assert vault.delete("nonexistent") is False
+
+
+def test_reads_do_not_create_vault(tmp_path, monkeypatch):
+    """get/list/delete must NOT create an empty vault when it's absent.
+
+    Silently creating an empty .kdbx on a read masks a missing/misconfigured
+    vault and can shadow the real one. They must raise FileNotFoundError, and no
+    file may appear. Only the write path (set) creates. Adversarial review #8.
+    """
+    monkeypatch.setattr(
+        "agent_core_credentials.store.get_master_password",
+        lambda vault_path: "pw",
+    )
+    vault_path = tmp_path / "credentials.kdbx"
+    store = CredentialStore(vault_path)
+
+    for op in (lambda: store.get("x"), store.list, lambda: store.delete("x")):
+        with pytest.raises(FileNotFoundError):
+            op()
+        assert not vault_path.exists()  # no empty vault was created
+
+    # The write path DOES create it.
+    store.set("apex", "jeff@test.com", "secret")
+    assert vault_path.exists()
+    assert store.get("apex") is not None
 
 
 def test_creates_vault_on_first_set(vault, tmp_path):

--- a/packages/credentials/tests/test_store.py
+++ b/packages/credentials/tests/test_store.py
@@ -85,29 +85,25 @@ def test_delete_missing_returns_false(vault):
     assert vault.delete("nonexistent") is False
 
 
-def test_reads_do_not_create_vault(tmp_path, monkeypatch):
+def test_reads_do_not_create_vault(vault, tmp_path):
     """get/list/delete must NOT create an empty vault when it's absent.
 
     Silently creating an empty .kdbx on a read masks a missing/misconfigured
     vault and can shadow the real one. They must raise FileNotFoundError, and no
     file may appear. Only the write path (set) creates. Adversarial review #8.
     """
-    monkeypatch.setattr(
-        "agent_core_credentials.store.get_master_password",
-        lambda vault_path: "pw",
-    )
-    vault_path = tmp_path / "credentials.kdbx"
-    store = CredentialStore(vault_path)
+    vault_path = tmp_path / "credentials.kdbx"  # the fixture's path, not yet created
+    assert not vault_path.exists()
 
-    for op in (lambda: store.get("x"), store.list, lambda: store.delete("x")):
+    for op in (lambda: vault.get("x"), vault.list, lambda: vault.delete("x")):
         with pytest.raises(FileNotFoundError):
             op()
         assert not vault_path.exists()  # no empty vault was created
 
     # The write path DOES create it.
-    store.set("apex", "jeff@test.com", "secret")
+    vault.set("apex", "jeff@test.com", "secret")
     assert vault_path.exists()
-    assert store.get("apex") is not None
+    assert vault.get("apex") is not None
 
 
 def test_creates_vault_on_first_set(vault, tmp_path):


### PR DESCRIPTION
Fixes 6 HIGH findings from the adversarial test-and-system review (ranks #1, #4–#8).

- **#1 bus/persistence** — `Persistence.connect()` leaked its aiosqlite connection thread if any post-open step (schema/migration/PRAGMA) raised. Made connect atomic: close+clear on failure. Sibling of the scheduler-engine leak (#468).
- **#4 webcam** — `capture_timeout_seconds` was advertised but never enforced; a hung `cap.read()` held the per-camera lock forever. Wrap the blocking capture in `asyncio.wait_for` → `ReadTimeoutError`, releasing the lock.
- **#5 hatchery** — the default `_generate_mcp_json` imported `agent_core.venv.mcp_config` (C2-2/#316, not merged), so every real hatch crashed with a cryptic ImportError after building the venv. Raise a clear `HatchError`; add a test driving the non-injected path (every other test injected `_mcp_json_gen`, hiding it).
- **#6 hatchery** — `reload_and_probe` stopped the shared daemon then swallowed a failed start, so hatching one being could take the whole fleet offline behind a green exit. New `start_failed` status renders loudly and exits non-zero.
- **#7 voice** — the SynthesisReady reply tail ran outside any try/except in a spawned task; any failure (stat/model_dump/publish, torn-down handle) died silently and hung the requester forever. Wrap it, route failures through `_publish_failed`, guard the handle.
- **#8 credentials** — `_open()` created an empty `.kdbx` when absent, and get/list/delete all went through it, so a read silently created (and could shadow) a vault. Reads now raise `FileNotFoundError`; only `set` creates.

Each fix is TDD (failing test → fix), the affected packages are green, and `just check` passes. Full report: the review artifact.
