### PR TITLE
ci(release): publish each package in its own environment (per-package matrix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,20 @@ permissions:
   contents: read
 
 jobs:
+  # Single source of truth for the published package set. Consumed by the build
+  # loop and BOTH publish matrices, so the list can never drift across jobs.
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      packages: ${{ steps.set.outputs.packages }}
+    steps:
+      - id: set
+        run: |
+          echo 'packages=["agent-core","agent-core-briefs","agent-core-busproxy","agent-core-channel","agent-core-credentials","agent-core-discord","agent-core-hatchery","agent-core-inbound","agent-core-notify","agent-core-qa","agent-core-voice","agent-core-webcam"]' >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -24,12 +37,9 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Build wheels and sdists for all 12 packages
+      - name: Build wheels and sdists for all packages
         run: |
-          for pkg in agent-core agent-core-briefs agent-core-busproxy agent-core-channel \
-                     agent-core-credentials agent-core-discord agent-core-hatchery \
-                     agent-core-inbound agent-core-notify agent-core-qa \
-                     agent-core-voice agent-core-webcam; do
+          for pkg in ${{ join(fromJSON(needs.prepare.outputs.packages), ' ') }}; do
             uv build --package "$pkg" --out-dir dist/
           done
 
@@ -42,37 +52,65 @@ jobs:
           name: dist
           path: dist/
 
+  # Per-package publish: each package runs in its own matrix leg with its OWN
+  # environment (named after the package). PyPI forbids the same
+  # (owner, repo, workflow, environment) tuple from backing more than one
+  # pending Trusted Publisher, so a distinct environment per package is required
+  # for a monorepo. fail-fast: false so one package's failure doesn't cancel the
+  # rest.
   publish-testpypi:
-    needs: build
+    needs: [prepare, build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.prepare.outputs.packages) }}
     permissions:
       id-token: write
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/agent-core
+      name: ${{ matrix.package }}
+      url: https://test.pypi.org/p/${{ matrix.package }}
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: dist
           path: dist/
+
+      - name: Isolate this package's distributions
+        run: |
+          prefix=$(echo "${{ matrix.package }}" | tr '-' '_')
+          mkdir -p pkg_dist
+          find dist -maxdepth 1 -type f \
+            \( -name "${prefix}-*.whl" -o -name "${prefix}-*.tar.gz" \) \
+            -exec cp {} pkg_dist/ \;
+          echo "Isolated distributions for ${{ matrix.package }} (prefix '${prefix}-'):"
+          ls -la pkg_dist/
+          if [ -z "$(ls -A pkg_dist/)" ]; then
+            echo "::error::no distributions found for ${{ matrix.package }}"
+            exit 1
+          fi
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          packages-dir: dist/
+          packages-dir: pkg_dist/
 
   publish-pypi:
-    needs: publish-testpypi
+    needs: [prepare, publish-testpypi]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.prepare.outputs.packages) }}
     permissions:
       id-token: write
     environment:
-      name: pypi
-      url: https://pypi.org/p/agent-core
+      name: ${{ matrix.package }}
+      url: https://pypi.org/p/${{ matrix.package }}
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
@@ -80,10 +118,24 @@ jobs:
           name: dist
           path: dist/
 
+      - name: Isolate this package's distributions
+        run: |
+          prefix=$(echo "${{ matrix.package }}" | tr '-' '_')
+          mkdir -p pkg_dist
+          find dist -maxdepth 1 -type f \
+            \( -name "${prefix}-*.whl" -o -name "${prefix}-*.tar.gz" \) \
+            -exec cp {} pkg_dist/ \;
+          echo "Isolated distributions for ${{ matrix.package }} (prefix '${prefix}-'):"
+          ls -la pkg_dist/
+          if [ -z "$(ls -A pkg_dist/)" ]; then
+            echo "::error::no distributions found for ${{ matrix.package }}"
+            exit 1
+          fi
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
-          packages-dir: dist/
+          packages-dir: pkg_dist/
 
   upload-github-release:
     needs: build


### PR DESCRIPTION
## Why
Our OIDC release pipeline published all 12 packages from a **single shared** environment (`testpypi` / `pypi`). That's incompatible with a monorepo: PyPI forbids the same `(owner, repo, workflow, environment)` tuple from backing more than one **pending** Trusted Publisher (anti-squatting), so only the first package name can register. Discovered live while setting up the pending publishers — `agent-core` registered, every other name was rejected with *"a pending trusted publisher matching this configuration has already been registered for a different project name."*

## What
- **`prepare` job** emits the 12-package list as JSON once → single source of truth consumed by the build loop and both publish matrices (no drift).
- **`publish-testpypi` / `publish-pypi`** become per-package **matrix** jobs (`fail-fast: false`), each leg running in an **`environment: <package-name>`** — a distinct publisher tuple per package, which registers cleanly.
- Each leg **isolates just its package's distributions** (`agent_core-*` won't match `agent_core_briefs-*`) and fails loudly if none are found.
- Build + GH-release jobs unchanged; action SHAs still pinned.

Paired with 12 per-package GitHub environments (created) and per-package pending Trusted Publishers on TestPyPI/PyPI (`environment = <package-name>`).
