### PR TITLE
fix: rename flagship dist to agent-core-bus + bump inter-package pins to 0.8.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,10 @@ jobs:
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
       # The slow tests shell out to `uv venv --python 3.12`; ensure a managed CPython exists
       - run: uv python install 3.12
-      # --package agent-core (+ agent-core-busproxy) intentionally excludes
+      # --package agent-core-bus (+ agent-core-busproxy) intentionally excludes
       # agent-core-voice/qwen-tts (no Torch in CI). busproxy is light (fastmcp,
       # httpx, anyio) and hosts the real-subprocess/dead-port slow tests.
-      - run: uv sync --locked --package agent-core --package agent-core-busproxy
+      - run: uv sync --locked --package agent-core-bus --package agent-core-busproxy
       # Slow-marked tests live in packages/core/tests and packages/agent-core-busproxy/tests.
       # --no-cov disables coverage for this subset run; the project-wide coverage
       # floor is enforced by the `check` job above, which runs the full suite.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build wheels and sdists for all 12 packages
         run: |
-          for pkg in agent-core agent-core-briefs agent-core-busproxy agent-core-channel \
+          for pkg in agent-core-bus agent-core-briefs agent-core-busproxy agent-core-channel \
                      agent-core-credentials agent-core-discord agent-core-hatchery \
                      agent-core-inbound agent-core-notify agent-core-qa \
                      agent-core-voice agent-core-webcam; do

--- a/packages/agent-core-briefs/pyproject.toml
+++ b/packages/agent-core-briefs/pyproject.toml
@@ -5,7 +5,7 @@ description = "Brief framework — structured-composition pattern for agent_core
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
-    "agent-core>=0.7,<0.8",
+    "agent-core-bus>=0.8,<0.9",
     "pluggy>=1.6",
     "pydantic>=2.7",
     "pyyaml>=6.0",

--- a/packages/agent-core-discord/pyproject.toml
+++ b/packages/agent-core-discord/pyproject.toml
@@ -5,8 +5,8 @@ description = "Discord bot adapter for the agent-core bus — one bot per agent 
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
-    "agent-core>=0.7,<0.8",
-    "agent-core-credentials>=0.7,<0.8",
+    "agent-core-bus>=0.8,<0.9",
+    "agent-core-credentials>=0.8,<0.9",
     "discord.py>=2.4",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0",

--- a/packages/agent-core-hatchery/pyproject.toml
+++ b/packages/agent-core-hatchery/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "rich>=13.0",
     "pyyaml>=6.0",
     "pydantic>=2.0",
-    "agent-core>=0.7,<0.8",
+    "agent-core-bus>=0.8,<0.9",
 ]
 
 [project.scripts]

--- a/packages/agent-core-inbound/pyproject.toml
+++ b/packages/agent-core-inbound/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
-    "agent-core>=0.7,<0.8",
-    "agent-core-credentials>=0.7,<0.8",
+    "agent-core-bus>=0.8,<0.9",
+    "agent-core-credentials>=0.8,<0.9",
     "pydantic>=2.0",
     "fastapi>=0.110",
     "uvicorn>=0.27",

--- a/packages/agent-core-voice/pyproject.toml
+++ b/packages/agent-core-voice/pyproject.toml
@@ -5,7 +5,7 @@ description = "Voice synthesis endpoint for agent_core — per-agent Qwen3-TTS v
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
-    "agent-core>=0.7,<0.8",
+    "agent-core-bus>=0.8,<0.9",
     "fastmcp>=2.0",
     "madrigal >= 0.2.0",
     "pluggy>=1.6",

--- a/packages/agent-core-webcam/pyproject.toml
+++ b/packages/agent-core-webcam/pyproject.toml
@@ -5,7 +5,7 @@ description = "Webcam endpoint for agent_core — agent-driven on-demand frame c
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
-    "agent-core>=0.7,<0.8",
+    "agent-core-bus>=0.8,<0.9",
     "fastmcp>=2.0",
     "opencv-python>=5.0.0.93",
     "pluggy>=1.6",

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
-name = "agent-core"
+name = "agent-core-bus"
 dynamic = ["version"]
 description = "Core infrastructure for AI agents - memory, knowledge compilation, and tooling"
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "claude-agent-sdk>=0.1.29",
-    "agent-core-credentials>=0.7,<0.8",
+    "agent-core-credentials>=0.8,<0.9",
     "python-dotenv>=1.0.0",
     "tzdata>=2024.1",
     "pydantic>=2.0",

--- a/packages/core/src/agent_core/__init__.py
+++ b/packages/core/src/agent_core/__init__.py
@@ -14,6 +14,6 @@ Modules:
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__: str = version("agent-core")
+    __version__: str = version("agent-core-bus")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"

--- a/packages/core/src/agent_core/venv/builder.py
+++ b/packages/core/src/agent_core/venv/builder.py
@@ -226,7 +226,7 @@ def build_being_venv(
     Raises UvNotFoundError, SidecarVerifyError, or subprocess.CalledProcessError.
     """
     uv = resolve_uv()
-    version = _metadata_version("agent-core")
+    version = _metadata_version("agent-core-bus")
 
     home = home_for_target(target)
     venv_dir = versioned_venv_dir(home, version, target=target)

--- a/packages/core/tests/test_version.py
+++ b/packages/core/tests/test_version.py
@@ -7,7 +7,7 @@ from importlib.metadata import version
 def test_version_matches_importlib_metadata() -> None:
     import agent_core
 
-    assert agent_core.__version__ == version("agent-core")
+    assert agent_core.__version__ == version("agent-core-bus")
 
 
 def test_version_is_not_hardcoded_sentinel() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ url = "https://download.pytorch.org/whl/cu130"
 explicit = true
 
 [tool.uv.sources]
-agent-core = { workspace = true }
+agent-core-bus = { workspace = true }
 agent-core-notify = { workspace = true }
 agent-core-credentials = { workspace = true }
 agent-core-discord = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -50,8 +50,8 @@ conflicts = [[
 
 [manifest]
 members = [
-    "agent-core",
     "agent-core-briefs",
+    "agent-core-bus",
     "agent-core-busproxy",
     "agent-core-channel",
     "agent-core-credentials",
@@ -112,7 +112,29 @@ wheels = [
 ]
 
 [[package]]
-name = "agent-core"
+name = "agent-core-briefs"
+source = { editable = "packages/agent-core-briefs" }
+dependencies = [
+    { name = "agent-core-bus" },
+    { name = "pluggy" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "simpleeval" },
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-core-bus", editable = "packages/core" },
+    { name = "pluggy", specifier = ">=1.6" },
+    { name = "pydantic", specifier = ">=2.7" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "simpleeval", specifier = ">=1.0" },
+    { name = "typer", specifier = ">=0.12" },
+]
+
+[[package]]
+name = "agent-core-bus"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "agent-core-credentials" },
@@ -157,28 +179,6 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
     { name = "tzdata", specifier = ">=2024.1" },
     { name = "uvicorn", specifier = ">=0.30" },
-]
-
-[[package]]
-name = "agent-core-briefs"
-source = { editable = "packages/agent-core-briefs" }
-dependencies = [
-    { name = "agent-core" },
-    { name = "pluggy" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "simpleeval" },
-    { name = "typer" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "agent-core", editable = "packages/core" },
-    { name = "pluggy", specifier = ">=1.6" },
-    { name = "pydantic", specifier = ">=2.7" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "simpleeval", specifier = ">=1.0" },
-    { name = "typer", specifier = ">=0.12" },
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ requires-dist = [
 name = "agent-core-discord"
 source = { editable = "packages/agent-core-discord" }
 dependencies = [
-    { name = "agent-core" },
+    { name = "agent-core-bus" },
     { name = "agent-core-credentials" },
     { name = "discord-py" },
     { name = "pydantic" },
@@ -259,7 +259,7 @@ voice = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-core", editable = "packages/core" },
+    { name = "agent-core-bus", editable = "packages/core" },
     { name = "agent-core-credentials", editable = "packages/credentials" },
     { name = "discord-py", specifier = ">=2.4" },
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = ">=1.1" },
@@ -272,7 +272,7 @@ provides-extras = ["voice"]
 name = "agent-core-hatchery"
 source = { editable = "packages/agent-core-hatchery" }
 dependencies = [
-    { name = "agent-core" },
+    { name = "agent-core-bus" },
     { name = "jinja2" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -289,7 +289,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-core", editable = "packages/core" },
+    { name = "agent-core-bus", editable = "packages/core" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -308,7 +308,7 @@ dev = [
 name = "agent-core-inbound"
 source = { editable = "packages/agent-core-inbound" }
 dependencies = [
-    { name = "agent-core" },
+    { name = "agent-core-bus" },
     { name = "agent-core-credentials" },
     { name = "fastapi" },
     { name = "pydantic" },
@@ -325,7 +325,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-core", editable = "packages/core" },
+    { name = "agent-core-bus", editable = "packages/core" },
     { name = "agent-core-credentials", editable = "packages/credentials" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "httpx", marker = "extra == 'test'" },
@@ -373,7 +373,7 @@ requires-dist = [
 name = "agent-core-voice"
 source = { editable = "packages/agent-core-voice" }
 dependencies = [
-    { name = "agent-core" },
+    { name = "agent-core-bus" },
     { name = "fastmcp" },
     { name = "madrigal" },
     { name = "pluggy" },
@@ -394,7 +394,7 @@ cu130 = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-core", editable = "packages/core" },
+    { name = "agent-core-bus", editable = "packages/core" },
     { name = "fastmcp", specifier = ">=2.0" },
     { name = "madrigal", specifier = ">=0.2.0" },
     { name = "pluggy", specifier = ">=1.6" },
@@ -410,7 +410,7 @@ provides-extras = ["cpu", "cu130"]
 name = "agent-core-webcam"
 source = { editable = "packages/agent-core-webcam" }
 dependencies = [
-    { name = "agent-core" },
+    { name = "agent-core-bus" },
     { name = "fastmcp" },
     { name = "opencv-python" },
     { name = "pluggy" },
@@ -419,7 +419,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-core", editable = "packages/core" },
+    { name = "agent-core-bus", editable = "packages/core" },
     { name = "fastmcp", specifier = ">=2.0" },
     { name = "opencv-python", specifier = ">=5.0.0.93" },
     { name = "pluggy", specifier = ">=1.6" },


### PR DESCRIPTION
## Why
Publishing 0.8.0 to PyPI failed: `400 The name 'agent-core' is too similar to an existing project` (the existing `agentcore`). Nothing published — clean failure. Fixing the flagship distribution name unblocks the release. In the process, found a second latent blocker.

## What
1. **Flagship rename** — `packages/core` distribution name `agent-core` → **`agent-core-bus`**. The Python import package `agent_core` is unchanged; only the pip/PyPI name changes. Updated the workspace source mapping (root `pyproject.toml`), the release build loop, and the six packages that depend on the flagship.
2. **Inter-package constraint bump** — every inter-package pin `>=0.7,<0.8` → `>=0.8,<0.9` (9 refs). The 0.8.0 version train left these excluding 0.8.x, so the published 0.8 packages **could not have resolved each other** (`pip install agent-core-discord` would fail on its `agent-core (<0.8)` dep). release-please does not manage these pins. Without this, the publish would ship broken metadata even under a valid name.

## Verified locally
`uv lock` clean (agent-core → agent-core-bus), flagship builds as `agent_core_bus-*`, and the discord wheel's `Requires-Dist` correctly reads `agent-core-bus>=0.8,<0.9` + `agent-core-credentials>=0.8,<0.9`. `twine check` PASSED. Full `just check` green via pre-push.

## Follow-ups (not blocking)
- Packages lack `readme`/`long_description` (twine warns) — PyPI pages will be bare. Worth adding per-package READMEs.
- release-please should manage inter-package version pins so this constraint drift can't recur.
