### PR TITLE
feat(hatchery): --no-daemon-reload for hatching without a live daemon

### DIFF
--- a/packages/agent-core-hatchery/src/agent_core_hatchery/cli.py
+++ b/packages/agent-core-hatchery/src/agent_core_hatchery/cli.py
@@ -23,20 +23,32 @@ app = typer.Typer(
 @app.callback(invoke_without_command=True)
 def hatch_being(
     config: Path | None = typer.Option(  # noqa: B008
-        None, "--config",
+        None,
+        "--config",
         help="Non-interactive: load HatchConfig from YAML.",
     ),
     vault_root: Path | None = typer.Option(  # noqa: B008
-        None, "--vault-root", "--root",
+        None,
+        "--vault-root",
+        "--root",
         help="Override the resolved vault root. Default: $HOME.",
     ),
     daemon_config_dir: Path | None = typer.Option(  # noqa: B008
-        None, "--daemon-config-dir",
+        None,
+        "--daemon-config-dir",
         help="Override the daemon's config directory. Default: ~/.agent-core/.",
     ),
     init_missing: bool = typer.Option(
-        False, "--init-missing",
+        False,
+        "--init-missing",
         help="Top-up an existing vault with newly-added scaffolding files.",
+    ),
+    no_daemon_reload: bool = typer.Option(
+        False,
+        "--no-daemon-reload",
+        help="Skip the post-hatch daemon reload+probe. Use when hatching without "
+        "a running installed daemon — CI, containers, or an air-gapped first "
+        "hatch. The being is still fully hatched; only the live handoff is skipped.",
     ),
 ) -> None:
     if config is not None:
@@ -64,13 +76,14 @@ def hatch_being(
     if interactive:
         letter_authored = offer_letter_authoring(cfg)
 
-    if not cfg.init_missing:
-        daemon_check_status = reload_and_probe(cfg)
-    else:
+    if cfg.init_missing or no_daemon_reload:
         daemon_check_status = "skipped"
+    else:
+        daemon_check_status = reload_and_probe(cfg)
 
     report_path = write_hatching_report(
-        cfg, result,
+        cfg,
+        result,
         letter_authored=letter_authored,
         daemon_check_status=daemon_check_status,
     )

--- a/packages/agent-core-hatchery/tests/test_cli_config_mode.py
+++ b/packages/agent-core-hatchery/tests/test_cli_config_mode.py
@@ -50,3 +50,33 @@ def test_config_mode_writes_hatching_report(tmp_path):
     report = tmp_path / ".testbeing" / "HATCHING-REPORT.md"
     assert report.is_file()
     assert "TestBeing" in report.read_text(encoding="utf-8")
+
+
+def test_no_daemon_reload_skips_probe_but_still_hatches(tmp_path):
+    """--no-daemon-reload fully hatches but never touches the daemon.
+
+    For CI / containers / air-gapped first hatch, where no installed daemon
+    exists to reload — the hard failure of the daemon handoff would otherwise
+    mask a fully successful hatch.
+    """
+    runner = CliRunner()
+    with (
+        patch("agent_core_hatchery.hatcher.Hatcher._build_being_venv"),
+        patch("agent_core_hatchery.hatcher.Hatcher._generate_mcp_json"),
+        patch("agent_core_hatchery.cli.reload_and_probe") as mock_probe,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "--config",
+                str(FIXTURES / "hatch-config-test-being.yaml"),
+                "--vault-root",
+                str(tmp_path),
+                "--daemon-config-dir",
+                str(tmp_path / ".agent-core"),
+                "--no-daemon-reload",
+            ],
+        )
+    assert result.exit_code == 0, result.stdout
+    mock_probe.assert_not_called()
+    assert (tmp_path / ".testbeing" / "HATCHING-REPORT.md").is_file()


### PR DESCRIPTION
## Why

After #316 landed, hatching a being in the staging container **fully succeeds** —
vault, sidecar venv, `.mcp.json`, and daemon fragments all written — but
`hatch-being` then **hard-exits 1** on its final step: `reload_and_probe`
(the Cβ-3/#327 hatch→run handoff) calls `agent-core daemon start`, which needs
an *installed* daemon. In CI, a container, or an air-gapped first hatch there is
no such daemon, so a fully successful hatch is masked by a daemon-handoff
failure it can do nothing about — and there was no way to opt out.

## What

`hatch-being --no-daemon-reload` skips **only** the post-hatch daemon
reload+probe (status → `skipped`, exit 0). The being is still fully hatched;
just the live handoff is left for the operator to do when a daemon exists.

- One flag, one branch change in the CLI (`cfg.init_missing or no_daemon_reload`
  → skip).
- Test: `--no-daemon-reload` fully hatches (report written) and
  `reload_and_probe` is asserted **never called**.

(`ruff format` also normalized the adjacent `typer.Option` defs to multi-line;
the file wasn't format-clean on `main` and the gate doesn't check format per
#433.)

## Test plan

`just check` green. Downstream: the staging hatch gate passes
`--no-daemon-reload` and now completes a full green hatch→boot in an isolated
container (no live daemon required).
