### PR TITLE
test: promote aiosqlite leak-guard to root + windows hang breadcrumb (#535)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,28 @@
 
 from __future__ import annotations
 
+import sys
+import threading
+import time
+from collections.abc import Iterator
+
+import pytest
 from hypothesis import HealthCheck, settings
+
+
+def pytest_runtest_logstart(nodeid: str, location: object) -> None:
+    """Windows-only breadcrumb naming each test as it starts.
+
+    The intermittent windows-CI hang (agent_core#535) is a suspended coroutine
+    on the ProactorEventLoop: ``pytest-timeout``'s ``timeout_method="thread"``
+    dumps thread stacks but the hung test's own frame is *in the event-loop
+    task*, not the main sync stack — so under ``-q`` the CI log never names the
+    offending test. This breadcrumb (stderr, flushed, win32 only) means the
+    LAST ``[run]`` line before a timeout dump identifies the culprit, without
+    the noise of a full ``-v`` run on the Linux/macOS legs.
+    """
+    if sys.platform == "win32":
+        print(f"[run] {nodeid}", file=sys.stderr, flush=True)
 
 # Hypothesis enforces a per-example deadline (200ms by default) measured in
 # wall-clock time. Under our default `-n auto` xdist run, many workers
@@ -20,3 +41,73 @@ settings.register_profile(
     suppress_health_check=[HealthCheck.too_slow],
 )
 settings.load_profile("default")
+
+
+# ---------------------------------------------------------------------------
+# aiosqlite connection-leak guard
+#
+# Promoted from ``packages/core/tests/conftest.py`` to this repo-root conftest
+# (2026-07-24) so it covers EVERY package's tests, not just core. The original
+# core-only guard could not see leaks from tests in other packages (qa, voice,
+# webcam, credentials, …) that build a bus / open a persistence connection —
+# those leaked aiosqlite worker threads accumulated suite-wide until a random
+# test hung on the Windows ProactorEventLoop (pytest-timeout → "ASGI callable
+# returned without completing response"). Running the guard at repo scope turns
+# that non-deterministic windows-CI hang into a localized, named failure at the
+# offending test. See agent_core#535, #468 (original core-scoped guard).
+# ---------------------------------------------------------------------------
+
+
+def _live_aiosqlite_threads() -> list[threading.Thread]:
+    """Return the currently-alive ``aiosqlite`` connection worker threads.
+
+    ``aiosqlite.Connection`` runs one ``threading.Thread`` per open connection
+    (``target=_connection_worker_thread``) until the connection is closed. The
+    thread is matched by its target function name — robust across aiosqlite
+    versions — with the auto-generated thread name as a fallback.
+    """
+    threads: list[threading.Thread] = []
+    for t in threading.enumerate():
+        if not t.is_alive():
+            continue
+        target = getattr(t, "_target", None)
+        target_name = getattr(target, "__name__", "") if target is not None else ""
+        if target_name == "_connection_worker_thread" or ("_connection_worker_thread" in t.name):
+            threads.append(t)
+    return threads
+
+
+@pytest.fixture(autouse=True)
+def fail_on_leaked_aiosqlite_connection() -> Iterator[None]:
+    """Fail any test that leaks an ``aiosqlite`` connection thread.
+
+    Each ``aiosqlite.connect`` starts a background ``Connection`` thread that
+    lives until the connection is closed. A test that opens a bus/persistence
+    connection and never closes it leaks that thread; across the suite they
+    accumulate until the asyncio selector chokes and a random test hangs
+    (``pytest-timeout`` → "ASGI callable returned without completing response")
+    — a non-deterministic failure that blocks CI and wedges the merge queue.
+    This guard turns that downstream flake into a deterministic, localized
+    failure at the offending test.
+
+    Fix a flagged test by building buses via the ``build_bus`` fixture, or by
+    calling ``await store.close()`` / ``await bus.stop()`` in teardown.
+    """
+    before = {id(t) for t in _live_aiosqlite_threads()}
+    yield
+    # aiosqlite joins its worker thread asynchronously after ``close()``; allow
+    # a brief grace so a properly-closed connection mid-teardown is not flagged.
+    leaked: list[threading.Thread] = []
+    for _ in range(100):  # up to ~1s
+        leaked = [t for t in _live_aiosqlite_threads() if id(t) not in before]
+        if not leaked:
+            break
+        time.sleep(0.01)
+    if leaked:
+        pytest.fail(
+            f"leaked {len(leaked)} aiosqlite connection thread(s) — the test "
+            "opened a bus/persistence connection without closing it. Build "
+            "buses via the `build_bus` fixture, or `await store.close()` / "
+            "`await bus.stop()` in teardown.",
+            pytrace=False,
+        )

--- a/packages/core/tests/conftest.py
+++ b/packages/core/tests/conftest.py
@@ -16,9 +16,7 @@ closed — inside the test's own event loop.
 from __future__ import annotations
 
 import sys
-import threading
-import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 
 import pytest
@@ -81,56 +79,7 @@ async def build_bus() -> AsyncIterator[BusFactory]:
         await bus.stop()
 
 
-def _live_aiosqlite_threads() -> list[threading.Thread]:
-    """Return the currently-alive ``aiosqlite`` connection worker threads.
-
-    ``aiosqlite.Connection`` runs one ``threading.Thread`` per open connection
-    (``target=_connection_worker_thread``) until the connection is closed. The
-    thread is matched by its target function name — robust across aiosqlite
-    versions — with the auto-generated thread name as a fallback.
-    """
-    threads: list[threading.Thread] = []
-    for t in threading.enumerate():
-        if not t.is_alive():
-            continue
-        target = getattr(t, "_target", None)
-        target_name = getattr(target, "__name__", "") if target is not None else ""
-        if target_name == "_connection_worker_thread" or ("_connection_worker_thread" in t.name):
-            threads.append(t)
-    return threads
-
-
-@pytest.fixture(autouse=True)
-def fail_on_leaked_aiosqlite_connection() -> Iterator[None]:
-    """Fail any test that leaks an ``aiosqlite`` connection thread.
-
-    Each ``aiosqlite.connect`` starts a background ``Connection`` thread that
-    lives until the connection is closed. A test that opens a bus/persistence
-    connection and never closes it leaks that thread; across the suite they
-    accumulate into the thousands until the asyncio selector chokes and a
-    random test hangs (``pytest-timeout`` → "ASGI callable returned without
-    completing response") — a non-deterministic failure that blocks CI and
-    wedges the merge queue. This guard turns that downstream flake into a
-    deterministic, localized failure at the offending test.
-
-    Fix a flagged test by building buses via the :func:`build_bus` fixture, or
-    by calling ``await store.close()`` / ``await bus.stop()`` in teardown.
-    """
-    before = {id(t) for t in _live_aiosqlite_threads()}
-    yield
-    # aiosqlite joins its worker thread asynchronously after ``close()``; allow
-    # a brief grace so a properly-closed connection mid-teardown is not flagged.
-    leaked: list[threading.Thread] = []
-    for _ in range(100):  # up to ~1s
-        leaked = [t for t in _live_aiosqlite_threads() if id(t) not in before]
-        if not leaked:
-            break
-        time.sleep(0.01)
-    if leaked:
-        pytest.fail(
-            f"leaked {len(leaked)} aiosqlite connection thread(s) — the test "
-            "opened a bus/persistence connection without closing it. Build "
-            "buses via the `build_bus` fixture, or `await store.close()` / "
-            "`await bus.stop()` in teardown.",
-            pytrace=False,
-        )
+# NOTE: the ``fail_on_leaked_aiosqlite_connection`` autouse guard was promoted
+# to the repo-root ``conftest.py`` (2026-07-24, agent_core#535) so it covers
+# every package's tests, not just core. It still applies to these tests via
+# inheritance from the root conftest.


### PR DESCRIPTION
## Harden aiosqlite leak detection + make the windows hang diagnosable (#535)

Investigation of the recurring **windows-only CI hang** (`ASGI callable returned
without completing response`, pytest-timeout) using systematic debugging.

### What the investigation found
- The pytest-timeout dump shows a **live aiosqlite `_connection_worker_thread`** +
  the MainThread blocked in windows IOCP (`GetQueuedCompletionStatus`) — an
  event loop waiting on I/O that never completes.
- **It is NOT an aiosqlite leak.** Promoting the `#468` leak-guard to repo scope
  and running the full suite is **leak-clean (1989 passed)**; there are no
  session/module-scoped bus fixtures either. **#468's fix is intact.**
- The hang is a **suspended coroutine on the windows ProactorEventLoop** in the
  bus HTTP-host tests (uvicorn). It **did not reproduce across ~23 local runs**
  (full suite ×1, core ×1, the 4 candidate bus-HTTP files ×20) — genuinely rare.
- **Why we can't name the culprit today:** `timeout_method="thread"` dumps thread
  stacks, but the hung test's frame is in the event-loop *task*, not the main
  sync stack — so under CI's `-q` the log never names the offending test.

### This PR (two changes)
1. **Promote `fail_on_leaked_aiosqlite_connection` to the repo-root conftest** so
   it guards *every* package's tests (was core-only). Fleet-wide leak detection;
   also proves the tree is currently leak-clean.
2. **Windows-only `[run] <nodeid>` breadcrumb** (`pytest_runtest_logstart`). The
   LAST `[run]` line before a timeout dump will name the hanging test on the next
   occurrence — no `-v` noise on the Linux/macOS legs.

### Honest scope
This **hardens + instruments**; it does not by itself fix the rare hang (it never
reproduced locally). The breadcrumb is what lets us pin + fix it the next time CI
hits it. Tracking continues in **#535**.
