### PR TITLE
ci(release): skip-existing on publish for idempotent retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,10 @@ jobs:
         with:
           packages-dir: dist/
           password: ${{ secrets.PYPI_API_TOKEN }}
+          # PyPI rate-limits NEW-project creation, so a 12-package first publish
+          # can 429 partway. skip-existing makes re-runs idempotent: already-
+          # published versions are skipped, so a retry only creates the rest.
+          skip-existing: true
 
   upload-github-release:
     needs: build


### PR DESCRIPTION
PyPI rate-limits new-project creation; the 12-package first publish 429'd after 4 uploaded. `skip-existing: true` makes re-runs idempotent so a retry only creates the remaining projects. Enables completing the publish under the rate limit.