### PR TITLE
feat: mypy --strict for agent-core-discord + log CancelledError swallows (closes #444)

### DIFF
--- a/packages/agent-core-discord/src/agent_core_discord/_acks.py
+++ b/packages/agent-core-discord/src/agent_core_discord/_acks.py
@@ -9,11 +9,14 @@ from __future__ import annotations
 import contextlib
 import logging
 import time
+from typing import Any
+
+from agent_core_discord._state import _EndpointState
 
 log = logging.getLogger(__name__)
 
 
-class _AcksMixin:
+class _AcksMixin(_EndpointState):
     def _track_pending_ack(self, message_id: str, emoji: str, channel_id: str) -> None:
         """Record a pending ack and evict the oldest entry if we hit the cap.
 
@@ -26,6 +29,7 @@ class _AcksMixin:
             old_id, (old_emoji, old_ch, _ts) = self._pending_acks.popitem(last=False)
             self._awaiting_reply_ids.discard(old_id)
             self._awaiting_reply_ids_timestamps.pop(old_id, None)
+            assert self._handle is not None
             self._handle.spawn(
                 self._remote_remove_ack(old_id, old_emoji, old_ch),
                 name=f"discord-endpoint-{self.name}-evict-ack",
@@ -51,7 +55,7 @@ class _AcksMixin:
                 exc_info=True,
             )
 
-    async def _clear_pending_ack(self, channel, message_id: str) -> None:
+    async def _clear_pending_ack(self, channel: Any, message_id: str) -> None:
         mid = str(message_id)
         self._awaiting_reply_ids.discard(mid)
         self._awaiting_reply_ids_timestamps.pop(mid, None)

--- a/packages/agent-core-discord/src/agent_core_discord/_handlers.py
+++ b/packages/agent-core-discord/src/agent_core_discord/_handlers.py
@@ -11,13 +11,14 @@ import logging
 import re
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from agent_core.bus.envelope import Envelope, EventPayload, TextMessagePayload
 from agent_core_discord._exceptions import _ToolError
+from agent_core_discord._state import _EndpointState
 from agent_core_discord.access import InboundContext, gate_message
 from agent_core_discord.sigil import parse_sigil
 from agent_core_discord.text_sanitize import scrub_surrogates
@@ -32,7 +33,7 @@ def _redact_url_qs(text: str) -> str:
     return re.sub(r"(https?://[^\s?]+)\?\S*", r"\1?<redacted>", text)
 
 
-class _HandlersMixin:
+class _HandlersMixin(_EndpointState):
     def _add_listener(self, handler: Callable[..., Any], event_name: str) -> None:
         """Register an event handler against the discord.py client.
 
@@ -45,7 +46,7 @@ class _HandlersMixin:
         else:
             # Older fakes / minimal stubs: rebind the handler's name and use
             # the @client.event protocol as a fallback.
-            handler.__name__ = event_name  # type: ignore[attr-defined]
+            handler.__name__ = event_name
             self._client.event(handler)
 
     def _remember_inbound_mapping(
@@ -82,7 +83,7 @@ class _HandlersMixin:
         # 1. Explicit always wins.
         discord_meta = (outbound.metadata or {}).get("discord") or {}
         if explicit := discord_meta.get("channel_id"):
-            return explicit
+            return str(explicit)
 
         # 2. Auto-echo via in_reply_to cache lookup.
         if outbound.in_reply_to:
@@ -90,7 +91,7 @@ class _HandlersMixin:
             if inbound:
                 inbound_discord = (inbound.metadata or {}).get("discord") or {}
                 if cid := inbound_discord.get("channel_id"):
-                    return cid
+                    return str(cid)
                 log.warning(
                     "channel_id resolution failed: cached_inbound_missing_channel_id, "
                     "in_reply_to=%s", outbound.in_reply_to,
@@ -148,7 +149,7 @@ class _HandlersMixin:
                 exc_info=True,
             )
 
-    def _make_on_message_handler(self):
+    def _make_on_message_handler(self) -> Callable[[Any], Coroutine[Any, Any, None]]:
         async def on_message(message: Any) -> None:
             # 1. Filter our OWN messages only — self-loops would feed the
             # bot its own posts. Other bots are NOT pre-filtered here:
@@ -364,7 +365,9 @@ class _HandlersMixin:
             return True
         return channel_id in self._access.channels
 
-    def _make_on_reaction_add_handler(self):
+    def _make_on_reaction_add_handler(
+        self,
+    ) -> Callable[[Any, Any], Coroutine[Any, Any, None]]:
         async def on_reaction_add(reaction: Any, user: Any) -> None:
             # 1. Drop the bot's own reactions.
             if user == self._client.user or user.bot:
@@ -440,7 +443,9 @@ class _HandlersMixin:
             self._user_display_name_cache[user_id_str] = name
         return name
 
-    def _make_on_raw_poll_vote_handler(self, event_type: str):
+    def _make_on_raw_poll_vote_handler(
+        self, event_type: str
+    ) -> Callable[[Any], Coroutine[Any, Any, None]]:
         """Build a handler for ``on_raw_poll_vote_add`` / ``on_raw_poll_vote_remove``.
 
         Both events have identical payload shape (``RawPollVoteActionEvent``
@@ -495,7 +500,9 @@ class _HandlersMixin:
 
         return on_raw_poll_vote
 
-    def _make_on_raw_message_lifecycle_handler(self, event_type: str):
+    def _make_on_raw_message_lifecycle_handler(
+        self, event_type: str
+    ) -> Callable[[Any], Coroutine[Any, Any, None]]:
         """Build a handler for ``on_raw_message_edit`` / ``on_raw_message_delete``.
 
         Both raw events expose ``message_id``, ``channel_id``, ``guild_id``

--- a/packages/agent-core-discord/src/agent_core_discord/_lifecycle.py
+++ b/packages/agent-core-discord/src/agent_core_discord/_lifecycle.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 from agent_core_credentials.secrets import SecretNotFoundError
 from agent_core_credentials.secrets import get as get_secret
 from agent_core_discord._state import _EndpointState
-from agent_core_discord.access import AccessConfig, _build_access_config, load_access_config
+from agent_core_discord.access import _build_access_config, load_access_config
 
 if TYPE_CHECKING:
     from agent_core.bus.handle import BusHandle
@@ -111,9 +111,7 @@ class _LifecycleMixin(_EndpointState):
         for d in entries:
             try:
                 mtime = d.stat().st_mtime
-                size = sum(
-                    f.stat().st_size for f in d.rglob("*") if f.is_file()
-                )
+                size = sum(f.stat().st_size for f in d.rglob("*") if f.is_file())
             except OSError:
                 continue
             if mtime < cutoff:
@@ -384,7 +382,10 @@ class _LifecycleMixin(_EndpointState):
                 try:
                     await self._sweep_task
                 except asyncio.CancelledError:
-                    pass
+                    log.debug(
+                        "discord endpoint '%s': sweep task cancelled cleanly during start rollback",
+                        self.name,
+                    )
                 except Exception:
                     log.exception(
                         "discord endpoint '%s': sweep task raised during start rollback",
@@ -395,7 +396,10 @@ class _LifecycleMixin(_EndpointState):
                 try:
                     await self._attachment_sweep_task
                 except asyncio.CancelledError:
-                    pass
+                    log.debug(
+                        "discord endpoint '%s': attachment sweep cancelled cleanly during start rollback",
+                        self.name,
+                    )
                 except Exception:
                     log.exception(
                         "discord endpoint '%s': attachment sweep raised during start rollback",
@@ -406,7 +410,10 @@ class _LifecycleMixin(_EndpointState):
                 try:
                     await self._access_reload_task
                 except asyncio.CancelledError:
-                    pass
+                    log.debug(
+                        "discord endpoint '%s': access reload task cancelled cleanly during start rollback",
+                        self.name,
+                    )
                 except Exception:
                     log.exception(
                         "discord endpoint '%s': access reload task raised during start rollback",
@@ -418,7 +425,10 @@ class _LifecycleMixin(_EndpointState):
                 try:
                     await self._client_task
                 except asyncio.CancelledError:
-                    pass
+                    log.debug(
+                        "discord endpoint '%s': gateway task cancelled cleanly during start rollback",
+                        self.name,
+                    )
                 except Exception:
                     log.exception(
                         "discord endpoint '%s': gateway task raised during start rollback",
@@ -470,7 +480,10 @@ class _LifecycleMixin(_EndpointState):
             try:
                 await self._sweep_task
             except asyncio.CancelledError:
-                pass
+                log.debug(
+                    "discord endpoint '%s': sweep task cancelled cleanly during stop",
+                    self.name,
+                )
             except Exception:
                 log.exception(
                     "discord endpoint '%s': sweep task raised during stop",
@@ -481,7 +494,10 @@ class _LifecycleMixin(_EndpointState):
             try:
                 await self._attachment_sweep_task
             except asyncio.CancelledError:
-                pass
+                log.debug(
+                    "discord endpoint '%s': attachment sweep cancelled cleanly during stop",
+                    self.name,
+                )
             except Exception:
                 log.exception(
                     "discord endpoint '%s': attachment sweep raised during stop",
@@ -492,7 +508,10 @@ class _LifecycleMixin(_EndpointState):
             try:
                 await self._access_reload_task
             except asyncio.CancelledError:
-                pass
+                log.debug(
+                    "discord endpoint '%s': access reload task cancelled cleanly during stop",
+                    self.name,
+                )
             except Exception:
                 log.exception(
                     "discord endpoint '%s': access reload task raised during stop",
@@ -504,7 +523,10 @@ class _LifecycleMixin(_EndpointState):
             try:
                 await self._client_task
             except asyncio.CancelledError:
-                pass
+                log.debug(
+                    "discord endpoint '%s': gateway task cancelled cleanly during stop",
+                    self.name,
+                )
             except Exception:
                 log.exception(
                     "discord endpoint '%s': gateway task raised during stop",

--- a/packages/agent-core-discord/src/agent_core_discord/_lifecycle.py
+++ b/packages/agent-core-discord/src/agent_core_discord/_lifecycle.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from agent_core_credentials.secrets import SecretNotFoundError
 from agent_core_credentials.secrets import get as get_secret
+from agent_core_discord._state import _EndpointState
 from agent_core_discord.access import AccessConfig, _build_access_config, load_access_config
 
 if TYPE_CHECKING:
@@ -24,7 +25,7 @@ log = logging.getLogger(__name__)
 _active_endpoints: dict[str, Any] = {}
 
 
-class _LifecycleMixin:
+class _LifecycleMixin(_EndpointState):
     def _sweep_recent_inbounds_once(self) -> int:
         """Evict entries older than TTL; return count evicted.
 
@@ -61,6 +62,7 @@ class _LifecycleMixin:
             self._pending_acks.pop(head_id)
             self._awaiting_reply_ids.discard(head_id)
             self._awaiting_reply_ids_timestamps.pop(head_id, None)
+            assert self._handle is not None
             self._handle.spawn(
                 self._remote_remove_ack(head_id, emoji, channel_id),
                 name=f"discord-endpoint-{self.name}-ttl-ack",

--- a/packages/agent-core-discord/src/agent_core_discord/_outbound.py
+++ b/packages/agent-core-discord/src/agent_core_discord/_outbound.py
@@ -17,6 +17,7 @@ from pydantic import ValidationError
 from agent_core.bus.envelope import AcknowledgmentPayload, Envelope, TextMessagePayload
 from agent_core.bus.protocol import EndpointUnavailable
 from agent_core_discord._exceptions import _ToolError
+from agent_core_discord._state import _EndpointState
 from agent_core_discord.args import (
     _CancelScheduledEventArgs,
     _CreatePollArgs,
@@ -146,7 +147,7 @@ def _serialize_poll(poll: Any) -> dict[str, Any] | None:
     }
 
 
-class _OutboundMixin:
+class _OutboundMixin(_EndpointState):
     async def deliver(self, envelope: Envelope) -> None:
         """Handle ToolInvocation and TextMessage envelopes."""
         if self._handle is None:
@@ -257,7 +258,7 @@ class _OutboundMixin:
 
         await self._handle.ack(envelope.id)
 
-    async def _deliver_text_message(self, envelope: Envelope) -> dict:
+    async def _deliver_text_message(self, envelope: Envelope) -> dict[str, Any]:
         """Route a bus TextMessage to Discord send.
 
         If ``metadata.discord.embeds`` is set, the embed dicts ride along
@@ -335,10 +336,10 @@ class _OutboundMixin:
         )
         return await self._send(args)
 
-    async def _dispatch(self, tool: str, args: dict, env: Envelope) -> Any:
+    async def _dispatch(self, tool: str, args: dict[str, Any], env: Envelope) -> Any:
         tool = _canonical_tool(tool)
 
-        def _v(model: Any, raw: dict) -> Any:
+        def _v(model: Any, raw: dict[str, Any]) -> Any:
             try:
                 return model(**raw)
             except ValidationError as exc:
@@ -346,7 +347,7 @@ class _OutboundMixin:
 
         # For tools that require channel_id, inject it via _resolve_channel_id
         # when the caller omitted it (auto-echo via in_reply_to cache).
-        def _inject_channel_id(raw: dict) -> dict:
+        def _inject_channel_id(raw: dict[str, Any]) -> dict[str, Any]:
             if "channel_id" not in raw or not raw["channel_id"]:
                 raw = dict(raw)
                 raw["channel_id"] = self._resolve_channel_id(env)
@@ -420,7 +421,7 @@ class _OutboundMixin:
         except Exception:
             log.exception("discord reply publish failed for %s", incoming.id)
 
-    async def _resolve_channel(self, channel_id: str):
+    async def _resolve_channel(self, channel_id: str) -> Any:
         ch = self._client.get_channel(channel_id) if self._client else None
         if ch is None and self._client is not None:
             try:
@@ -431,7 +432,7 @@ class _OutboundMixin:
             raise _ToolError(f"channel '{channel_id}' not found")
         return ch
 
-    async def _send(self, args: _SendArgs) -> dict:
+    async def _send(self, args: _SendArgs) -> dict[str, Any]:
         if args.text is None and not args.embeds and not args.files:
             raise _ToolError(
                 "send: one of 'text', 'embeds', or 'files' is required"
@@ -439,11 +440,13 @@ class _OutboundMixin:
         ch = await self._resolve_channel(args.channel_id)
 
         # Build embeds list (validate via discord.Embed.from_dict).
-        embeds = None
+        # Holds discord.Embed objects on the real path or raw dicts on the
+        # fake-client fallback, so the element type is intentionally Any.
+        embeds: list[Any] | None = None
         if args.embeds:
             _check_embeds_within_caps(args.embeds)
             try:
-                import discord  # type: ignore
+                import discord
 
                 embeds = [discord.Embed.from_dict(e) for e in args.embeds]
             except ImportError:
@@ -462,14 +465,16 @@ class _OutboundMixin:
             if target is None:
                 raise _ToolError(f"send: reply_to message '{args.reply_to}' not found")
             try:
-                import discord  # type: ignore
+                import discord
 
                 reference = discord.MessageReference.from_message(target)
             except (ImportError, AttributeError):
                 # Fakes don't need a real reference; pass the message itself as a marker.
                 reference = target
 
-        files = None
+        # Holds discord.File objects on the real path or raw path strings on
+        # the fake-client fallback, so the element type is intentionally Any.
+        files: list[Any] | None = None
         if args.files:
             # discord.File accepts a local path or a binary file-like object —
             # not an HTTP URL. Reject URL strings upfront with a clear message
@@ -481,7 +486,7 @@ class _OutboundMixin:
                         "Use download_attachments first if you need URL bytes."
                     )
             try:
-                import discord  # type: ignore
+                import discord
 
                 files = [discord.File(f) for f in args.files]
             except ImportError:
@@ -565,7 +570,7 @@ class _OutboundMixin:
             out["message_id"] = message_ids[-1]
         return out
 
-    async def _edit(self, args: _EditArgs) -> dict:
+    async def _edit(self, args: _EditArgs) -> dict[str, Any]:
         if args.text is None and not args.embeds:
             raise _ToolError("edit: one of 'text' or 'embeds' is required")
         ch = await self._resolve_channel(args.channel_id)
@@ -576,11 +581,12 @@ class _OutboundMixin:
         if msg is None:
             raise _ToolError(f"edit: message '{args.message_id}' not found")
 
-        embeds = None
+        # Embed objects on the real path or raw dicts on the fake fallback.
+        embeds: list[Any] | None = None
         if args.embeds:
             _check_embeds_within_caps(args.embeds)
             try:
-                import discord  # type: ignore
+                import discord
 
                 embeds = [discord.Embed.from_dict(e) for e in args.embeds]
             except ImportError:
@@ -601,7 +607,7 @@ class _OutboundMixin:
             await self._clear_pending_ack(ch, args.cleanup_inbound_message_id)
         return {"status": "edited", "message_id": args.message_id}
 
-    async def _react(self, args: _ReactArgs) -> dict:
+    async def _react(self, args: _ReactArgs) -> dict[str, Any]:
         ch = await self._resolve_channel(args.channel_id)
         try:
             msg = await ch.fetch_message(args.message_id)
@@ -616,9 +622,9 @@ class _OutboundMixin:
             await self._clear_pending_ack(ch, args.cleanup_inbound_message_id)
         return {"status": "reacted", "emoji": args.emoji}
 
-    async def _fetch(self, args: _FetchArgs) -> list[dict]:
+    async def _fetch(self, args: _FetchArgs) -> list[dict[str, Any]]:
         ch = await self._resolve_channel(args.channel_id)
-        out: list[dict] = []
+        out: list[dict[str, Any]] = []
         # discord.py's history() returns an async iterator; the fake provides one.
         before = None
         if args.before is not None:

--- a/packages/agent-core-discord/src/agent_core_discord/_state.py
+++ b/packages/agent-core-discord/src/agent_core_discord/_state.py
@@ -1,0 +1,150 @@
+"""Shared instance-state base for the five DiscordEndpoint mixins.
+
+``DiscordEndpoint`` composes five mixins (``_AcksMixin``, ``_LifecycleMixin``,
+``_HandlersMixin``, ``_OutboundMixin``, ``_ToolsMixin``). Every mixin method
+reads ``self._X`` state that is assigned once in ``DiscordEndpoint.__init__``
+and calls methods defined on *sibling* mixins. mypy type-checks each mixin
+class standalone, so without a common base it cannot resolve either the shared
+attributes or the cross-mixin method calls.
+
+``_EndpointState`` is that common base. It carries:
+
+* **class-level attribute annotations** (no assignments) for every shared
+  ``self._X`` — the authoritative types, read from ``DiscordEndpoint.__init__``.
+* **cross-mixin method declarations** under ``TYPE_CHECKING`` so a method
+  defined on one mixin resolves when called from another. These are pure
+  type declarations: the block never executes at runtime, so ``_EndpointState``
+  is an empty class at runtime and adds no behaviour of its own.
+
+Each mixin inherits ``_EndpointState``; ``DiscordEndpoint`` inherits all five
+(a shared diamond that C3 resolves cleanly).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+from collections.abc import Callable, Coroutine
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agent_core.bus.envelope import Envelope
+    from agent_core.bus.handle import BusHandle
+    from agent_core_discord.access import AccessConfig
+    from agent_core_discord.args import (
+        _CancelScheduledEventArgs,
+        _CreatePollArgs,
+        _CreateScheduledEventArgs,
+        _CreateThreadArgs,
+        _DownloadAttachmentsArgs,
+        _GetChannelInfoArgs,
+        _ListChannelsArgs,
+        _ListScheduledEventsArgs,
+        _SendArgs,
+        _SendBriefingArgs,
+        _SendTypingArgs,
+    )
+
+
+class _EndpointState:
+    """Type-only carrier for DiscordEndpoint's shared attributes and the
+    cross-mixin method surface. Not instantiated directly; each mixin inherits
+    it so standalone type-checking resolves shared state and sibling calls.
+    """
+
+    # --- Construction args / public config (set in DiscordEndpoint.__init__) ---
+    name: str
+    target: str
+    token_env: str
+    outbound_channel_id: str | None
+    env_file: Path | None
+    access_config_path: Path | None
+    attachments_dir: Path
+    pending_acks_max: int
+    pending_acks_ttl_seconds: float
+    pending_acks_sweep_seconds: float
+    attachment_retention_days: int
+    attachment_max_total_bytes: int
+    attachment_sweep_seconds: float
+    transcribe_voice: bool
+    whisper_model: str
+    transcribe_max_duration_secs: float
+    access_config_reload_interval: float
+    _TYPING_TTL_SECONDS: float
+
+    # --- Internal runtime state ---
+    _transcription_model: Any | None
+    _client_factory: Callable[..., Any] | None
+    _handle: BusHandle | None
+    _client: Any
+    _user_display_name_cache: dict[str, str]
+    _client_task: asyncio.Task[Any] | None
+    _sweep_task: asyncio.Task[Any] | None
+    _attachment_sweep_task: asyncio.Task[Any] | None
+    _ready_event: asyncio.Event
+    _access: AccessConfig
+    _pending_acks: OrderedDict[str, tuple[str, str, float]]
+    _inbound_envelope_discord: OrderedDict[str, tuple[str, str]]
+    _recent_inbounds: OrderedDict[str, Envelope]
+    _recent_inbounds_max: int
+    _recent_inbounds_ttl_seconds: float
+    _recent_inbounds_timestamps: dict[str, float]
+    _awaiting_reply_ids: set[str]
+    _awaiting_reply_ids_timestamps: dict[str, float]
+    _typing_tasks: set[asyncio.Task[Any]]
+    _access_reload_task: asyncio.Task[Any] | None
+    _access_config_mtime: tuple[float, int] | None
+
+    if TYPE_CHECKING:
+        # Cross-mixin method surface. Declared here so a method defined on one
+        # mixin resolves when called from another; the concrete implementation
+        # (and its docstring) lives on the owning mixin. Signatures must stay in
+        # lockstep with those implementations.
+
+        # _AcksMixin
+        def _track_pending_ack(self, message_id: str, emoji: str, channel_id: str) -> None: ...
+        async def _remote_remove_ack(
+            self, message_id: str, emoji: str, channel_id: str
+        ) -> None: ...
+        async def _clear_pending_ack(self, channel: Any, message_id: str) -> None: ...
+
+        # _HandlersMixin
+        def _add_listener(self, handler: Callable[..., Any], event_name: str) -> None: ...
+        def _resolve_channel_id(self, outbound: Envelope) -> str: ...
+        def _make_on_message_handler(
+            self,
+        ) -> Callable[[Any], Coroutine[Any, Any, None]]: ...
+        def _make_on_reaction_add_handler(
+            self,
+        ) -> Callable[[Any, Any], Coroutine[Any, Any, None]]: ...
+        def _make_on_raw_poll_vote_handler(
+            self, event_type: str
+        ) -> Callable[[Any], Coroutine[Any, Any, None]]: ...
+        def _make_on_raw_message_lifecycle_handler(
+            self, event_type: str
+        ) -> Callable[[Any], Coroutine[Any, Any, None]]: ...
+
+        # _OutboundMixin
+        async def _resolve_channel(self, channel_id: str) -> Any: ...
+        async def _send(self, args: _SendArgs) -> dict[str, Any]: ...
+
+        # _ToolsMixin
+        async def _persist_attachment(self, *, url: str, subdir: str) -> tuple[Path, int]: ...
+        async def _transcribe_audio(self, path: Path) -> str: ...
+        async def _send_briefing(self, args: _SendBriefingArgs) -> dict[str, Any]: ...
+        async def _send_typing(self, args: _SendTypingArgs) -> dict[str, Any]: ...
+        async def _download_attachments(self, args: _DownloadAttachmentsArgs) -> dict[str, Any]: ...
+        async def _list_channels(self, args: _ListChannelsArgs) -> list[dict[str, Any]]: ...
+        async def _get_channel_info(self, args: _GetChannelInfoArgs) -> dict[str, Any]: ...
+        async def _create_poll(self, args: _CreatePollArgs) -> dict[str, Any]: ...
+        async def _create_scheduled_event(
+            self, args: _CreateScheduledEventArgs
+        ) -> dict[str, Any]: ...
+        async def _cancel_scheduled_event(
+            self, args: _CancelScheduledEventArgs
+        ) -> dict[str, Any]: ...
+        async def _list_scheduled_events(
+            self, args: _ListScheduledEventsArgs
+        ) -> list[dict[str, Any]]: ...
+        async def _create_thread(self, args: _CreateThreadArgs) -> dict[str, Any]: ...

--- a/packages/agent-core-discord/src/agent_core_discord/_tools.py
+++ b/packages/agent-core-discord/src/agent_core_discord/_tools.py
@@ -16,6 +16,7 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 from agent_core_discord._exceptions import _PersistError, _ToolError
+from agent_core_discord._state import _EndpointState
 from agent_core_discord.args import (
     _CancelScheduledEventArgs,
     _CreatePollArgs,
@@ -72,7 +73,7 @@ def _safe_filename(url: str) -> str:
     return clean
 
 
-class _ToolsMixin:
+class _ToolsMixin(_EndpointState):
     async def _download_url(self, url: str) -> tuple[bytes, str]:
         """Fetch a URL's bytes + Content-Type header.
 
@@ -118,10 +119,10 @@ class _ToolsMixin:
         path.write_bytes(data)
         return path, len(data)
 
-    async def _download_attachments(self, args: _DownloadAttachmentsArgs) -> dict:
+    async def _download_attachments(self, args: _DownloadAttachmentsArgs) -> dict[str, Any]:
         if not args.attachment_urls:
             return {"saved": []}
-        saved: list[dict] = []
+        saved: list[dict[str, Any]] = []
         for url in args.attachment_urls:
             try:
                 path, nbytes = await self._persist_attachment(
@@ -147,8 +148,8 @@ class _ToolsMixin:
             )
         return {"saved": saved}
 
-    async def _list_channels(self, args: _ListChannelsArgs) -> list[dict]:
-        out: list[dict] = []
+    async def _list_channels(self, args: _ListChannelsArgs) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
         if self._client is None:
             return out
         for g in self._client.guilds:
@@ -170,7 +171,7 @@ class _ToolsMixin:
                 )
         return out
 
-    async def _get_channel_info(self, args: _GetChannelInfoArgs) -> dict:
+    async def _get_channel_info(self, args: _GetChannelInfoArgs) -> dict[str, Any]:
         ch = await self._resolve_channel(args.channel_id)
         # discord.py text channels expose ``.guild`` (a Guild object), NOT a
         # flat ``.guild_id`` attribute. Reading ``getattr(ch, "guild_id", "")``
@@ -209,7 +210,7 @@ class _ToolsMixin:
                 return g
         raise _ToolError(f"guild '{guild_id}' not found")
 
-    async def _send_briefing(self, args: _SendBriefingArgs) -> dict:
+    async def _send_briefing(self, args: _SendBriefingArgs) -> dict[str, Any]:
         embeds = build_briefing_embeds(
             date_line=args.date_line,
             focus=args.focus,
@@ -226,9 +227,9 @@ class _ToolsMixin:
             )
         )
 
-    async def _create_poll(self, args: _CreatePollArgs) -> dict:
+    async def _create_poll(self, args: _CreatePollArgs) -> dict[str, Any]:
         try:
-            import discord  # type: ignore
+            import discord
         except ImportError as exc:
             raise _ToolError("create_poll requires discord.py") from exc
         ch = await self._resolve_channel(args.channel_id)
@@ -246,9 +247,9 @@ class _ToolsMixin:
         mid = str(new_msg.id)
         return {"status": "sent", "message_id": mid, "message_ids": [mid]}
 
-    async def _create_scheduled_event(self, args: _CreateScheduledEventArgs) -> dict:
+    async def _create_scheduled_event(self, args: _CreateScheduledEventArgs) -> dict[str, Any]:
         try:
-            import discord  # type: ignore
+            import discord
         except ImportError as exc:
             raise _ToolError("create_scheduled_event requires discord.py") from exc
         guild = await self._resolve_guild(args.guild_id)
@@ -289,7 +290,7 @@ class _ToolsMixin:
         ev = await guild.create_scheduled_event(**kwargs)
         return {"status": "created", "event_id": str(ev.id), "name": ev.name}
 
-    async def _cancel_scheduled_event(self, args: _CancelScheduledEventArgs) -> dict:
+    async def _cancel_scheduled_event(self, args: _CancelScheduledEventArgs) -> dict[str, Any]:
         guild = await self._resolve_guild(args.guild_id)
         ev = None
         if hasattr(guild, "get_scheduled_event"):
@@ -302,7 +303,7 @@ class _ToolsMixin:
                     continue
                 seen.add(key)
                 try:
-                    ev = guild.get_scheduled_event(key)  # type: ignore[arg-type]
+                    ev = guild.get_scheduled_event(key)
                 except Exception:
                     ev = None
                 if ev is not None:
@@ -339,7 +340,7 @@ class _ToolsMixin:
             )
         return out
 
-    async def _create_thread(self, args: _CreateThreadArgs) -> dict:
+    async def _create_thread(self, args: _CreateThreadArgs) -> dict[str, Any]:
         """Create a thread in the channel, optionally anchored to a message.
 
         Note on ``thread_id`` vs ``message_id``: when a thread is anchored
@@ -370,7 +371,7 @@ class _ToolsMixin:
             "name": getattr(th, "name", args.name),
         }
 
-    async def _send_typing(self, args: _SendTypingArgs) -> dict:
+    async def _send_typing(self, args: _SendTypingArgs) -> dict[str, Any]:
         ch = await self._resolve_channel(args.channel_id)
         seconds = float(args.duration_seconds)
         typing_factory = getattr(ch, "typing", None)
@@ -389,7 +390,7 @@ class _ToolsMixin:
         task = asyncio.create_task(_pulse())
         self._typing_tasks.add(task)
 
-        def _done(t: asyncio.Task) -> None:
+        def _done(t: asyncio.Task[Any]) -> None:
             self._typing_tasks.discard(task)
 
         task.add_done_callback(_done)

--- a/packages/agent-core-discord/src/agent_core_discord/access.py
+++ b/packages/agent-core-discord/src/agent_core_discord/access.py
@@ -48,7 +48,7 @@ def _build_access_config(raw: dict[str, Any], source: str = "<unknown>") -> Acce
         )
         raw_allowed_bot_ids = []
     return AccessConfig(
-        dm_policy=dm_policy,  # type: ignore[arg-type]
+        dm_policy=dm_policy,
         allow_from=list(raw.get("allowFrom", [])),
         channels=dict(raw.get("channels", {})),
         ack_reaction=raw.get("ackReaction", "👀"),

--- a/packages/agent-core-discord/src/agent_core_discord/endpoint.py
+++ b/packages/agent-core-discord/src/agent_core_discord/endpoint.py
@@ -13,7 +13,7 @@ import types as _types
 from collections import OrderedDict
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from agent_core.bus.protocol import EndpointUnavailable  # noqa: F401 — deliver() globals
 from agent_core_discord._acks import _AcksMixin
@@ -28,10 +28,6 @@ from agent_core_discord.shape_validator import (  # noqa: F401 — deliver() glo
     validate as validate_shape,
 )
 
-if TYPE_CHECKING:
-    from agent_core.bus.envelope import Envelope
-    from agent_core.bus.handle import BusHandle
-
 log = logging.getLogger(__name__)
 
 # Rebind _OutboundMixin.deliver's __globals__ to this module's namespace so that
@@ -40,7 +36,9 @@ log = logging.getLogger(__name__)
 # characterization test patches validate_shape on the endpoint module; the rebinding
 # keeps the patch target working without modifying the test.
 _deliver_orig = _OutboundMixin.__dict__["deliver"]
-_OutboundMixin.deliver = _types.FunctionType(
+# Dynamic method rebind (runtime test seam, see comment above) — mypy can't
+# model reassigning a method, and the behaviour is intentional.
+_OutboundMixin.deliver = _types.FunctionType(  # type: ignore[method-assign]
     _deliver_orig.__code__,
     globals(),
     _deliver_orig.__name__,
@@ -96,11 +94,14 @@ class DiscordEndpoint(_AcksMixin, _LifecycleMixin, _HandlersMixin, _OutboundMixi
         self.target = target
         self.token_env = token_env
         self.outbound_channel_id = outbound_channel_id
-        self.env_file: Path | None = Path(env_file).expanduser() if env_file else None
-        self.access_config_path: Path | None = (
+        # Attribute types are declared once on the shared _EndpointState base;
+        # __init__ only assigns values (no inline annotations) so the mixins and
+        # this class agree on a single source of truth for each attribute's type.
+        self.env_file = Path(env_file).expanduser() if env_file else None
+        self.access_config_path = (
             Path(access_config_path).expanduser() if access_config_path else None
         )
-        self.attachments_dir: Path = (
+        self.attachments_dir = (
             Path(attachments_dir).expanduser().resolve()
             if attachments_dir
             else _default_attachments_dir(name)
@@ -119,52 +120,52 @@ class DiscordEndpoint(_AcksMixin, _LifecycleMixin, _HandlersMixin, _OutboundMixi
         # mirrors _user_display_name_cache: first-miss-then-hit, instance-scoped).
         # Not pre-loaded at start() to avoid adding startup latency for endpoints
         # that never see voice messages.
-        self._transcription_model: Any | None = None
+        self._transcription_model = None
         self._client_factory = _client_factory  # test seam
-        self._handle: BusHandle | None = None
-        self._client: Any = None
+        self._handle = None
+        self._client = None
         # Sticky cache of ``user_id → display_name`` so raw events that
         # only carry IDs (poll votes, future engagement events) don't
         # have to re-do the get_user / fetch_user dance on every fire.
         # First miss → HTTP fetch; every subsequent vote from the same
         # user → cache hit. Failures are deliberately NOT cached so a
         # transient HTTP error doesn't lock the user at empty forever.
-        self._user_display_name_cache: dict[str, str] = {}
-        self._client_task: asyncio.Task | None = None
-        self._sweep_task: asyncio.Task | None = None
-        self._attachment_sweep_task: asyncio.Task | None = None
-        self._ready_event: asyncio.Event = asyncio.Event()
-        self._access: AccessConfig = AccessConfig()
+        self._user_display_name_cache = {}
+        self._client_task = None
+        self._sweep_task = None
+        self._attachment_sweep_task = None
+        self._ready_event = asyncio.Event()
+        self._access = AccessConfig()
         # message_id → (ack_emoji, channel_id, monotonic_inserted_at).
         # OrderedDict so the head is the oldest entry — used for both LRU
         # eviction at the cap and TTL eviction in the sweep loop.
-        self._pending_acks: OrderedDict[str, tuple[str, str, float]] = OrderedDict()
+        self._pending_acks = OrderedDict()
         # Inbound bus envelope id → (Discord message id, channel id) for
         # outbound TextMessage replies that set in_reply_to but omit metadata.
-        self._inbound_envelope_discord: OrderedDict[str, tuple[str, str]] = OrderedDict()
+        self._inbound_envelope_discord = OrderedDict()
         # Cache of recently-published inbounds keyed by envelope_id, for
         # _resolve_channel_id auto-echo (#83). Mirrors claude_code_mcp.py's
         # _recent_inbounds pattern at N=2 of this shape; extract to shared
         # utility when a third endpoint needs it (rule-of-three).
-        self._recent_inbounds: OrderedDict[str, Envelope] = OrderedDict()
+        self._recent_inbounds = OrderedDict()
         self._recent_inbounds_max = recent_inbounds_max
         self._recent_inbounds_ttl_seconds = recent_inbounds_ttl_seconds
-        self._recent_inbounds_timestamps: dict[str, float] = {}
+        self._recent_inbounds_timestamps = {}
         # Discord message ids we published to the bus and have not "finished"
         # yet (cleared when ack reaction is removed or TTL/LRU evicts).
-        self._awaiting_reply_ids: set[str] = set()
+        self._awaiting_reply_ids = set()
         # Sibling timestamps map — same insertion/deletion pairs as
         # `_awaiting_reply_ids`. Per-task lazy TTL safety net inside
         # `_typing_while_pending` evicts orphan entries after
         # `_TYPING_TTL_SECONDS`. See spec doc for the pair-management
         # discipline (#84).
-        self._awaiting_reply_ids_timestamps: dict[str, float] = {}
-        self._typing_tasks: set[asyncio.Task] = set()
+        self._awaiting_reply_ids_timestamps = {}
+        self._typing_tasks = set()
         self.access_config_reload_interval = access_config_reload_interval
-        self._access_reload_task: asyncio.Task | None = None
+        self._access_reload_task = None
         # Stored as (st_mtime, st_size) so we detect changes even on
         # filesystems with coarse mtime granularity (e.g. overlay in CI).
-        self._access_config_mtime: tuple[float, int] | None = None
+        self._access_config_mtime = None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agent-core-discord/src/agent_core_discord/send_retry.py
+++ b/packages/agent-core-discord/src/agent_core_discord/send_retry.py
@@ -52,7 +52,10 @@ def _retry_after_seconds(exc: BaseException) -> float | None:
 
 def _backoff_seconds(attempt: int) -> float:
     """Exponential backoff, capped."""
-    return min(DISCORD_SEND_MAX_DELAY_S, DISCORD_SEND_BASE_DELAY_S * (2**attempt))
+    # ``2**attempt`` types as Any (int**int may be float for negative exponents),
+    # so pin the result to float via the annotated local before returning.
+    delay: float = min(DISCORD_SEND_MAX_DELAY_S, DISCORD_SEND_BASE_DELAY_S * (2**attempt))
+    return delay
 
 
 def retry_delay_seconds(exc: BaseException, attempt: int) -> float:

--- a/packages/agent-core-discord/src/agent_core_discord/testing/fakes.py
+++ b/packages/agent-core-discord/src/agent_core_discord/testing/fakes.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from types import SimpleNamespace
 from typing import Any
 
@@ -124,7 +124,7 @@ class FakeMessage:
         id: str,
         channel_id: str,
         content: str = "",
-        author=None,
+        author: Any = None,
         poll: FakePoll | None = None,
         attachments: list[FakeAttachment] | None = None,
     ):
@@ -183,15 +183,15 @@ class FakeChannel:
         self.threads_created: list[dict[str, Any]] = []
         self._fake_client: FakeDiscordClient | None = None
 
-    def typing(self):
+    def typing(self) -> Any:
         ch = self
 
         class _T:
-            async def __aenter__(self):
+            async def __aenter__(self) -> None:
                 ch._typing_count += 1
                 return None
 
-            async def __aexit__(self, *exc):
+            async def __aexit__(self, *exc: Any) -> None:
                 ch._typing_count -= 1
                 return None
 
@@ -201,9 +201,9 @@ class FakeChannel:
         self,
         content: str | None = None,
         *,
-        embeds: list | None = None,
+        embeds: list[Any] | None = None,
         reference: Any = None,
-        files: list | None = None,
+        files: list[Any] | None = None,
         poll: Any = None,
     ) -> FakeMessage:
         new_id = f"new-{len(self.sent) + 1}"
@@ -260,8 +260,8 @@ class FakeChannel:
     async def fetch_message(self, message_id: str) -> FakeMessage | None:
         return self._messages.get(message_id)
 
-    def history(self, limit: int = 50, before: Any = None):
-        async def _gen():
+    def history(self, limit: int = 50, before: Any = None) -> AsyncIterator[FakeMessage]:
+        async def _gen() -> AsyncIterator[FakeMessage]:
             for m in list(self._messages.values())[:limit]:
                 yield m
 
@@ -387,17 +387,17 @@ class FakeDiscordClient:
         self.fetch_user_call_count = 0
         self._closed = False
         self._logged_in = False
-        self._handlers: dict[str, Callable] = {}
+        self._handlers: dict[str, Callable[..., Any]] = {}
         self._on_ready_event = asyncio.Event()
         self._closed_event: asyncio.Event | None = None
-        self._on_ready_task: asyncio.Task | None = None
+        self._on_ready_task: asyncio.Task[Any] | None = None
 
-    def event(self, fn: Callable) -> Callable:
+    def event(self, fn: Callable[..., Any]) -> Callable[..., Any]:
         """Decorator @client.event — registers the handler by function name."""
         self._handlers[fn.__name__] = fn
         return fn
 
-    def add_listener(self, fn: Callable, name: str | None = None) -> None:
+    def add_listener(self, fn: Callable[..., Any], name: str | None = None) -> None:
         """Mirrors discord.Client.add_listener — register by explicit event name."""
         self._handlers[name or fn.__name__] = fn
 
@@ -443,7 +443,7 @@ class FakeDiscordClient:
         return self._channels.get(str(channel_id))
 
     @property
-    def guilds(self):
+    def guilds(self) -> list[FakeGuild]:
         return list(self._guilds.values())
 
     async def login(self, token: str) -> None:
@@ -470,7 +470,7 @@ class FakeDiscordClient:
         if self._closed_event is not None:
             self._closed_event.set()
 
-    async def fire(self, event_name: str, *args) -> None:
+    async def fire(self, event_name: str, *args: Any) -> None:
         """Test helper: invoke a registered handler."""
         h = self._handlers.get(event_name)
         if h is not None:
@@ -495,13 +495,13 @@ class FakeDiscordClient:
 class FakeBusHandle:
     """Minimal BusHandle stub for endpoint lifecycle tests."""
 
-    async def publish(self, *a, **kw): ...
-    async def ack(self, *a, **kw): ...
-    async def nack(self, *a, **kw): ...
-    def endpoints(self):
+    async def publish(self, *a: Any, **kw: Any) -> None: ...
+    async def ack(self, *a: Any, **kw: Any) -> None: ...
+    async def nack(self, *a: Any, **kw: Any) -> None: ...
+    def endpoints(self) -> list[Any]:
         return []
 
-    def spawn(self, coro, *, name=None):
+    def spawn(self, coro: Any, *, name: str | None = None) -> asyncio.Task[Any]:
         import asyncio
 
         return asyncio.create_task(coro, name=name)

--- a/packages/core/src/agent_core/plugins/builtin_aliases.py
+++ b/packages/core/src/agent_core/plugins/builtin_aliases.py
@@ -72,7 +72,7 @@ def register_endpoint_types() -> dict[str, type[Any]]:
     endpoint_types = dict(_ENDPOINT_TYPES)
     if "builtin.discord" not in endpoint_types:
         try:
-            from agent_core_discord.endpoint import DiscordEndpoint  # type: ignore[import-untyped]
+            from agent_core_discord.endpoint import DiscordEndpoint
         except ImportError:
             pass
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,10 +98,36 @@ python_version = "3.12"
 files = [
     "packages/core/src",
     "packages/agent-core-channel/src",
+    "packages/agent-core-discord/src",
 ]
 warn_unused_ignores = true
 no_implicit_optional = true
 check_untyped_defs = true
+
+# discord.py publishes no type stubs — silence the missing-import noise so the
+# strict override below can focus on our own code.
+[[tool.mypy.overrides]]
+module = ["discord", "discord.*"]
+ignore_missing_imports = true
+
+# agent-core-discord is held to full --strict (issue #444). The strict flags
+# are listed individually rather than via the `strict = true` umbrella: in a
+# per-module override the umbrella leaks several flags (e.g.
+# disallow_any_generics) to the other packages in `files`, whereas the
+# individual booleans scope correctly to this module pattern only. Keeps
+# packages/core + agent-core-channel on their lighter flag set.
+[[tool.mypy.overrides]]
+module = ["agent_core_discord.*"]
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_decorators = true
+warn_return_any = true
+no_implicit_reexport = true
+strict_equality = true
+extra_checks = true
 
 [tool.pytest.ini_options]
 testpaths = [


### PR DESCRIPTION
Closes #444 — the final step (6 of 6) of the #406 discord-endpoint decomposition. Two commits, per the spec.

## 1. `feat: enable mypy --strict for agent-core-discord src`

Wires `packages/agent-core-discord/src` into `[tool.mypy].files` and holds it to full strict, then fixes all **315** resulting strict gaps (0 errors, `mypy` clean across 110 files).

- **Scoping fix vs the spec:** the spec prescribed a `strict = true` per-module override, but that *leaks* strict flags (e.g. `disallow_any_generics`) into `packages/core` + `agent-core-channel`, breaking their green build. Replaced it with the individual strict flags, which scope correctly per-module (`warn_redundant_casts` dropped — it's a global-only flag mypy rejects in a per-module section).
- **Mixin typing:** `DiscordEndpoint` composes 5 mixins that each read shared `self._X` state and call sibling-mixin methods — mypy can't resolve those checking each mixin in isolation (224 `attr-defined`). Introduced a single shared base **`_EndpointState`** carrying the authoritative attribute annotations (types read from `DiscordEndpoint.__init__`) + the cross-mixin method signatures under `TYPE_CHECKING`. **Zero runtime footprint** — the class is empty at runtime; annotations and `TYPE_CHECKING` stubs never execute. `__init__` keeps every assignment (annotations moved to `_state`, single source of truth).
- Real types throughout — no blanket `Any` to silence, 9 stale `# type: ignore`s removed, and exactly **one** added: `# type: ignore[method-assign]` on the intentional dynamic `deliver` rebind (a load-bearing test seam).
- Also removes core's now-unused `# type: ignore[import-untyped]` on the `agent_core_discord` import (it's typed now).

## 2. `fix: log the 8 CancelledError swallows ... at debug level`

Resolves SpecReview #406's Important finding: the 8 `except asyncio.CancelledError: pass` guards in `_lifecycle.py`'s `start()` rollback + `stop()` silently swallowed expected task cancellations. Each `pass` → `log.debug(...)` naming the task + phase (visible in verbose output, silent in prod). The 6 `except CancelledError: raise` guards are untouched.

## Verification

`mypy` clean (0 errors), discord tests **341 passed / 1 skipped**, `just check` green.

Note: done by hand — this ticket is a ~315-error type sweep that foreman couldn't complete autonomously (3 attempts, 3 different failure modes). Worth a decomposition-sizing lesson: heavy type-sweep/refactor tickets need to be split finer or run attended.
