### PR TITLE
fix(deps): raise agent-core sibling caps from <0.9 to <0.10

### DIFF
--- a/packages/agent-core-briefs/pyproject.toml
+++ b/packages/agent-core-briefs/pyproject.toml
@@ -5,7 +5,7 @@ description = "Brief framework — structured-composition pattern for agent_core
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
-    "agent-core-bus>=0.8,<0.9",
+    "agent-core-bus>=0.9.2,<0.10",
     "pluggy>=1.6",
     "pydantic>=2.7",
     "pyyaml>=6.0",

--- a/packages/agent-core-discord/pyproject.toml
+++ b/packages/agent-core-discord/pyproject.toml
@@ -5,8 +5,8 @@ description = "Discord bot adapter for the agent-core bus — one bot per agent 
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
-    "agent-core-bus>=0.8,<0.9",
-    "agent-core-credentials>=0.8,<0.9",
+    "agent-core-bus>=0.9.2,<0.10",
+    "agent-core-credentials>=0.9.2,<0.10",
     "discord.py>=2.4",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0",

--- a/packages/agent-core-hatchery/pyproject.toml
+++ b/packages/agent-core-hatchery/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "rich>=13.0",
     "pyyaml>=6.0",
     "pydantic>=2.0",
-    "agent-core-bus>=0.8,<0.9",
+    "agent-core-bus>=0.9.2,<0.10",
 ]
 
 [project.scripts]

--- a/packages/agent-core-inbound/pyproject.toml
+++ b/packages/agent-core-inbound/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
-    "agent-core-bus>=0.8,<0.9",
-    "agent-core-credentials>=0.8,<0.9",
+    "agent-core-bus>=0.9.2,<0.10",
+    "agent-core-credentials>=0.9.2,<0.10",
     "pydantic>=2.0",
     "fastapi>=0.110",
     "uvicorn>=0.27",

--- a/packages/agent-core-voice/pyproject.toml
+++ b/packages/agent-core-voice/pyproject.toml
@@ -5,7 +5,7 @@ description = "Voice synthesis endpoint for agent_core — per-agent Qwen3-TTS v
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
-    "agent-core-bus>=0.8,<0.9",
+    "agent-core-bus>=0.9.2,<0.10",
     "fastmcp>=2.0",
     "madrigal >= 0.2.0",
     "pluggy>=1.6",

--- a/packages/agent-core-webcam/pyproject.toml
+++ b/packages/agent-core-webcam/pyproject.toml
@@ -5,7 +5,7 @@ description = "Webcam endpoint for agent_core — agent-driven on-demand frame c
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
-    "agent-core-bus>=0.8,<0.9",
+    "agent-core-bus>=0.9.2,<0.10",
     "fastmcp>=2.0",
     "opencv-python>=5.0.0.93",
     "pluggy>=1.6",

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -6,7 +6,7 @@ license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "claude-agent-sdk>=0.1.29",
-    "agent-core-credentials>=0.8,<0.9",
+    "agent-core-credentials>=0.9.2,<0.10",
     "python-dotenv>=1.0.0",
     "tzdata>=2024.1",
     "pydantic>=2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32' and extra != 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130'",
@@ -101,9 +101,9 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
     { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (extra != 'extra-16-agent-core-voice-cpu' and extra != 'extra-16-agent-core-voice-cu130')" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
     { name = "torch", version = "2.13.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "extra == 'extra-16-agent-core-voice-cu130'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/8e/ac2a9566747a93f8be36ee08532eb0160558b07630a081a6056a9f89bf1d/accelerate-1.12.0.tar.gz", hash = "sha256:70988c352feb481887077d2ab845125024b2a137a5090d6d7a32b57d03a45df6", size = 398399, upload-time = "2025-11-21T11:27:46.973Z" }
@@ -386,10 +386,10 @@ dependencies = [
 
 [package.optional-dependencies]
 cpu = [
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
 ]
 cu130 = [
     { name = "torch", version = "2.13.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
@@ -1359,7 +1359,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(python_full_version < '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "cuda-pathfinder", marker = "python_full_version < '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
@@ -1394,43 +1394,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-16-agent-core-voice-cpu') or (platform_machine == 'aarch64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (platform_machine == 'x86_64' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'linux' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -3224,7 +3224,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -3267,7 +3267,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -3280,7 +3280,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3312,9 +3312,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "nvidia-cusparse", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3327,7 +3327,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -4364,9 +4364,9 @@ dependencies = [
     { name = "onnxruntime" },
     { name = "soundfile" },
     { name = "sox" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
     { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (extra != 'extra-16-agent-core-voice-cpu' and extra != 'extra-16-agent-core-voice-cu130')" },
-    { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
+    { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
     { name = "torchaudio", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "extra == 'extra-16-agent-core-voice-cu130'" },
     { name = "transformers" },
 ]
@@ -5162,18 +5162,19 @@ name = "torch"
 version = "2.13.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'darwin'",
     "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "fsspec", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "jinja2", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "networkx", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "setuptools", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "sympy", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "filelock", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "fsspec", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "jinja2", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "networkx", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "setuptools", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "sympy", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", upload-time = "2026-07-08T12:26:18Z" },
@@ -5243,7 +5244,6 @@ resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
@@ -5255,13 +5255,13 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "fsspec", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "jinja2", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "networkx", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "setuptools", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "sympy", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
-    { name = "typing-extensions", marker = "(python_full_version >= '3.15' and extra == 'extra-16-agent-core-voice-cpu') or (python_full_version < '3.15' and extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130') or (sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu')" },
+    { name = "filelock", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "fsspec", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "jinja2", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "networkx", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "setuptools", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "sympy", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-16-agent-core-voice-cpu') or (extra == 'extra-16-agent-core-voice-cpu' and extra == 'extra-16-agent-core-voice-cu130')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:ffadde149901c8afa138daa38d898264003cfcf1a3336ca5cd964b5af227d867", upload-time = "2026-07-08T19:28:41Z" },
@@ -5346,6 +5346,7 @@ name = "torchaudio"
 version = "2.11.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'darwin'",
     "python_full_version < '3.13' and sys_platform == 'darwin'",
@@ -5407,7 +5408,6 @@ resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",


### PR DESCRIPTION
fix(deps): raise agent-core sibling caps from <0.9 to <0.10

Every package pinned its agent-core siblings below 0.9 while the fleet is
published at 0.9.3, so a clean install of any of them silently pulled 0.8.2
siblings no matter what was released.

For the hatchery this is fatal rather than merely stale. hatcher.py imports
agent_core.venv.builder, and agent_core.venv does not exist in ANY release
below 0.9 -- the dependency constraint forbids the module the code imports.
Hatching Maud from a clean 0.9.3 install failed with:

    ModuleNotFoundError: No module named 'agent_core.venv'

despite agent-core-bus 0.9.3 being installed, because `uv tool` environments
are isolated: the hatchery resolves its OWN bus copy, which the cap held at
0.8.2. Upgrading the standalone agent-core-bus tool did nothing for it.

Floors set to >=0.9.2 rather than >=0.9: 0.9.0 and 0.9.1 shipped wheels
missing agent_core.venv entirely (#566), so they are not viable floors even
though they satisfy >=0.9. Verified on PyPI that both agent-core-bus and
agent-core-credentials publish 0.9.2 and 0.9.3.

Packages updated: briefs, discord, hatchery, inbound, voice, webcam, core.

Refs #566, #573
