### PR TITLE
fix(scheduler): open the SQLite store in WAL mode with a busy timeout

### DIFF
--- a/packages/core/src/agent_core/endpoints/scheduler.py
+++ b/packages/core/src/agent_core/endpoints/scheduler.py
@@ -23,7 +23,9 @@ from __future__ import annotations
 
 import json
 import logging
+import sqlite3
 import uuid
+from contextlib import closing
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -185,6 +187,75 @@ def _default_db_path() -> Path:
     return Path("~/.agent-core/scheduler.db").expanduser()
 
 
+# How long SQLite waits for a competing writer's lock before raising
+# "database is locked", in seconds. APScheduler's acquire_jobs loop runs
+# concurrently with bus-driven create/update/delete mutations against the same
+# file, so the two genuinely contend.
+_SQLITE_BUSY_TIMEOUT_SECONDS = 30.0
+
+
+def create_scheduler_engine(db_path: Path) -> AsyncEngine:
+    """Build the scheduler's aiosqlite engine with contention-safe pragmas.
+
+    The default ``sqlite+aiosqlite://`` engine uses SQLite's rollback journal,
+    under which any writer takes an exclusive lock over the whole database and
+    concurrent readers fail immediately with ``SQLITE_BUSY``. APScheduler's
+    ``_process_jobs`` loop calls ``acquire_jobs`` continuously while bus
+    ToolInvocations (``create_job``/``update_job``/``delete_job``) write to the
+    same file, so that contention is routine rather than exceptional.
+
+    When it happens the ``OperationalError`` escapes ``_process_jobs``, unwinds
+    APScheduler's task group, and kills the scheduler outright — every
+    scheduled job silently stops firing. Two settings prevent it:
+
+    - ``journal_mode=WAL`` lets readers and a writer proceed concurrently.
+    - ``busy_timeout`` makes a blocked connection wait and retry rather than
+      fail instantly, covering the WAL write-write case that WAL alone does
+      not.
+
+    The bus's own store already does this (``bus/persistence.py``); the
+    scheduler was the one SQLite store in core without it.
+
+    WAL is applied once, here, over a plain stdlib ``sqlite3`` connection
+    rather than from a SQLAlchemy ``connect`` event listener. Two reasons:
+
+    - It is a persistent property of the *database file*, recorded in its
+      header, so every later connection inherits it. Re-applying per
+      connection buys nothing.
+    - The listener version leaked. Executing a cursor inside the ``connect``
+      event of an aiosqlite engine leaves a connection thread that
+      ``dispose()`` does not reclaim; the suite's leak guard caught it on
+      three scheduler tests. That is the same failure this codebase already
+      hit in #468, so it is worth not re-introducing.
+
+    Args:
+        db_path: Filesystem path to the scheduler's SQLite database. Its
+            parent directory must already exist.
+
+    Returns:
+        An ``AsyncEngine`` pointed at a WAL-mode database, whose connections
+        wait rather than fail when the file is locked.
+    """
+    # Persist WAL on the file itself. sqlite3.connect creates the database if
+    # it does not exist, and journal_mode survives in the header from then on.
+    with closing(sqlite3.connect(db_path)) as conn:
+        mode = conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+    if mode.lower() != "wal":  # pragma: no cover - defensive
+        # Never observed on a local file; would mean the database is on a
+        # filesystem that cannot support WAL's shared-memory index (some
+        # network mounts). Loud beats a scheduler that dies under load.
+        raise RuntimeError(
+            f"scheduler database {db_path} refused WAL mode (got {mode!r}); "
+            "concurrent access would crash the scheduler"
+        )
+
+    return create_async_engine(
+        f"sqlite+aiosqlite:///{db_path}",
+        # sqlite3.connect(timeout=...) — sets the busy handler at connect time.
+        connect_args={"timeout": _SQLITE_BUSY_TIMEOUT_SECONDS},
+    )
+
+
 def load_seed_jobs(yaml_path: Path) -> dict[str, JobDef]:
     """Parse a yaml file into validated JobDef entries keyed by name.
 
@@ -248,7 +319,7 @@ class SchedulerEndpoint:
     async def start(self, bus: BusHandle) -> None:
         self._handle = bus
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._engine = create_async_engine(f"sqlite+aiosqlite:///{self.db_path}")
+        self._engine = create_scheduler_engine(self.db_path)
         data_store = SQLAlchemyDataStore(self._engine)
         self._scheduler = AsyncScheduler(data_store=data_store)
         try:

--- a/packages/core/tests/test_scheduler_sqlite_pragmas.py
+++ b/packages/core/tests/test_scheduler_sqlite_pragmas.py
@@ -1,0 +1,98 @@
+"""The scheduler's SQLite engine must tolerate concurrent access.
+
+Regression guard for the crash found 2026-08-05 on windows CI: APScheduler's
+``acquire_jobs`` hit ``sqlite3.OperationalError: database is locked``, the
+exception escaped ``_process_jobs``, unwound the scheduler's task group and
+logged "Scheduler crashed". Nothing restarts that task, so every scheduled job
+stops firing while the endpoint still reports as started.
+
+Each test there had its own ``tmp_path`` database, so this was a single
+scheduler locking its own file — exactly the shape the daemon runs in, where
+the ``acquire_jobs`` loop competes with bus-driven job mutations.
+
+These tests assert the *effect* on a real connection rather than the presence
+of the configuration, and each carries a negative control showing the
+assertion can fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from agent_core.endpoints.scheduler import (
+    _SQLITE_BUSY_TIMEOUT_SECONDS,
+    create_scheduler_engine,
+)
+
+
+async def _pragma(engine, name: str):
+    """Read a PRAGMA back off a real connection from this engine."""
+    async with engine.connect() as conn:
+        result = await conn.execute(text(f"PRAGMA {name}"))
+        return result.scalar()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_engine_uses_wal_journal(tmp_path):
+    """WAL lets the acquire_jobs reader run while a mutation writes."""
+    engine = create_scheduler_engine(tmp_path / "sched.db")
+    try:
+        assert (await _pragma(engine, "journal_mode")).lower() == "wal"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_plain_engine_does_not_use_wal(tmp_path):
+    """Negative control: the default engine is what crashed the scheduler.
+
+    Without this, `test_scheduler_engine_uses_wal_journal` would still pass if
+    WAL were SQLite's default and `create_scheduler_engine` did nothing.
+    A fresh path is required — journal_mode is persistent in the database file,
+    so reusing the other test's file would report wal no matter what.
+    """
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'plain.db'}")
+    try:
+        assert (await _pragma(engine, "journal_mode")).lower() != "wal"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_engine_sets_busy_timeout(tmp_path):
+    """A blocked connection must wait for the lock, not fail instantly.
+
+    WAL alone does not cover write-write contention; the busy timeout does.
+    """
+    engine = create_scheduler_engine(tmp_path / "sched.db")
+    try:
+        # PRAGMA busy_timeout reports milliseconds.
+        assert await _pragma(engine, "busy_timeout") == int(_SQLITE_BUSY_TIMEOUT_SECONDS * 1000)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_plain_engine_has_no_busy_timeout(tmp_path):
+    """Negative control for the busy timeout."""
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'plain.db'}")
+    try:
+        assert await _pragma(engine, "busy_timeout") != int(_SQLITE_BUSY_TIMEOUT_SECONDS * 1000)
+    finally:
+        await engine.dispose()
+
+
+# Deliberately NOT tested here: an end-to-end "reader survives a concurrent
+# writer" case. The obvious version — hold an uncommitted INSERT on one
+# connection and read from another — passes with and without WAL, because
+# SQLite's rollback journal only takes a RESERVED lock for an open write
+# transaction and still admits readers; the exclusive lock exists only during
+# the commit itself. Verified by neutering create_scheduler_engine and watching
+# that test pass anyway, while the two pragma tests above failed.
+#
+# Reproducing the real crash needs two processes racing a commit, which is
+# timing-dependent — precisely the property that made the original failure a CI
+# flake. Trading a deterministic pragma assertion for a racy end-to-end one
+# would reintroduce the class of problem this change exists to remove.


### PR DESCRIPTION
Closes #585. The supervision half is #586 and deliberately not in scope here.

## What was wrong

The scheduler's SQLite store was built with no journal or locking configuration — the only such store in core. Under SQLite's default rollback journal, a committing writer locks the whole database and concurrent readers fail instantly with `SQLITE_BUSY`. APScheduler's `_process_jobs` loop calls `acquire_jobs` continuously while bus `ToolInvocation`s write to the same file, so they contend during ordinary operation.

When they do, the scheduler doesn't degrade — it dies:

```
sqlite3.OperationalError: database is locked
  -> apscheduler.datastores.sqlalchemy.acquire_jobs
  -> ExceptionGroup: unhandled errors in a TaskGroup
  -> ERROR apscheduler._schedulers.async_: Scheduler crashed
```

Surfaced as a windows CI failure on the release branch ([run 31009607568](https://github.com/jeffrichley/agent_core/actions/runs/31009607568)). The visible symptom was a `CancelledError` in an unrelated `await` — the task group cancelling its children as it unwound.

Each test had its own `tmp_path` database, so this was **one scheduler locking its own file**, not cross-test contention. Same shape the daemon runs in.

## The fix

Mirrors `bus/persistence.py`: `journal_mode=WAL` plus a `busy_timeout`.

## Two things worth a reviewer's attention

**1. The first implementation leaked, and the leak guard caught it.**

Applying WAL from a SQLAlchemy `connect` event listener — the documented recipe — leaves a connection thread that `dispose()` never reclaims. Three scheduler tests failed teardown with `leaked 1 aiosqlite connection thread(s)`; clean `main` had zero. Same failure class as #468.

Isolated by running each half alone: `connect_args` clean, listener leaking. WAL is a persistent property of the *database file*, so it is now set once over a plain stdlib `sqlite3` connection — sufficient, and nothing to leak.

**2. I removed a test because it asserted nothing.**

I first wrote `test_concurrent_reader_survives_open_write_transaction` to exercise the real failure. Running it against a neutered build showed it **passing without the fix** — SQLite's rollback journal only takes a RESERVED lock for an open write transaction and still admits readers; the exclusive lock exists only during the commit.

It's gone, with a comment explaining why. Reproducing the true race needs two processes racing a commit — timing-dependent, which is exactly the property that made the original failure a flake. Trading a deterministic assertion for a racy one would reintroduce the problem this PR exists to remove.

## Verification

- Every assertion carries a negative control on a fresh path (journal_mode is persistent, so reusing a path would report `wal` regardless).
- Neutered the WAL step → `test_scheduler_engine_uses_wal_journal` fails with `journal_mode == "delete"`. Restored → passes.
- `packages/core/tests`: **1222 passed, 40 skipped**, no leak errors.
- `ruff check` / `ruff format` clean.
- `mypy packages/core/src`: one pre-existing `agent_core_discord` stub error, identical on clean `origin/main` — a local-env artifact, not from this change.

## What this does not fix

A crashed scheduler is still neither restarted nor reported — `start_in_background()` is called once and nothing watches that task, so the endpoint keeps reading healthy while jobs stop firing. This PR removes one cause of that crash; #586 covers the missing supervision, which is the more expensive half.
