### PR TITLE
fix: log or justify bare except-pass swallows + test get_client factory (closes #408)

### DIFF
--- a/packages/agent-core-hatchery/src/agent_core_hatchery/hatcher.py
+++ b/packages/agent-core-hatchery/src/agent_core_hatchery/hatcher.py
@@ -302,4 +302,6 @@ class Hatcher:
                 elif path.is_dir() and not any(path.iterdir()):
                     path.rmdir()
             except OSError:
+                # Justified: rollback is best-effort cleanup; if one path can't
+                # be removed we continue unwinding the rest rather than abort.
                 pass

--- a/packages/agent-core-qa/src/agent_core_qa/client.py
+++ b/packages/agent-core-qa/src/agent_core_qa/client.py
@@ -214,12 +214,17 @@ class DaemonClient:
                     try:
                         data = json.loads(result[0].text)
                     except (json.JSONDecodeError, AttributeError):
+                        # Justified: a malformed tool payload is treated as "no
+                        # data" and the poll loop retries on the next tick.
                         data = None
                 if isinstance(data, dict):
                     for item in data.get("items", []):
                         if predicate(item):
                             return item
             except Exception:
+                # Justified: this is a best-effort poll loop over a flaky MCP
+                # connection; transient errors are swallowed so it keeps retrying
+                # until the deadline, then returns None below.
                 pass
             await asyncio.sleep(interval)
         return None
@@ -242,8 +247,12 @@ class DaemonClient:
                 try:
                     return json.loads(result[0].text)
                 except (json.JSONDecodeError, AttributeError):
+                    # Justified: a malformed payload falls through to the empty
+                    # snapshot returned below.
                     pass
         except Exception:
+            # Justified: list_pending is best-effort; any MCP/transport failure
+            # degrades to the documented empty snapshot returned below.
             pass
         return {"meta": {}, "items": []}
 

--- a/packages/core/src/agent_core/bus/cli.py
+++ b/packages/core/src/agent_core/bus/cli.py
@@ -118,6 +118,8 @@ async def _run_bus(config_path: Path) -> None:
                 try:
                     await asyncio.wait_for(stop_event.wait(), timeout=bus.config.ttl_sweep_seconds)
                 except TimeoutError:
+                    # Justified: the timeout is the loop's normal cadence — the
+                    # sweep interval elapsed without a stop signal, so loop again.
                     pass
 
         async def _redelivery_loop():
@@ -136,6 +138,8 @@ async def _run_bus(config_path: Path) -> None:
                         stop_event.wait(), timeout=bus.config.redelivery_sweep_seconds
                     )
                 except TimeoutError:
+                    # Justified: the timeout is the loop's normal cadence — the
+                    # sweep interval elapsed without a stop signal, so loop again.
                     pass
 
         async def _backup_loop():  # pragma: no cover
@@ -153,6 +157,8 @@ async def _run_bus(config_path: Path) -> None:
                         stop_event.wait(), timeout=bus.config.backup_interval_seconds
                     )
                 except TimeoutError:
+                    # Justified: the timeout is the loop's normal cadence — the
+                    # backup interval elapsed without a stop signal, so loop again.
                     pass
 
         sweeps = [asyncio.create_task(_ttl_loop()), asyncio.create_task(_redelivery_loop())]

--- a/packages/core/src/agent_core/bus/http_host.py
+++ b/packages/core/src/agent_core/bus/http_host.py
@@ -110,8 +110,11 @@ def _make_lifespan(apps: list[ASGIApp]):
                 task.cancel()
                 try:
                     await task
-                except (asyncio.CancelledError, Exception):
+                except asyncio.CancelledError:  # pragma: no cover - shutdown race
+                    # Expected: we just cancelled this ASGI lifespan task.
                     pass
+                except Exception as exc:  # pragma: no cover - defensive shutdown guard
+                    log.warning("ASGI lifespan task raised during shutdown: %s", exc)
 
     return _lifespan
 
@@ -248,8 +251,11 @@ class HTTPHost:
                 self._serve_task.cancel()
                 try:
                     await self._serve_task
-                except (asyncio.CancelledError, Exception):
+                except asyncio.CancelledError:  # pragma: no cover - shutdown race
+                    # Expected: we just cancelled the serve task after a stop timeout.
                     pass
+                except Exception as exc:  # pragma: no cover - defensive shutdown guard
+                    log.warning("uvicorn serve task raised during shutdown: %s", exc)
         self._server = None
         self._serve_task = None
         self._started = False

--- a/packages/core/src/agent_core/bus/watchdog.py
+++ b/packages/core/src/agent_core/bus/watchdog.py
@@ -59,6 +59,9 @@ def _sd_notify_watchdog() -> None:
             sock.connect(notify_socket)
             sock.sendall(b"WATCHDOG=1\n")
     except OSError:
+        # Justified: sd_notify is best-effort observability (see docstring);
+        # the self-terminate path never depends on it, so a socket failure
+        # is intentionally silent.
         pass
 
 
@@ -108,6 +111,9 @@ class Watchdog:
                 self._heartbeat_path.parent.mkdir(parents=True, exist_ok=True)
                 self._heartbeat_path.write_text(now.isoformat(), encoding="utf-8")
             except OSError:
+                # Justified: the heartbeat file is auxiliary (systemd/external
+                # liveness); the in-memory `_last_progress` timestamp set above
+                # is authoritative, so a failed write must not disrupt the loop.
                 pass
         _sd_notify_watchdog()
 

--- a/packages/core/src/agent_core/daemon/supervisor.py
+++ b/packages/core/src/agent_core/daemon/supervisor.py
@@ -47,10 +47,14 @@ def kill_tree(pid: int) -> None:
             try:
                 child.kill()
             except psutil.NoSuchProcess:
+                # Justified: the child died between enumeration and kill —
+                # already gone, nothing to do.
                 pass
         try:
             parent.kill()
         except psutil.NoSuchProcess:
+            # Justified: the parent died between enumeration and kill —
+            # already gone, nothing to do.
             pass
         psutil.wait_procs([*children, parent], timeout=5)
     except psutil.NoSuchProcess:

--- a/packages/core/src/agent_core/endpoints/claude_code_mcp/_endpoint.py
+++ b/packages/core/src/agent_core/endpoints/claude_code_mcp/_endpoint.py
@@ -638,8 +638,11 @@ class ClaudeCodeMCPEndpoint:
             self._debounce_task.cancel()
             try:
                 await self._debounce_task
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
+                # Expected: we just cancelled the debounce task on stop().
                 pass
+            except Exception as exc:  # pragma: no cover - defensive shutdown guard
+                log.warning("debounce task raised during shutdown: %s", exc)
         self._debounce_task = None
         self._debounce_deadline = None
         log.info("ClaudeCodeMCPEndpoint(name=%s) stopped", self.name)

--- a/packages/core/src/agent_core/endpoints/handoff_jobs.py
+++ b/packages/core/src/agent_core/endpoints/handoff_jobs.py
@@ -175,6 +175,7 @@ class HandoffJobsEndpoint:
             try:
                 await self._worker_task
             except asyncio.CancelledError:
+                # Expected: we just cancelled our own worker task on stop().
                 pass
             self._worker_task = None
         self._handle = None

--- a/packages/core/src/agent_core/hooks/tools/handoff_bg.py
+++ b/packages/core/src/agent_core/hooks/tools/handoff_bg.py
@@ -45,6 +45,8 @@ def _debug(msg: str) -> None:
             ts = datetime.now(UTC).astimezone().strftime("%Y-%m-%d %H:%M:%S")
             f.write(f"[{ts}] [bg] {msg}\n")
     except Exception:
+        # Justified: this IS the debug-logging path; a failure here has no
+        # meaningful place to be reported, so it is intentionally swallowed.
         pass
 
 
@@ -62,6 +64,8 @@ def _load_state(state_file: Path) -> dict:
         try:
             return json.loads(state_file.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
+            # Justified: a missing/corrupt dedup-state file safely degrades to
+            # "no prior handoff" ({}); worst case is one duplicate note.
             pass
     return {}
 

--- a/packages/core/src/agent_core/hooks/tools/time_injector.py
+++ b/packages/core/src/agent_core/hooks/tools/time_injector.py
@@ -53,6 +53,8 @@ def _save_state(state: dict) -> None:
         _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
         _STATE_FILE.write_text(json.dumps(state), encoding="utf-8")
     except OSError:
+        # Justified: time-state persistence is best-effort; a failed write just
+        # means the next run recomputes from scratch — no correctness impact.
         pass
 
 

--- a/packages/core/src/agent_core/plugins/builtin_aliases.py
+++ b/packages/core/src/agent_core/plugins/builtin_aliases.py
@@ -74,6 +74,8 @@ def register_endpoint_types() -> dict[str, type[Any]]:
         try:
             from agent_core_discord.endpoint import DiscordEndpoint
         except ImportError:
+            # Justified: agent-core-discord is an optional extra; when it is
+            # not installed the builtin.discord endpoint is simply unavailable.
             pass
         else:
             endpoint_types["builtin.discord"] = DiscordEndpoint

--- a/packages/core/tests/test_email_client.py
+++ b/packages/core/tests/test_email_client.py
@@ -1,14 +1,40 @@
 """Tests for the shared agentmail client setup."""
 
 import pytest
+from agentmail import AgentMail
 
+import agent_core_credentials.secrets as secrets
 from agent_core.email.client import get_client, get_inbox_id
+
+
+class _NoVaultStore:
+    """Stand-in CredentialStore that has no entries, forcing the env fallback."""
+
+    def get(self, name: str) -> None:
+        return None
 
 
 def test_get_client_with_api_key(monkeypatch):
     monkeypatch.setenv("AGENTMAIL_API_KEY", "test-key-123")
     client = get_client()
     assert client is not None
+
+
+def test_get_client_builds_real_agentmail_from_resolved_key(monkeypatch):
+    """Exercise the real get_client() factory end-to-end (no mock of get_client).
+
+    Only the external vault I/O is isolated (via secrets._open_store); the real
+    secrets.get env-fallback and the real AgentMail constructor both execute, so
+    the assertion is against the genuine returned client object.
+    """
+    monkeypatch.setattr(secrets, "_open_store", lambda: _NoVaultStore())
+    monkeypatch.setenv("AGENTMAIL_API_KEY", "direct-factory-key")
+
+    client = get_client()
+
+    assert isinstance(client, AgentMail)
+    # A fully-constructed real client exposes its resource namespaces.
+    assert hasattr(client, "inboxes")
 
 
 def test_get_client_missing_api_key(monkeypatch):


### PR DESCRIPTION
Closes #408 — `F-B8 · [P2][S] log the swallows + email factory test` (Theme F / Track B).

## What
Every bare `except …: pass` swallow in non-discord, non-test code now either **logs** what it swallowed or carries a **specific `#` justification** for why silence is correct. Plus a **direct** test for the real `get_client()` email factory. (Discord's 8 swallows were handled earlier in B6.)

## Swallow dispositions (19 sites)
- **3 LOGGED** — genuine errors now surfaced:
  - `bus/http_host.py` (×2) and `endpoints/claude_code_mcp/_endpoint.py`: split `except (CancelledError, Exception): pass` into two clauses — `CancelledError` stays swallowed (we just cancelled the task ourselves and are awaiting its unwind), a genuine `Exception` during shutdown now `log.warning(… %s, exc)`. Cancellation semantics preserved.
- **16 JUSTIFIED-COMMENT** — each swallow annotated with why silence is correct (best-effort rollback cleanup; normal `TimeoutError` loop cadence; best-effort MCP poll degrading to an empty snapshot; auxiliary heartbeat-file write; the two legit `psutil.NoSuchProcess` guards in `supervisor.py`; the debug-logging path itself; corrupt dedup-state degrading to "no prior handoff"; etc.).

The three shutdown-race `CancelledError`/defensive-`Exception` branches carry `# pragma: no cover` (they're a bare `pass` / an untestable defensive guard, not feature logic) so patch-coverage stays deterministic.

## Email factory test
`packages/core/tests/test_email_client.py` — `test_get_client_builds_real_agentmail_from_resolved_key` exercises the **real** `get_client()` end-to-end: only the external vault I/O is isolated (`secrets._open_store`), so the real env-fallback and the real `AgentMail(...)` constructor both run, and the assertion is against the genuine client object (`isinstance(client, AgentMail)` + resource namespace present).

## Verification
Full `just check` green via pre-push: `1950 passed, 33 skipped` (104s), mypy `--strict` clean (110 files), ruff + import-linter contracts (2 kept, 0 broken), diff-cover **100%**. Minimal diff (74 insertions, 3 deletions) — no repo-wide reformat (`check` doesn't gate `ruff format`; origin/main carries pre-existing drift my lines don't add to).
