### PR TITLE
fix(packaging): force-include agent_core.venv in all build targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,18 @@ jobs:
       - name: Validate distribution metadata
         run: uvx twine check dist/*
 
+      # Fail-closed gate: twine check validates METADATA, not that the wheel
+      # actually imports. 0.9.0 and 0.9.1 both passed twine check and both were
+      # DOA on install — agent_core.venv had been silently dropped from the
+      # sdist the wheel was built from (#566). Install the built wheel into a
+      # clean environment and run the console script. Nothing publishes unless
+      # the entry point a user actually types works.
+      - name: Smoke-test built wheel (must import and run)
+        run: |
+          uv venv /tmp/smoke
+          uv pip install --python /tmp/smoke/bin/python dist/agent_core_bus-*.whl
+          /tmp/smoke/bin/agent-core --help
+
       - name: List built artifacts
         run: ls -la dist/
 

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -40,17 +40,30 @@ example = "agent_core.plugins.example_entrypoint"
 requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
 
+# Force-include agent_core.venv in EVERY build target. It is a SOURCE
+# subpackage whose name collides with the root .gitignore's `venv/` pattern.
+# The rescue negations there (`!packages/core/src/agent_core/venv/`) are written
+# REPO-root-relative, so git honors them but hatchling — which builds with root
+# = packages/core — cannot resolve them, and drops the subpackage.
+#
+# This MUST be declared here (shared, applies to all targets) rather than under
+# targets.wheel. The release runs `uv build` without `--wheel`
+# (.github/workflows/release.yml), which builds the sdist FIRST and then the
+# wheel from that sdist. A wheel-only force-include is too late: the files are
+# already absent from the sdist the wheel is built against. 0.9.1 shipped with
+# exactly that mistake and was still broken on install.
+#
+# The trap that hid this for two releases: in a git WORKTREE `.git` is a file,
+# not a directory, so hatchling's VCS-ignore detection silently no-ops and the
+# subpackage IS included. Every local build looked correct while every
+# published wheel was broken. Validate packaging from a real clone, never a
+# worktree. release.yml now smoke-tests the built wheel before publishing.
+# See #566.
+[tool.hatch.build]
+artifacts = ["src/agent_core/venv/**"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/agent_core"]
-# Force-include agent_core.venv. It is a SOURCE subpackage whose name collides
-# with the root .gitignore's `venv/` pattern, and the rescue negation there
-# (`!packages/core/src/agent_core/venv/`) is written REPO-root-relative. That
-# path does not exist inside an sdist, whose root is this package — so when the
-# release builds the wheel FROM the sdist (`uv build` without `--wheel`, as
-# .github/workflows/release.yml does), the broad ignore matches and the negation
-# misses. The subpackage is silently dropped and `agent_core.cli` dies at import
-# on every clean install. See #566.
-artifacts = ["src/agent_core/venv/**"]
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"


### PR DESCRIPTION
## The bug

`0.9.0` and `0.9.1` both published wheels that are dead on arrival:

```
$ agent-core --help
  File ".../site-packages/agent_core/cli.py", line 31, in <module>
    from agent_core.venv.cli import venv_app
ModuleNotFoundError: No module named 'agent_core.venv'
```

Verified against the real published artifacts — `agent_core/venv/` is absent from
the `0.9.1` sdist **and** wheel on PyPI.

## Root cause

`agent_core.venv` is a **source** subpackage whose name collides with the root
`.gitignore`'s broad `venv/` pattern. The rescue negations there are written
repo-root-relative:

```
!packages/core/src/agent_core/venv/
```

`git` honors those (the files are correctly tracked — `git check-ignore` reports
not-ignored). Hatchling does not: it builds with root = `packages/core`, where
that path cannot resolve, so the broad ignore wins and the subpackage is dropped.

## Why the 0.9.1 attempt failed

`#567` added the force-include under `[tool.hatch.build.targets.wheel]`. That is
one layer too late. `release.yml` runs `uv build` **without** `--wheel`, which
builds the sdist first and then the wheel *from that sdist* — by the time the
wheel target is consulted, the files are already gone. Moving the declaration to
the shared `[tool.hatch.build]` table covers both targets.

## Why this survived two releases

**In a git worktree, `.git` is a file rather than a directory, so hatchling's
VCS-ignore detection silently no-ops and the subpackage IS included.** Every
local build I did was in a worktree, so every local build looked correct while
every published wheel was broken. This is the part worth remembering.

## The second change: a fail-closed release gate

`twine check` validates *metadata*, not importability — both broken releases
passed it. This PR adds a step that installs the built wheel into a clean
environment and runs the console script before anything publishes:

```yaml
- name: Smoke-test built wheel (must import and run)
  run: |
    uv venv /tmp/smoke
    uv pip install --python /tmp/smoke/bin/python dist/agent_core_bus-*.whl
    /tmp/smoke/bin/agent-core --help
```

Either broken release would have been caught here instead of by a user.

## Validation

All of it from a **real clone**, never a worktree:

- Reproduced the failure at `v0.9.1` — 0 `agent_core/venv` files in sdist and wheel, matching the broken PyPI artifact
- With the fix: 4 files in both sdist and wheel
- Clean install of the resulting wheel: `agent-core --help` runs, `agent_core.venv.cli` imports
- Audited **all 12 packages** — wheel contents vs. source tree — no other dropped source files

Refs #566
