### PR TITLE
docs(presence): mark the temporal-filter design superseded

### DIFF
--- a/docs/superpowers/specs/2026-08-03-presence-multiclass-tracks.md
+++ b/docs/superpowers/specs/2026-08-03-presence-multiclass-tracks.md
@@ -1,5 +1,25 @@
 # Presence v2 — per-track multi-class identity
 
+> ⚠️ **SUPERSEDED IN PART, SAME DAY — read this before acting on the design below.**
+>
+> This spec argues for a per-track temporal filter as the fix for flapping.
+> **It was not needed.** Flapping was an artifact of the absolute threshold, and
+> replacing that threshold with multi-class `identify()` removed it entirely:
+> the live flap rate went `33% -> 92% -> 100%` across (old threshold) ->
+> (pose-matched re-enrollment) -> (multi-class). **37/37 ticks correct, zero
+> smoothing.**
+>
+> Tracks, association and the log-odds accumulator are therefore **NOT BUILT and
+> not currently justified.** The measurements in the Design section are real and
+> worth keeping — IoU is ~0.94 at a 2s gap, so tracking would work — but "would
+> work" is not "is needed".
+>
+> What shipped instead: multi-class identification with two-gate open-set
+> rejection (score + margin), wired at level 3 for Wren and level 2 for Pepper.
+>
+> **Revisit this design only if flapping returns** — e.g. with more enrolled
+> identities, or if ID-switching between two present people becomes a real case.
+
 **Author:** Wren · **Date:** 2026-08-03 · **Status:** design, not approved
 **Supersedes:** the single-template / scene-level-threshold model in
 `2026-07-27-presence-awareness-design.md` and `2026-07-28-presence-state-loop.md`


### PR DESCRIPTION
Docs only.

`2026-08-03-presence-multiclass-tracks.md` argues for a per-track temporal filter as the fix for flapping. **It wasn't needed** — flapping was an artifact of the absolute threshold, and multi-class `identify()` removed it entirely: live flap rate went `33% -> 92% -> 100%`, 37/37 ticks correct with zero smoothing.

Adds a banner at the top so nobody builds tracks on the strength of a spec written before the measurement that obsoleted it. The IoU figures stay — tracking *would* work, which is not the same as being needed.

Written the same day it was superseded, on purpose: a spec recommending unnecessary work is exactly the stale artifact that costs someone a week six months from now.