### PR TITLE
fix(channel): declare agent-core-bus and fastmcp, which the code imports

### DIFF
--- a/packages/agent-core-channel/pyproject.toml
+++ b/packages/agent-core-channel/pyproject.toml
@@ -10,6 +10,20 @@ dependencies = [
     "httpx>=0.27",
     "typer>=0.12",
     "pyyaml>=6.0",
+    # REQUIRED, not optional. __main__.py:62 does an unconditional
+    # `from agent_core.plugins.manager import ...` and uses the result two lines
+    # later to wire plugin renderers. Without it the relay dies at startup with
+    # ModuleNotFoundError, so `pip install agent-core-channel` produces a package
+    # that cannot run.
+    #
+    # Floor is 0.9.2, not 0.9: 0.9.0 and 0.9.1 shipped wheels missing the
+    # agent_core.venv subpackage (#566), so they satisfy >=0.9 and are still
+    # broken on import.
+    "agent-core-bus>=0.9.2,<0.10",
+    # bus_client.py:18 does a module-level `from fastmcp import Client`. This
+    # has not broken yet only because fastmcp arrives transitively — that is
+    # luck, not a contract, and it disappears the moment a transitive drops it.
+    "fastmcp>=2.0",
 ]
 
 [project.scripts]

--- a/packages/agent-core-channel/tests/test_declared_dependencies.py
+++ b/packages/agent-core-channel/tests/test_declared_dependencies.py
@@ -1,0 +1,89 @@
+"""Every top-level package this code imports must be a declared dependency.
+
+Regression guard for the defect found 2026-08-05: ``__main__.py`` does an
+unconditional ``from agent_core.plugins.manager import ...`` while
+``pyproject.toml`` declared only mcp/anyio/httpx/typer/pyyaml. A clean
+``pip install agent-core-channel`` therefore produced a package that died at
+startup with ``ModuleNotFoundError: No module named 'agent_core'``, which left
+a freshly hatched being with no MCP session and silently dead-lettered every
+message addressed to her.
+
+The import is late-bound (inside ``main()``), so nothing at collection time
+catches it -- the module imports fine; only *running* it fails.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+SRC = PACKAGE_ROOT / "src"
+
+# Distribution name -> top-level module it provides, for deps whose names differ.
+_DIST_TO_MODULE = {
+    "agent-core-bus": "agent_core",
+    "pyyaml": "yaml",
+}
+
+# Provided by the standard library or by this package itself.
+_EXEMPT = {"agent_core_channel"}
+
+
+def _declared_modules() -> set[str]:
+    data = tomllib.loads((PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for spec in data["project"]["dependencies"]:
+        dist = re.split(r"[><=!~\[;\s]", spec, maxsplit=1)[0].strip().lower()
+        modules.add(_DIST_TO_MODULE.get(dist, dist.replace("-", "_")))
+    return modules
+
+
+def _imported_modules() -> dict[str, set[str]]:
+    """Top-level module -> set of files importing it, across all of src/."""
+    found: dict[str, set[str]] = {}
+    for path in SRC.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [a.name.split(".")[0] for a in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                # level > 0 is a relative import; it has no top-level name.
+                names = [node.module.split(".")[0]] if node.module and not node.level else []
+            else:
+                continue
+            for name in names:
+                found.setdefault(name, set()).add(path.name)
+    return found
+
+
+def test_every_imported_third_party_module_is_declared() -> None:
+    declared = _declared_modules()
+    stdlib = sys.stdlib_module_names
+    undeclared = {
+        mod: sorted(files)
+        for mod, files in _imported_modules().items()
+        if mod not in declared and mod not in stdlib and mod not in _EXEMPT
+    }
+    assert not undeclared, (
+        "these modules are imported but not declared in pyproject.toml "
+        f"dependencies: {undeclared}. A package that imports a module it does "
+        "not declare installs cleanly and fails at runtime."
+    )
+
+
+def test_agent_core_bus_is_declared() -> None:
+    """Explicit guard on the specific dependency that was missing.
+
+    Kept separate from the general check so that removing it fails with a
+    message naming the incident rather than a generic diff.
+    """
+    assert "agent_core" in _declared_modules(), (
+        "agent-core-bus must stay in dependencies: __main__.py imports "
+        "agent_core.plugins.manager unconditionally at startup. Removing it "
+        "reproduces the 2026-08-05 outage where a hatched being's channel "
+        "relay died and her messages dead-lettered."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,9 @@ requires-dist = [
 name = "agent-core-channel"
 source = { editable = "packages/agent-core-channel" }
 dependencies = [
+    { name = "agent-core-bus" },
     { name = "anyio" },
+    { name = "fastmcp" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "pyyaml" },
@@ -218,7 +220,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agent-core-bus", editable = "packages/core" },
     { name = "anyio", specifier = ">=4.0" },
+    { name = "fastmcp", specifier = ">=2.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
fix(channel): declare agent-core-bus and fastmcp, which the code imports

agent-core-channel imported two top-level packages it did not declare, so a
clean `pip install agent-core-channel` produced something that cannot run.

Found live: Maud, hatched from PyPI 2026-08-04, never received a single
Discord message. Her channel relay died at startup with

    File ".../agent_core_channel/__main__.py", line 62, in main
        from agent_core.plugins.manager import create_plugin_manager, ...
    ModuleNotFoundError: No module named 'agent_core'

so no MCP session ever registered, and the bus dead-lettered her messages
after five delivery attempts with "no MCP session connected for maud".

Two undeclared imports, both module-scope and unconditional:

1. agent_core -- __main__.py:62. Late-bound inside main(), so importing the
   module succeeds and only *running* it fails. Its result is used two lines
   later to wire plugin renderers; there is no fallback path.
   Floor is >=0.9.2, not >=0.9: 0.9.0 and 0.9.1 shipped wheels missing the
   agent_core.venv subpackage (#566), so they satisfy >=0.9 and still break.

2. fastmcp -- bus_client.py:18. Has not broken yet only because fastmcp
   arrives transitively. That is luck, not a contract, and it evaporates the
   moment a transitive dependency drops it.

Adds tests/test_declared_dependencies.py, which walks src/ with ast and
asserts every imported top-level module is declared. It found the fastmcp
case on its first run -- I was only looking for agent_core. Verified by
negative control: removing the dependency makes it fail.

Not fixed here, deliberately: agent-core-busproxy and agent-core-notify were
checked and are consistent (they import no agent-core siblings). The same
ast check is worth generalising across all packages, but that is a separate
change from unbreaking the shipped one.

Refs #566
