### PR TITLE
chore(staging): add isolated pre-prod container harness for the daemon

### DIFF
--- a/staging/Dockerfile
+++ b/staging/Dockerfile
@@ -1,0 +1,56 @@
+# agent_core staging harness — isolated pre-prod gate.
+#
+# Boots a candidate agent_core version as a throwaway daemon in a container,
+# fully walled off from the live Wren + Pepper daemon on the host. Nothing here
+# touches the host bus, ports, vault, or Discord bots.
+#
+# Install modes (build arg INSTALL_MODE):
+#   source (default) — git clone jeffrichley/agent_core@REF and `uv sync` the
+#                      workspace. Resolves sibling packages (agent-core-credentials
+#                      etc.) BY PATH, so it works even before every package is on
+#                      PyPI and regardless of inter-package version pins. This is
+#                      the right mode for a staging gate: test the candidate CODE.
+#   pypi             — pip install agent-core-bus==VERSION from PyPI. Only works
+#                      once ALL dependency packages are published (blocked today
+#                      by the new-project rate limit). Doubles as publish-validation.
+FROM python:3.12-slim
+
+ARG INSTALL_MODE=source
+ARG VERSION=0.8.2
+ARG REF=main
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:0.8.2 /uv /usr/local/bin/uv
+
+# --- install the candidate ---
+# source mode: clone + `uv sync --package agent-core-bus` (core + its real deps,
+# resolved from the workspace by path; excludes heavy voice/torch). The daemon
+# then runs via `uv run --no-sync` from /src.
+RUN set -eux; \
+    if [ "$INSTALL_MODE" = "source" ]; then \
+        git clone --depth 1 --branch "${REF}" https://github.com/jeffrichley/agent_core.git /src; \
+        cd /src && UV_PYTHON=python3.12 uv sync --no-dev --package agent-core-bus; \
+    elif [ "$INSTALL_MODE" = "pypi" ]; then \
+        uv pip install --system "agent-core-bus==${VERSION}"; \
+        mkdir -p /src; \
+    else \
+        echo "unknown INSTALL_MODE=${INSTALL_MODE}"; exit 2; \
+    fi
+
+# A tiny launcher that runs the daemon under the right interpreter for either
+# mode, plus a `status` helper the shakedown calls.
+RUN printf '#!/bin/sh\nif [ -d /src/.venv ]; then exec uv run --project /src --no-sync agent-core "$@"; else exec agent-core "$@"; fi\n' \
+      > /usr/local/bin/ac && chmod +x /usr/local/bin/ac
+
+RUN mkdir -p /data
+COPY config/staging.yaml /config/staging.yaml
+
+RUN ac --help >/dev/null
+RUN echo "mode=${INSTALL_MODE} ref=${REF} version=${VERSION}" > /agent-core-version.txt
+
+EXPOSE 8789
+# Foreground daemon — the process under test. Runs until SIGTERM.
+CMD ["ac", "bus", "run", "--config", "/config/staging.yaml"]

--- a/staging/README.md
+++ b/staging/README.md
@@ -1,0 +1,82 @@
+# agent_core staging harness — the pre-prod gate
+
+A **standing test container** you run a candidate `agent_core` version through
+**before promoting it to the live Wren + Pepper daemon.** Nothing here touches
+the host: the container is the isolation wall — its own filesystem, ports,
+SQLite storage, and (later) its own Discord bot. The live beings are never the
+test subject.
+
+## The promotion flow
+
+```
+candidate version ──▶ ./shakedown.sh ──▶ PASS ──▶ promote to live daemon
+   (main / a tag)          │                         (agent-core daemon
+                           └─▶ FAIL ──▶ do NOT promote   refresh --instance prod)
+```
+
+## Usage
+
+```bash
+# Default: test the published PyPI package (also validates the publish).
+./shakedown.sh
+
+# Test a specific published version:
+INSTALL_MODE=pypi VERSION=0.8.2 ./shakedown.sh
+
+# Test an unpublished branch / main from source (for pre-release candidates):
+INSTALL_MODE=source REF=main ./shakedown.sh
+```
+
+Exit 0 = the candidate booted clean in isolation → cleared to promote.
+Non-zero = do **not** promote; the output names what broke.
+
+## What Phase 1 checks (this version)
+
+The high-risk unknown is: *does the assembled daemon actually boot and run its
+endpoints on the candidate version?* — the thing 140 commits of CI-green work
+never proved as a live system. Phase 1 asserts:
+
+- the candidate **installs** at all (build fails loudly if not),
+- the **daemon boots** (`bus status` responds),
+- **endpoints register** (stub + scheduler),
+- **boot logs are clean** (no tracebacks/fatals),
+- the **HTTP surface is reachable**.
+
+No Discord, no brain, no vault — deliberately. Zero risk to the live beings,
+no Discord-token conflicts.
+
+## Isolation guarantees
+
+| resource | live daemon | this harness |
+|---|---|---|
+| process/filesystem | host | **container** |
+| bus HTTP port | `127.0.0.1:8789` | container `8789` → host `127.0.0.1:18789` |
+| storage | host `~/.agent-core` | container `/data/bus.sqlite` (ephemeral) |
+| Discord bots | discord-wren / -pepper / -testbot | **none** (Phase 1) |
+| vault / creds | host KeePass | **none** (Phase 1) |
+
+## Roadmap
+
+- **Phase 1 (done):** isolated substrate boot gate (above).
+- **Phase 2:** add the `discord-testbot` bot so a real Discord message exercises
+  the v0.8.x Discord endpoint. Requires the one-connection host-handoff:
+  disable the `discord-testbot` endpoint in the host daemon
+  (`~/.agent-core/agent_core.yaml`) first — one gateway connection per token —
+  then pass `DISCORD_TESTBOT_TOKEN` into the container.
+- **Phase 3:** attach a Claude session (brain) that drains testbot's mailbox and
+  replies — the full loop: Discord → v0.8.x bus → endpoint → mailbox → brain →
+  reply. Plus an explicit supervision test (kill an endpoint, confirm restart).
+
+## Design notes
+
+- **Install from source *or* PyPI.** A staging gate should test the *code*
+  (main/a branch), but Phase 1 defaults to PyPI because it's the fastest path
+  and doubles as a publish-validation. Use `INSTALL_MODE=source REF=<branch>`
+  for pre-release candidates.
+- **Why a container, given agent_core is native-first (no Docker)?** The
+  container is a *test harness*, not the deployment model — adopters still run
+  native. It just gives the strongest isolation for a first live shakedown.
+- **agent_core already has the pieces:** `agent-core daemon install
+  --instance {prod|source|test}` gives per-instance frozen venvs, and `.testbot`
+  + `discord-testbot` are a ready-made test being + isolated Discord surface.
+  This harness wraps that machinery in a container for full isolation.

--- a/staging/config/staging.yaml
+++ b/staging/config/staging.yaml
@@ -1,0 +1,27 @@
+# Isolated staging daemon config — runs INSIDE the container only.
+# Deliberately minimal: no Discord, no claude_code_mcp (brain), no vault.
+# Those are layered in later phases once the substrate boot is proven.
+bus:
+  storage_path: /data/bus.sqlite
+
+http:
+  # Loopback, exactly like prod. The v0.8.x bus refuses a non-loopback bind
+  # without an auth hook (a real security guard — the harness caught this).
+  # We inspect from INSIDE the container via `docker exec`, so nothing needs to
+  # be exposed to the host — stronger isolation anyway.
+  bind_host: 127.0.0.1
+  bind_port: 8789
+
+endpoints:
+  # A no-op endpoint — proves the endpoint registry + supervisor wiring boot.
+  - type: builtin.stub
+    name: stub
+
+  # A real background endpoint with a run-loop — a good supervision target
+  # (the shakedown can kill it and confirm the supervisor restarts it).
+  - type: builtin.scheduler
+    name: scheduler
+  # NOTE: no HTTP-mounted endpoint here on purpose — the v0.8.x config schema
+  # changed (handoff_jobs no longer takes a `config:` block; the live v0.7.0
+  # config would fail v0.8.x validation — a promotion migration item). HTTP-
+  # surface testing moves to Phase 2 with the real MCP/discord endpoints.

--- a/staging/shakedown.sh
+++ b/staging/shakedown.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# agent_core staging shakedown — the pre-prod gate.
+#
+# Builds the staging image for a candidate version, boots it as an isolated
+# container, and asserts the daemon comes up clean. Exits 0 = candidate is
+# clear to promote to the live daemon; non-zero = do NOT promote.
+#
+# Usage:
+#   ./shakedown.sh                          # pypi, version 0.8.2 (default)
+#   INSTALL_MODE=pypi VERSION=0.8.2 ./shakedown.sh
+#   INSTALL_MODE=source REF=main ./shakedown.sh
+#
+# Nothing here touches the host bus/ports/vault — the container is the wall.
+set -uo pipefail
+
+INSTALL_MODE="${INSTALL_MODE:-pypi}"
+VERSION="${VERSION:-0.8.2}"
+REF="${REF:-main}"
+IMAGE="agent-core-staging:${INSTALL_MODE}-${VERSION}"
+NAME="agent-core-canary"
+HOST_PORT="${HOST_PORT:-18789}"   # deliberately NOT 8789 (the live daemon's port)
+# pwd -W emits the Windows-style path (E:/…) that Windows Docker needs for the
+# build context; plain pwd emits the MSYS /e/… form Docker can't resolve.
+HERE="$(cd "$(dirname "$0")" && { pwd -W 2>/dev/null || pwd; })"
+
+pass() { echo "  ✅ $1"; }
+fail() { echo "  ❌ $1"; FAILED=1; }
+FAILED=0
+
+echo "=== agent_core staging shakedown =="
+echo "mode=$INSTALL_MODE version=$VERSION ref=$REF image=$IMAGE port=$HOST_PORT"
+
+cleanup() { docker rm -f "$NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+cleanup
+
+echo "--- build ---"
+if ! docker build \
+      --build-arg "INSTALL_MODE=$INSTALL_MODE" \
+      --build-arg "VERSION=$VERSION" \
+      --build-arg "REF=$REF" \
+      -t "$IMAGE" "$HERE"; then
+  echo "RESULT: FAIL — image build failed (candidate does not even install)"
+  exit 1
+fi
+
+echo "--- boot (fully isolated container; daemon binds loopback, inspected via exec) ---"
+docker run -d --name "$NAME" "$IMAGE" >/dev/null
+
+# Wait for the daemon to come up (bus status returns cleanly), up to ~40s.
+booted=0
+for i in $(seq 1 20); do
+  if docker exec "$NAME" ac bus status --config /config/staging.yaml >/tmp/canary_status.txt 2>/tmp/canary_status.err; then
+    booted=1; break
+  fi
+  sleep 2
+done
+
+echo "--- assertions ---"
+installed_ver="$(docker exec "$NAME" cat /agent-core-version.txt 2>/dev/null | tr -d '\r')"
+[ -n "$installed_ver" ] && pass "installed agent-core-bus $installed_ver" || fail "could not read installed version"
+
+if [ "$booted" = "1" ]; then
+  pass "daemon booted — 'bus status' responds"
+else
+  fail "daemon did NOT boot within timeout"
+fi
+
+# Endpoints registered?
+status="$(cat /tmp/canary_status.txt 2>/dev/null)"
+echo "$status" | grep -qiE "\bstub\b"      && pass "endpoint 'stub' registered"      || fail "endpoint 'stub' missing"
+echo "$status" | grep -qiE "scheduler"     && pass "endpoint 'scheduler' registered" || fail "endpoint 'scheduler' missing"
+
+# No tracebacks / fatal errors in the boot logs?
+logs="$(docker logs "$NAME" 2>&1)"
+if echo "$logs" | grep -qiE "Traceback|CRITICAL|Fatal|Error: "; then
+  fail "boot logs contain errors:"
+  echo "$logs" | grep -iE "Traceback|CRITICAL|Fatal|Error: " | head -5 | sed 's/^/      /'
+else
+  pass "boot logs clean (no tracebacks)"
+fi
+
+# HTTP surface (informational — only binds when the config has HTTP-mounted
+# endpoints; the minimal Phase-1 config has none, so absence is expected).
+code="$(docker exec "$NAME" curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:8789/" 2>/dev/null)"
+if [ -n "$code" ] && [ "$code" != "000" ]; then
+  pass "http surface up (HTTP $code, loopback)"
+else
+  echo "  ℹ️  http surface not bound — expected (no HTTP-mounted endpoints in Phase-1 config)"
+fi
+
+echo "--- daemon status snapshot ---"
+echo "$status" | sed 's/^/      /' | head -20
+
+echo ""
+if [ "$FAILED" = "0" ]; then
+  echo "RESULT: PASS — candidate $installed_ver booted clean in isolation. Cleared to promote."
+  exit 0
+else
+  echo "RESULT: FAIL — do NOT promote. See failures above."
+  echo "  (logs: docker logs $NAME  |  the container is torn down on exit — comment out cleanup to inspect)"
+  exit 1
+fi


### PR DESCRIPTION
A standing test container to run a candidate agent_core version through **before promoting it to the live daemon**. Boots the daemon fully isolated (own filesystem, loopback bus, ephemeral SQLite, no vault/Discord) and asserts a clean boot. Reusable gate: `staging/shakedown.sh`.

**Phase 1 (this PR):** substrate boot gate — install, daemon up, endpoints register, logs clean. Green against `main`.

**Findings from the first run** (why a staging gate earns its keep):
- The bus correctly **refuses a non-loopback HTTP bind without an auth hook** (security hardening working).
- The `handoff_jobs` **config schema changed since v0.7.0** — the live daemon's config would fail v0.8.x validation, so promotion needs a config-migration pass first.

Discord + brain + supervision-kill are phased in `staging/README.md`. No Python touched.