### PR TITLE
feat(venv): canonical .mcp.json generator (C2-2, #316)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,9 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+# ...but agent_core.venv is a SOURCE package, not a virtualenv — don't ignore it.
+!packages/core/src/agent_core/venv/
+!packages/core/src/agent_core/venv/**
 
 # Spyder project settings
 .spyderproject

--- a/packages/agent-core-hatchery/src/agent_core_hatchery/hatcher.py
+++ b/packages/agent-core-hatchery/src/agent_core_hatchery/hatcher.py
@@ -26,12 +26,6 @@ class VaultExistsError(Exception):
     """Raised when default-mode hatch is attempted against an existing vault."""
 
 
-class HatchError(RuntimeError):
-    """Raised when a hatch cannot complete because a required subsystem is
-    unavailable — surfaced as a clear, actionable message rather than a cryptic
-    ImportError deep in the build."""
-
-
 @dataclass
 class HatchResult:
     vault_root: Path
@@ -194,10 +188,7 @@ class Hatcher:
         """Rename the placeholder `_being_/` segment to <being_name_lower>/."""
         parts = list(rel.parts)
         if "_being_" in parts:
-            parts = [
-                self._config.being_name_lower if p == "_being_" else p
-                for p in parts
-            ]
+            parts = [self._config.being_name_lower if p == "_being_" else p for p in parts]
         return Path(*parts) if parts else rel
 
     def _copy_skills_tree(self, result: HatchResult) -> None:
@@ -205,9 +196,7 @@ class Hatcher:
         if not skills_src.is_dir():
             return
 
-        skills_dest = (
-            self._config.resolved_vault_root() / ".claude" / "skills"
-        )
+        skills_dest = self._config.resolved_vault_root() / ".claude" / "skills"
         for src in sorted(skills_src.rglob("*")):
             rel = src.relative_to(skills_src)
             dest = skills_dest / rel
@@ -246,6 +235,7 @@ class Hatcher:
             stable = self._venv_builder(self._config.being_name_lower)
         else:
             from agent_core.venv.builder import build_being_venv  # C2-1 (#315)
+
             stable = build_being_venv(self._config.being_name_lower)
 
         self._tracked_writes.append(stable)
@@ -255,8 +245,8 @@ class Hatcher:
         """Write the being's .mcp.json via C2-2's canonical generator (Cβ-3, #327).
 
         Uses the injected _mcp_json_gen callable if set (for tests); otherwise
-        lazy-imports C2-2's generate_mcp_json from agent_core.venv.mcp_config
-        (module path to be confirmed once #316 merges — update here then).
+        delegates to C2-2's generate_mcp_json (agent_core.venv.mcp_config, #316),
+        which writes the stable-interpreter shape the hatchery reuses.
 
         Appends the returned path to _tracked_writes for transactional rollback.
         """
@@ -267,22 +257,8 @@ class Hatcher:
                 daemon_config_dir=self._config.resolved_daemon_config_dir(),
             )
         else:
-            # C2-2 (#316): not yet merged. Fail with a clear, actionable error
-            # instead of a bare ImportError surfacing after the venv is built —
-            # a real (non-injected) hatch cannot complete until #316 lands.
-            # Expected module path: agent_core.venv.mcp_config (confirm on merge).
-            # Expected contract: generate_mcp_json(target, *, vault_root, ...) -> Path
-            try:
-                from agent_core.venv.mcp_config import (  # type: ignore[import-not-found]
-                    generate_mcp_json,
-                )
-            except ImportError as exc:
-                raise HatchError(
-                    "Cannot generate the being's .mcp.json: the canonical "
-                    "generator agent_core.venv.mcp_config (C2-2, #316) is not "
-                    "yet available, so a real hatch cannot complete. Inject "
-                    "_mcp_json_gen to hatch before #316 merges."
-                ) from exc
+            from agent_core.venv.mcp_config import generate_mcp_json
+
             path = generate_mcp_json(
                 self._config.being_name_lower,
                 vault_root=self._config.resolved_vault_root(),

--- a/packages/agent-core-hatchery/tests/test_hatcher_basic.py
+++ b/packages/agent-core-hatchery/tests/test_hatcher_basic.py
@@ -1,11 +1,12 @@
 """Integration test: --config mode renders a complete vault into a tmpdir."""
 
+import json
 import re
 from pathlib import Path
 
 import pytest
 from agent_core_hatchery.config import HatchConfig
-from agent_core_hatchery.hatcher import Hatcher, HatchError, VaultExistsError
+from agent_core_hatchery.hatcher import Hatcher, VaultExistsError
 
 
 def _noop_venv_builder(target: str) -> Path:
@@ -169,14 +170,14 @@ def test_no_gendered_pronouns_in_rendered_vault(tmp_path):
     )
 
 
-def test_hatch_without_injected_mcp_gen_fails_clearly(tmp_path):
-    """The real (non-injected) hatch path must fail with a clear HatchError.
+def test_hatch_without_injected_mcp_gen_uses_real_generator(tmp_path):
+    """The real (non-injected) hatch path writes a canonical .mcp.json.
 
-    ``_generate_mcp_json`` lazy-imports agent_core.venv.mcp_config (C2-2, #316),
-    which is not yet merged — so a real hatch cannot complete. Every other test
-    injects ``_mcp_json_gen``, hiding this; this drives the real path and pins a
-    clear, actionable error instead of a cryptic post-venv ImportError.
-    Adversarial review finding #5.
+    ``_generate_mcp_json`` delegates to C2-2's agent_core.venv.mcp_config
+    (#316, now merged). Every other test injects ``_mcp_json_gen``; this one
+    drives the real generator to prove the wiring end-to-end — a real hatch
+    produces a valid, stable-interpreter .mcp.json (closing the hatchery's
+    "never generates .mcp.json" gap by construction).
     """
     cfg = HatchConfig(
         being_name="TestBeing",
@@ -185,7 +186,14 @@ def test_hatch_without_injected_mcp_gen_fails_clearly(tmp_path):
         daemon_config_dir=str(tmp_path / ".agent-core"),
     )
     # Inject only the venv builder to isolate the mcp path; leave _mcp_json_gen
-    # unset so the real generator import is exercised.
+    # unset so the real generator runs.
     hatcher = Hatcher(cfg, _venv_builder=_noop_venv_builder)
-    with pytest.raises(HatchError, match="#316"):
-        hatcher.hatch()
+    result = hatcher.hatch()
+
+    mcp_path = cfg.resolved_vault_root() / ".mcp.json"
+    assert mcp_path.is_file()
+    assert mcp_path in result.files_written
+    doc = json.loads(mcp_path.read_text(encoding="utf-8"))
+    assert set(doc["mcpServers"]) == {"agent-core", "agent-core-channel", "notify"}
+    # The C2-2 P0 regression guard: stable interpreter, never version-stamped.
+    assert ".venv-" not in doc["mcpServers"]["agent-core"]["command"]

--- a/packages/core/src/agent_core/venv/cli.py
+++ b/packages/core/src/agent_core/venv/cli.py
@@ -58,3 +58,31 @@ def upgrade(
 ) -> None:
     """Alias for build: upgrade the pinned venv for a being or the daemon."""
     _do_build(target, python_version)
+
+
+@venv_app.command("regen-mcp")
+def regen_mcp(
+    target: str = typer.Argument(..., help="Being name (e.g. 'wren', 'pepper')."),
+) -> None:
+    """Regenerate a being's canonical .mcp.json (C2-2, #316).
+
+    Rewrites the stable-interpreter shape only if the current file is missing
+    or drifted (e.g. a version-stamped path). This is the migration tool for
+    moving a live being off a ``.venv-<version>`` interpreter path.
+    """
+    from agent_core.venv.builder import home_for_target
+    from agent_core.venv.mcp_config import repair_mcp_json
+
+    if target == "daemon":
+        console.print("[red]the daemon has no .mcp.json[/red] — pass a being name.")
+        raise typer.Exit(code=2)
+
+    path, changed = repair_mcp_json(
+        target,
+        vault_root=home_for_target(target),
+        daemon_config_dir=home_for_target("daemon"),
+    )
+    if changed:
+        console.print(f"[green].mcp.json regenerated:[/green] {path}")
+    else:
+        console.print(f"[dim].mcp.json already canonical:[/dim] {path}")

--- a/packages/core/src/agent_core/venv/mcp_config.py
+++ b/packages/core/src/agent_core/venv/mcp_config.py
@@ -1,0 +1,239 @@
+"""Canonical ``.mcp.json`` generator (C2-2, issue #316).
+
+Each being's ``.mcp.json`` lists three stdio MCP servers — ``agent-core``
+(busproxy), ``agent-core-channel``, and ``notify`` — that Claude Code launches
+as subprocesses. Every server's ``command`` is the being's Python interpreter.
+
+The headline ``[P0]`` this module fixes: that interpreter path used to be
+hand-written as a **version-stamped, machine-specific** absolute path
+(``…/.agent-core/.venv-v0.7.0/Scripts/python.exe``), so every venv bump
+stranded the being. The canonical shape instead points at the **stable**
+per-being venv path ``~/.<being>/.venv/…`` that the venv builder (C2-1)
+atomically repoints across upgrades.
+
+Two correctness invariants worth stating loudly:
+
+* The path is written **absolute**, because Claude Code does not expand ``~``
+  or environment variables in an MCP ``command``.
+* The path is **never symlink-resolved**. ``~/.<being>/.venv`` is a junction
+  to the current versioned dir; resolving it would land back on
+  ``…/venvs/<version>/`` and re-introduce the exact version-stamp drift this
+  generator exists to kill. We build the path from the stable location only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from agent_core.venv.builder import (
+    home_for_target,
+    python_in_venv,
+    stable_venv_path,
+)
+
+#: Filename of a being's MCP server manifest, written at its vault root.
+MCP_JSON_NAME = ".mcp.json"
+
+#: Loopback bus URL used when the daemon config declares no explicit port.
+_DEFAULT_DAEMON_PORT = 8789
+
+
+def stable_interpreter(being_name: str) -> Path:
+    """Return the stable, absolute interpreter path for a being's venv.
+
+    ``~/.<being>/.venv/<bin>/python[.exe]`` — the junction path the venv
+    builder repoints on upgrade. Deliberately **not** resolved through the
+    junction, so a venv version bump never strands the being (the C2-2
+    headline P0).
+
+    Args:
+        being_name: Lowercased being name (e.g. ``"wren"``).
+
+    Returns:
+        The absolute interpreter path (unresolved junction).
+    """
+    return python_in_venv(stable_venv_path(home_for_target(being_name)))
+
+
+def _daemon_url(daemon_config_dir: Path) -> str:
+    """Return the loopback bus URL, taking the port from the daemon config.
+
+    Reads ``http.bind_port`` from ``<daemon_config_dir>/agent_core.yaml`` when
+    present; falls back to the default port otherwise. The host is always
+    ``127.0.0.1``: the bus binds loopback, and an MCP client connects over
+    loopback regardless of the server's advertised ``bind_host``.
+
+    Args:
+        daemon_config_dir: The daemon's config directory (e.g. ``~/.agent-core``).
+
+    Returns:
+        A ``http://127.0.0.1:<port>`` URL.
+    """
+    port = _DEFAULT_DAEMON_PORT
+    config_path = daemon_config_dir / "agent_core.yaml"
+    try:
+        raw: Any = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return f"http://127.0.0.1:{port}"
+    http = raw.get("http") if isinstance(raw, dict) else None
+    if isinstance(http, dict) and isinstance(http.get("bind_port"), int):
+        port = http["bind_port"]
+    return f"http://127.0.0.1:{port}"
+
+
+def build_mcp_config(
+    being_name: str,
+    *,
+    daemon_url: str,
+    interpreter: Path,
+) -> dict[str, Any]:
+    """Return the canonical ``.mcp.json`` document for a being.
+
+    Pure and deterministic — no filesystem access — so it is the single source
+    of truth shared by :func:`generate_mcp_json` (writes) and
+    :func:`mcp_json_needs_repair` (compares).
+
+    Args:
+        being_name: Lowercased being name, used as the ``--agent`` value.
+        daemon_url: The bus URL passed to the busproxy and channel servers.
+        interpreter: The stable interpreter path used as every server's command.
+
+    Returns:
+        The ``.mcp.json`` document as a nested dict.
+    """
+    command = str(interpreter)
+    return {
+        "mcpServers": {
+            "agent-core": {
+                "type": "stdio",
+                "command": command,
+                "args": [
+                    "-m",
+                    "agent_core_busproxy",
+                    "--agent",
+                    being_name,
+                    "--daemon-url",
+                    daemon_url,
+                ],
+            },
+            "agent-core-channel": {
+                "type": "stdio",
+                "command": command,
+                "args": [
+                    "-m",
+                    "agent_core_channel",
+                    "--agent",
+                    being_name,
+                    "--daemon-url",
+                    daemon_url,
+                ],
+            },
+            "notify": {
+                "type": "stdio",
+                "command": command,
+                "args": ["-m", "agent_core_notify.mcp_server"],
+            },
+        }
+    }
+
+
+def generate_mcp_json(
+    being_name: str,
+    *,
+    vault_root: Path,
+    daemon_config_dir: Path,
+) -> Path:
+    """Write a being's canonical ``.mcp.json`` and return its path.
+
+    Overwrites any existing (possibly drifted) file — this is the write half of
+    the generate/repair pair, and the entry point the hatchery reuses (Theme C).
+
+    Args:
+        being_name: Lowercased being name.
+        vault_root: The being's vault directory; ``.mcp.json`` is written here.
+        daemon_config_dir: The daemon config dir, used to resolve the bus port.
+
+    Returns:
+        The path to the written ``.mcp.json``.
+    """
+    # The file is written at ``vault_root`` (where the being's project lives),
+    # but the interpreter is derived from the being's *venv* location
+    # (``home_for_target(being_name)``) — the exact path the C2-1 builder
+    # repoints. In the standard case these coincide (``vault_root`` defaults to
+    # the being's home); the interpreter must track the builder, not the write
+    # location, so a non-default ``vault_root`` never mis-points the command.
+    document = build_mcp_config(
+        being_name,
+        daemon_url=_daemon_url(daemon_config_dir),
+        interpreter=stable_interpreter(being_name),
+    )
+    path = vault_root / MCP_JSON_NAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def mcp_json_needs_repair(
+    being_name: str,
+    *,
+    vault_root: Path,
+    daemon_config_dir: Path,
+) -> bool:
+    """Return whether a being's ``.mcp.json`` is missing or not canonical.
+
+    A missing file, an unparseable file, or any deviation from the canonical
+    document (most importantly a version-stamped interpreter path) counts as
+    needing repair.
+
+    Args:
+        being_name: Lowercased being name.
+        vault_root: The being's vault directory.
+        daemon_config_dir: The daemon config dir, used to resolve the bus port.
+
+    Returns:
+        ``True`` if the file should be regenerated.
+    """
+    path = vault_root / MCP_JSON_NAME
+    if not path.is_file():
+        return True
+    try:
+        current = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return True
+    expected = build_mcp_config(
+        being_name,
+        daemon_url=_daemon_url(daemon_config_dir),
+        interpreter=stable_interpreter(being_name),
+    )
+    return current != expected
+
+
+def repair_mcp_json(
+    being_name: str,
+    *,
+    vault_root: Path,
+    daemon_config_dir: Path,
+) -> tuple[Path, bool]:
+    """Regenerate a being's ``.mcp.json`` only if it has drifted.
+
+    The idempotent entry point ``daemon doctor`` (M3) re-runs: a canonical file
+    is left untouched; a missing or drifted one is rewritten.
+
+    Args:
+        being_name: Lowercased being name.
+        vault_root: The being's vault directory.
+        daemon_config_dir: The daemon config dir, used to resolve the bus port.
+
+    Returns:
+        ``(path, changed)`` — ``changed`` is ``True`` iff the file was rewritten.
+    """
+    if not mcp_json_needs_repair(
+        being_name, vault_root=vault_root, daemon_config_dir=daemon_config_dir
+    ):
+        return vault_root / MCP_JSON_NAME, False
+    path = generate_mcp_json(being_name, vault_root=vault_root, daemon_config_dir=daemon_config_dir)
+    return path, True

--- a/packages/core/tests/test_venv_cli.py
+++ b/packages/core/tests/test_venv_cli.py
@@ -86,3 +86,30 @@ class TestVenvUpgradeCommand:
         _patch_build(monkeypatch, raises=UvNotFoundError("uv not found"))
         result = cli_runner.invoke(venv_app, ["upgrade", "daemon"])
         assert result.exit_code == 1
+
+
+class TestRegenMcpCommand:
+    def test_daemon_target_rejected(
+        self, cli_runner: CliRunner
+    ) -> None:
+        result = cli_runner.invoke(venv_app, ["regen-mcp", "daemon"])
+        assert result.exit_code == 2
+        assert "no .mcp.json" in result.output
+
+    def test_regenerates_and_reports(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        result = cli_runner.invoke(venv_app, ["regen-mcp", "wren"])
+        assert result.exit_code == 0
+        assert "regenerated" in result.output
+        assert (tmp_path / ".wren" / ".mcp.json").is_file()
+
+    def test_canonical_reports_no_change(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        cli_runner.invoke(venv_app, ["regen-mcp", "wren"])
+        result = cli_runner.invoke(venv_app, ["regen-mcp", "wren"])
+        assert result.exit_code == 0
+        assert "already canonical" in result.output

--- a/packages/core/tests/test_venv_mcp_config.py
+++ b/packages/core/tests/test_venv_mcp_config.py
@@ -1,0 +1,202 @@
+"""Unit tests for agent_core.venv.mcp_config (C2-2, issue #316)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from agent_core.venv.mcp_config import (
+    MCP_JSON_NAME,
+    build_mcp_config,
+    generate_mcp_json,
+    mcp_json_needs_repair,
+    repair_mcp_json,
+    stable_interpreter,
+)
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point Path.home() at a temp dir so being/daemon homes are isolated."""
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    return tmp_path
+
+
+def _expected_python(home: Path, being: str) -> Path:
+    bin_dir = "Scripts" if sys.platform == "win32" else "bin"
+    exe = "python.exe" if sys.platform == "win32" else "python"
+    return home / f".{being}" / ".venv" / bin_dir / exe
+
+
+# ---------------------------------------------------------------------------
+# stable_interpreter — the headline P0 regression guard
+# ---------------------------------------------------------------------------
+
+class TestStableInterpreter:
+    def test_points_at_stable_venv(self, home: Path) -> None:
+        assert stable_interpreter("wren") == _expected_python(home, "wren")
+
+    def test_is_absolute(self, home: Path) -> None:
+        assert stable_interpreter("wren").is_absolute()
+
+    def test_not_version_stamped(self, home: Path) -> None:
+        # The whole point of C2-2: no ".venv-<version>" and no "venvs/<ver>".
+        text = str(stable_interpreter("pepper"))
+        assert ".venv-" not in text
+        assert f"{Path('venvs')}" not in text
+
+    def test_per_being_home(self, home: Path) -> None:
+        assert stable_interpreter("pepper") == _expected_python(home, "pepper")
+
+
+# ---------------------------------------------------------------------------
+# build_mcp_config — the canonical document
+# ---------------------------------------------------------------------------
+
+class TestBuildMcpConfig:
+    def test_three_servers_with_expected_keys(self) -> None:
+        doc = build_mcp_config("wren", daemon_url="http://127.0.0.1:8789", interpreter=Path("/x/py"))
+        assert set(doc["mcpServers"]) == {"agent-core", "agent-core-channel", "notify"}
+
+    def test_every_command_is_the_interpreter(self) -> None:
+        doc = build_mcp_config("wren", daemon_url="http://127.0.0.1:8789", interpreter=Path("/x/py"))
+        for server in doc["mcpServers"].values():
+            assert server["type"] == "stdio"
+            assert server["command"] == str(Path("/x/py"))
+
+    def test_busproxy_and_channel_carry_agent_and_url(self) -> None:
+        doc = build_mcp_config("wren", daemon_url="http://127.0.0.1:9999", interpreter=Path("/x/py"))
+        assert doc["mcpServers"]["agent-core"]["args"] == [
+            "-m", "agent_core_busproxy", "--agent", "wren", "--daemon-url", "http://127.0.0.1:9999",
+        ]
+        assert doc["mcpServers"]["agent-core-channel"]["args"] == [
+            "-m", "agent_core_channel", "--agent", "wren", "--daemon-url", "http://127.0.0.1:9999",
+        ]
+
+    def test_notify_has_no_agent_or_url(self) -> None:
+        doc = build_mcp_config("wren", daemon_url="http://127.0.0.1:8789", interpreter=Path("/x/py"))
+        assert doc["mcpServers"]["notify"]["args"] == ["-m", "agent_core_notify.mcp_server"]
+
+
+# ---------------------------------------------------------------------------
+# _daemon_url — port resolution from the daemon config
+# ---------------------------------------------------------------------------
+
+class TestDaemonUrl:
+    def test_defaults_when_no_config(self, tmp_path: Path) -> None:
+        doc = generate_mcp_json("wren", vault_root=tmp_path / "v", daemon_config_dir=tmp_path / "d")
+        args = json.loads(doc.read_text())["mcpServers"]["agent-core"]["args"]
+        assert args[-1] == "http://127.0.0.1:8789"
+
+    def test_reads_bind_port_from_config(self, tmp_path: Path) -> None:
+        dcfg = tmp_path / "d"
+        dcfg.mkdir()
+        (dcfg / "agent_core.yaml").write_text("http:\n  bind_host: 0.0.0.0\n  bind_port: 9001\n")
+        doc = generate_mcp_json("wren", vault_root=tmp_path / "v", daemon_config_dir=dcfg)
+        args = json.loads(doc.read_text())["mcpServers"]["agent-core"]["args"]
+        # Host is forced to loopback even though the config binds 0.0.0.0.
+        assert args[-1] == "http://127.0.0.1:9001"
+
+    def test_malformed_config_falls_back(self, tmp_path: Path) -> None:
+        dcfg = tmp_path / "d"
+        dcfg.mkdir()
+        (dcfg / "agent_core.yaml").write_text(": not valid yaml :\n  - [")
+        doc = generate_mcp_json("wren", vault_root=tmp_path / "v", daemon_config_dir=dcfg)
+        args = json.loads(doc.read_text())["mcpServers"]["agent-core"]["args"]
+        assert args[-1] == "http://127.0.0.1:8789"
+
+    def test_non_mapping_config_falls_back(self, tmp_path: Path) -> None:
+        # Valid YAML that parses to a list, not a mapping.
+        dcfg = tmp_path / "d"
+        dcfg.mkdir()
+        (dcfg / "agent_core.yaml").write_text("- just\n- a\n- list\n")
+        doc = generate_mcp_json("wren", vault_root=tmp_path / "v", daemon_config_dir=dcfg)
+        args = json.loads(doc.read_text())["mcpServers"]["agent-core"]["args"]
+        assert args[-1] == "http://127.0.0.1:8789"
+
+
+# ---------------------------------------------------------------------------
+# generate_mcp_json — writing
+# ---------------------------------------------------------------------------
+
+class TestGenerateMcpJson:
+    def test_writes_file_and_returns_path(self, home: Path, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        path = generate_mcp_json("wren", vault_root=vault, daemon_config_dir=tmp_path / "d")
+        assert path == vault / MCP_JSON_NAME
+        assert path.is_file()
+
+    def test_creates_missing_parent(self, home: Path, tmp_path: Path) -> None:
+        vault = tmp_path / "deep" / "vault"
+        path = generate_mcp_json("wren", vault_root=vault, daemon_config_dir=tmp_path / "d")
+        assert path.is_file()
+
+    def test_command_is_the_stable_interpreter(self, home: Path, tmp_path: Path) -> None:
+        path = generate_mcp_json("wren", vault_root=tmp_path / "v", daemon_config_dir=tmp_path / "d")
+        doc = json.loads(path.read_text())
+        assert doc["mcpServers"]["agent-core"]["command"] == str(_expected_python(home, "wren"))
+
+    def test_overwrites_drifted_version_stamped_file(self, home: Path, tmp_path: Path) -> None:
+        vault = tmp_path / "v"
+        vault.mkdir()
+        drifted = {
+            "mcpServers": {
+                "agent-core": {
+                    "type": "stdio",
+                    "command": r"C:\Users\x\.agent-core\.venv-v0.7.0\Scripts\python.exe",
+                    "args": ["-m", "agent_core_busproxy", "--agent", "wren", "--daemon-url", "http://127.0.0.1:8789"],
+                }
+            }
+        }
+        (vault / MCP_JSON_NAME).write_text(json.dumps(drifted))
+        path = generate_mcp_json("wren", vault_root=vault, daemon_config_dir=tmp_path / "d")
+        doc = json.loads(path.read_text())
+        assert ".venv-" not in doc["mcpServers"]["agent-core"]["command"]
+        assert set(doc["mcpServers"]) == {"agent-core", "agent-core-channel", "notify"}
+
+
+# ---------------------------------------------------------------------------
+# repair — idempotent drift detection
+# ---------------------------------------------------------------------------
+
+class TestRepair:
+    def test_needs_repair_when_missing(self, home: Path, tmp_path: Path) -> None:
+        assert mcp_json_needs_repair("wren", vault_root=tmp_path / "v", daemon_config_dir=tmp_path / "d")
+
+    def test_needs_repair_when_unparseable(self, home: Path, tmp_path: Path) -> None:
+        vault = tmp_path / "v"
+        vault.mkdir()
+        (vault / MCP_JSON_NAME).write_text("{ not json")
+        assert mcp_json_needs_repair("wren", vault_root=vault, daemon_config_dir=tmp_path / "d")
+
+    def test_canonical_file_needs_no_repair(self, home: Path, tmp_path: Path) -> None:
+        vault = tmp_path / "v"
+        generate_mcp_json("wren", vault_root=vault, daemon_config_dir=tmp_path / "d")
+        assert not mcp_json_needs_repair("wren", vault_root=vault, daemon_config_dir=tmp_path / "d")
+
+    def test_repair_leaves_canonical_untouched(self, home: Path, tmp_path: Path) -> None:
+        vault = tmp_path / "v"
+        generate_mcp_json("wren", vault_root=vault, daemon_config_dir=tmp_path / "d")
+        before = (vault / MCP_JSON_NAME).read_text()
+        path, changed = repair_mcp_json("wren", vault_root=vault, daemon_config_dir=tmp_path / "d")
+        assert changed is False
+        assert path.read_text() == before
+
+    def test_repair_rewrites_drift(self, home: Path, tmp_path: Path) -> None:
+        vault = tmp_path / "v"
+        vault.mkdir()
+        (vault / MCP_JSON_NAME).write_text('{"mcpServers": {"stale": {}}}')
+        path, changed = repair_mcp_json("wren", vault_root=vault, daemon_config_dir=tmp_path / "d")
+        assert changed is True
+        assert set(json.loads(path.read_text())["mcpServers"]) == {
+            "agent-core", "agent-core-channel", "notify",
+        }
+
+    def test_generate_then_repair_is_stable(self, home: Path, tmp_path: Path) -> None:
+        vault = tmp_path / "v"
+        generate_mcp_json("wren", vault_root=vault, daemon_config_dir=tmp_path / "d")
+        _, changed = repair_mcp_json("wren", vault_root=vault, daemon_config_dir=tmp_path / "d")
+        assert changed is False


### PR DESCRIPTION
Closes #316 (C2-2 · canonical `.mcp.json` generator, headline `[P0]`).

## Why

Each being's `.mcp.json` was **hand-written**, so it drifted to a
**version-stamped, machine-specific** interpreter path
(`…\.agent-core\.venv-v0.7.0\Scripts\python.exe`). A venv bump strands every
being. And the hatchery had **no generator at all** — a real hatch could not
complete (`_generate_mcp_json` raised a `#316-not-merged` error), which is what
blocked hatching a being end-to-end.

## What

A canonical generator in `agent_core.venv.mcp_config` (part of `agent-core-bus`):

- **`generate_mcp_json(being, *, vault_root, daemon_config_dir)`** — writes the
  three stdio servers (`agent-core`/busproxy, `agent-core-channel`, `notify`)
  with the **stable** interpreter `~/.<being>/.venv/…` the C2-1 builder
  repoints. Two invariants: the path is absolute (Claude Code doesn't expand
  `~`), and it is **never `resolve()`d** — resolving the `.venv` junction would
  land back on `…/venvs/<ver>/` and re-introduce the exact drift this kills.
- **`repair_mcp_json` / `mcp_json_needs_repair`** — idempotent drift detection
  (missing / unparseable / non-canonical → rewrite), the entry point M3's
  `daemon doctor` will re-run.
- **`agent-core venv regen-mcp <being>`** — the migration CLI.
- **Hatchery wiring** — `_generate_mcp_json` now delegates to the real
  generator; the obsolete guard + orphaned `HatchError` are removed. This
  **closes the hatchery's "never generates `.mcp.json`" gap by construction**
  and unblocks a real hatch.
- **`.gitignore` fix** — the broad `venv/` rule was silently ignoring the
  *source* package `packages/core/src/agent_core/venv/` (every new module there
  needed `git add -f`). Negated.

## Deliberately NOT in this PR: the live Wren/Pepper migration

The ticket lists "regenerate Wren's and Pepper's `.mcp.json`" — that is a
**runtime apply, not code**, and it is **not safe yet**: `~/.wren/.venv` and
`~/.pepper/.venv` **do not exist** (their per-being venvs were never built; the
live files still point at the intact `~/.agent-core/.venv-v0.7.0`). Regenerating
the path now would point at a missing interpreter and break both live beings'
MCP on next restart. The migration is a separate, sequenced, backed-up step —
`agent-core venv build wren|pepper` (now possible; sidecars published) → `venv
regen-mcp` → restart — done deliberately, keeping `.venv-v0.7.0` as fallback
until verified.

## Note on #316's 8-day "Failed"

No branch, PR, or partial code existed — the foreman planner died at its own
pre-push `just typecheck` gate (the known worktree-not-`uv sync`ed false-red),
not on a real code problem. Implemented fresh here.

## Test plan

- `just check` green: full suite passing, `mypy` clean (gate scope), ruff +
  format clean, coverage floor met, `diff-cover` ≥ 80 on changed lines.
- New unit tests: `test_venv_mcp_config.py` (stable-path regression guard,
  server shape, port resolution, generate/overwrite, repair idempotence),
  `test_venv_cli.py` (regen-mcp), and the rewritten hatchery test drives the
  **real** generator end-to-end.
