### PR TITLE
fix(packaging): force-include agent_core.venv — published CLI is broken on every clean install

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -42,6 +42,15 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agent_core"]
+# Force-include agent_core.venv. It is a SOURCE subpackage whose name collides
+# with the root .gitignore's `venv/` pattern, and the rescue negation there
+# (`!packages/core/src/agent_core/venv/`) is written REPO-root-relative. That
+# path does not exist inside an sdist, whose root is this package — so when the
+# release builds the wheel FROM the sdist (`uv build` without `--wheel`, as
+# .github/workflows/release.yml does), the broad ignore matches and the negation
+# misses. The subpackage is silently dropped and `agent_core.cli` dies at import
+# on every clean install. See #566.
+artifacts = ["src/agent_core/venv/**"]
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"


### PR DESCRIPTION
Fixes #566. **The published `agent-core` CLI is broken on every clean install** — this restores it.

## Symptom

```
$ uv tool install agent-core-bus        # 0.9.0, current PyPI
$ agent-core --help
ModuleNotFoundError: No module named 'agent_core.venv'
```

`cli.py:31` imports it at module scope, so **every** subcommand dies, not just `venv`.

## Root cause — a path-relativity bug, not a missing file

The root `.gitignore` carries a broad `venv/` pattern (for virtualenvs) plus a rescue negation:

```
venv/
!packages/core/src/agent_core/venv/
```

That negation is **repo-root-relative**. Inside an sdist the root is *this package*, so `packages/core/...` does not exist there — **the broad ignore matches and the negation misses.**

## Why every local build looked fine

| build command | path | venv in wheel |
|---|---|---|
| `uv build --wheel` | from the worktree — git present, negation resolves | ✅ 4 files |
| `uv build` (no flag) | **wheel built FROM the sdist** | ❌ 0 files |

`.github/workflows/release.yml` runs `uv build --package "$pkg"` with **no `--wheel`**. So every *published* wheel takes the broken path while every *local* build takes the working one — which is why this survived a release and why nobody hit it: we all run from the source workspace via `uv run`, where the filesystem satisfies the import regardless.

## The fix

```toml
artifacts = ["src/agent_core/venv/**"]
```

Hatchling's `artifacts` force-includes paths that VCS-ignore would otherwise drop. This makes packaging **independent of `.gitignore` semantics** rather than dependent on a negation that only resolves in one of the two build paths.

## Verification

Built the same way CI does (`uv build --package agent-core-bus`, no `--wheel`):

```
before:  venv files in wheel = 0
after:   venv files in wheel = 4
         agent_core/venv/{__init__,builder,cli,mcp_config}.py
```

## Note on history

Two distinct failures produced the identical symptom:
- **v0.8.2** — no negation in `.gitignore` at all
- **v0.9.0** — negation present, but unable to resolve inside an sdist

So 0.9.0 does **not** fix it, and a further release is needed after this lands.

## Follow-up worth doing separately

There is no gate that installs the built wheel and runs `agent-core --help`. A build that is never installed is a build nobody has tested — noted in #566.
