### PR TITLE
fix(scheduler): report a dead scheduler to the bus instead of failing silently

### DIFF
--- a/packages/core/src/agent_core/endpoints/scheduler.py
+++ b/packages/core/src/agent_core/endpoints/scheduler.py
@@ -21,6 +21,7 @@ Each job carries an `envelope_kind` (default `"TextMessage"`, also supports
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import sqlite3
@@ -31,7 +32,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import yaml
-from apscheduler import AsyncScheduler
+from apscheduler import AsyncScheduler, RunState
 from apscheduler.datastores.sqlalchemy import SQLAlchemyDataStore
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
@@ -193,6 +194,11 @@ def _default_db_path() -> Path:
 # file, so the two genuinely contend.
 _SQLITE_BUSY_TIMEOUT_SECONDS = 30.0
 
+# How often the liveness watchdog checks that APScheduler is still running.
+# Detection latency, not a correctness knob: a dead scheduler is reported
+# within roughly this long. Cheap (an in-memory enum read), so it is short.
+_LIVENESS_POLL_SECONDS = 5.0
+
 
 def create_scheduler_engine(db_path: Path) -> AsyncEngine:
     """Build the scheduler's aiosqlite engine with contention-safe pragmas.
@@ -309,12 +315,57 @@ class SchedulerEndpoint:
         self.db_path: Path = Path(db_path).expanduser() if db_path else _default_db_path()
         self._handle: BusHandle | None = None
         self._scheduler: AsyncScheduler | None = None
+        # Set by stop() before it tears anything down, so the liveness watchdog
+        # can tell an intentional shutdown from a crash and exit quietly.
+        self._stopping = False
+        # The watchdog task. Owned here rather than left to the handle's drain,
+        # so stop() is self-contained: an endpoint that spawns a non-terminating
+        # task and does not cancel it leaks that task for the life of the loop.
+        self._liveness_task: asyncio.Task[None] | None = None
         # The aiosqlite-backed engine is owned here (not by APScheduler's data
         # store, which never disposes a caller-supplied engine). It MUST be
         # disposed in stop(), else its connection pool's background aiosqlite
         # threads leak on every stop — accumulating across a test suite until
         # the event loop chokes and a random test times out.
         self._engine: AsyncEngine | None = None
+
+    async def _watch_scheduler_liveness(self) -> None:
+        """Raise when APScheduler's background task has died.
+
+        This exists because a dead scheduler is otherwise invisible. APScheduler
+        runs ``run_until_stopped`` inside its own task group; when that task
+        raises (a locked database, say) the group unwinds internally, the
+        library logs "Scheduler crashed", and nothing else happens. ``start()``
+        returned successfully long before, so the endpoint remains registered
+        and ``bus status`` keeps listing it as a healthy endpoint with 0
+        pending — while every scheduled job has stopped firing. The only
+        evidence is one ERROR line and the absence of things that should have
+        happened.
+
+        Raising here routes the death into machinery that already exists but
+        that nothing was feeding: ``BusHandle.spawn`` reports a failed tracked
+        task to the bus, which calls ``EndpointSupervisor.record_failure``,
+        which restarts the endpoint with backoff and quarantines it after
+        ``restarts_before_quarantine`` attempts. Quarantined endpoints show up
+        under "Degraded Endpoints" in ``bus status``.
+
+        Raises:
+            RuntimeError: when the scheduler is no longer running and this
+                endpoint is not deliberately shutting down.
+        """
+        while True:
+            await asyncio.sleep(_LIVENESS_POLL_SECONDS)
+            if self._stopping:
+                return
+            scheduler = self._scheduler
+            if scheduler is None:
+                return  # stop() already tore it down
+            if scheduler.state is not RunState.started:
+                raise RuntimeError(
+                    f"scheduler endpoint {self.name!r} is no longer running "
+                    f"(state={scheduler.state.name}); its background task died. "
+                    "Scheduled jobs have stopped firing."
+                )
 
     async def start(self, bus: BusHandle) -> None:
         self._handle = bus
@@ -327,6 +378,16 @@ class SchedulerEndpoint:
             # Allow concurrent fires per task (APScheduler defaults to max_running_jobs=1).
             await self._scheduler.configure_task(_fire, max_running_jobs=None)
             await self._scheduler.start_in_background()
+            # APScheduler runs run_until_stopped inside its OWN task group, so
+            # when that task dies the exception unwinds there and never reaches
+            # the bus. Without this watchdog the endpoint stays in
+            # _active_endpoints, bus status keeps reporting it healthy, and
+            # every scheduled job silently stops firing. See #586.
+            self._stopping = False
+            self._liveness_task = bus.spawn(
+                self._watch_scheduler_liveness(),
+                name=f"scheduler-liveness:{self.name}",
+            )
             _active_endpoints[self.name] = self
             if self.jobs_path is not None:
                 await self._seed_jobs()
@@ -580,6 +641,32 @@ class SchedulerEndpoint:
             log.exception("scheduler failed to publish Acknowledgment for %s", incoming.id)
 
     async def stop(self) -> None:
+        # Set BEFORE anything is torn down. The liveness watchdog treats a
+        # not-running scheduler as a crash, and a normal shutdown makes the
+        # scheduler not-running — without this flag every clean stop would
+        # report a spurious endpoint failure to the supervisor.
+        self._stopping = True
+        # Cancel the watchdog before the scheduler goes away. The _stopping
+        # flag already makes it exit quietly, but it sleeps between polls, so
+        # without an explicit cancel it would linger for up to one poll
+        # interval past shutdown — long enough to be a leaked task in a test
+        # suite that stops hundreds of endpoints.
+        if self._liveness_task is not None:
+            task, self._liveness_task = self._liveness_task, None
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                # Two cases, both non-fatal here:
+                #   - CancelledError: the normal path, we just cancelled it.
+                #   - the watchdog's own RuntimeError: it already fired and
+                #     spawn()'s done-callback already reported it to the
+                #     supervisor. Awaiting a task that finished with an
+                #     exception re-raises it, so without this stop() would
+                #     abort before disposing the engine below — leaking an
+                #     aiosqlite pool on every supervisor restart, which is the
+                #     failure this endpoint already fought in #468.
+                pass
         _active_endpoints.pop(self.name, None)
         if self._scheduler is not None:
             try:

--- a/packages/core/tests/test_scheduler_endpoint.py
+++ b/packages/core/tests/test_scheduler_endpoint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import textwrap
 import uuid
@@ -150,9 +151,15 @@ async def test_start_stop_lifecycle(tmp_path):
     """SchedulerEndpoint can start and stop cleanly."""
 
     class _FakeHandle:
+        # spawn mirrors the real BusHandle: the scheduler runs its liveness
+        # watchdog through it. A fake missing a method the real object has
+        # makes the endpoint's use of it untestable (see #586).
         async def publish(self, *a, **kw): ...
         async def ack(self, *a, **kw): ...
         async def nack(self, *a, **kw): ...
+        def spawn(self, coro, *, name=None):
+            return asyncio.create_task(coro, name=name)
+
         def endpoints(self):
             return []
 
@@ -177,9 +184,15 @@ async def test_stop_disposes_engine_leaving_no_leaked_connections(tmp_path):
     """
 
     class _FakeHandle:
+        # spawn mirrors the real BusHandle: the scheduler runs its liveness
+        # watchdog through it. A fake missing a method the real object has
+        # makes the endpoint's use of it untestable (see #586).
         async def publish(self, *a, **kw): ...
         async def ack(self, *a, **kw): ...
         async def nack(self, *a, **kw): ...
+        def spawn(self, coro, *, name=None):
+            return asyncio.create_task(coro, name=name)
+
         def endpoints(self):
             return []
 
@@ -198,9 +211,15 @@ async def test_failed_start_rolls_back_and_disposes_engine(tmp_path, monkeypatch
     """
 
     class _FakeHandle:
+        # spawn mirrors the real BusHandle: the scheduler runs its liveness
+        # watchdog through it. A fake missing a method the real object has
+        # makes the endpoint's use of it untestable (see #586).
         async def publish(self, *a, **kw): ...
         async def ack(self, *a, **kw): ...
         async def nack(self, *a, **kw): ...
+        def spawn(self, coro, *, name=None):
+            return asyncio.create_task(coro, name=name)
+
         def endpoints(self):
             return []
 
@@ -291,9 +310,15 @@ async def test_seed_jobs_are_added_on_start(tmp_path):
     """When jobs_path points at a yaml file, jobs are added at start()."""
 
     class _FakeHandle:
+        # spawn mirrors the real BusHandle: the scheduler runs its liveness
+        # watchdog through it. A fake missing a method the real object has
+        # makes the endpoint's use of it untestable (see #586).
         async def publish(self, *a, **kw): ...
         async def ack(self, *a, **kw): ...
         async def nack(self, *a, **kw): ...
+        def spawn(self, coro, *, name=None):
+            return asyncio.create_task(coro, name=name)
+
         def endpoints(self):
             return []
 
@@ -333,9 +358,15 @@ async def test_seed_jobs_skip_duplicates(tmp_path):
     """Re-running start() with the same yaml does not duplicate jobs."""
 
     class _FakeHandle:
+        # spawn mirrors the real BusHandle: the scheduler runs its liveness
+        # watchdog through it. A fake missing a method the real object has
+        # makes the endpoint's use of it untestable (see #586).
         async def publish(self, *a, **kw): ...
         async def ack(self, *a, **kw): ...
         async def nack(self, *a, **kw): ...
+        def spawn(self, coro, *, name=None):
+            return asyncio.create_task(coro, name=name)
+
         def endpoints(self):
             return []
 
@@ -371,15 +402,40 @@ async def test_seed_jobs_skip_duplicates(tmp_path):
 
 
 class _RecordingHandle:
-    """Test-double BusHandle that records publishes."""
+    """Test-double BusHandle that records publishes.
+
+    ``spawn`` mirrors the real ``BusHandle.spawn``: it tracks the task and
+    routes a non-cancellation exception to a failure hook instead of crashing
+    the loop. It was missing until 2026-08-05, which is part of why #586 went
+    unnoticed — the scheduler's supervision could not have been exercised by
+    any test using this fake, because the method it depends on did not exist
+    here. A fake that silently lacks a method the real object has turns "the
+    endpoint never calls it" into an untestable claim.
+    """
 
     def __init__(self):
         self.published: list = []
+        self.spawned: list[asyncio.Task] = []
+        self.task_failures: list[BaseException] = []
 
     async def publish(self, envelope, to=None) -> None:
         if to is not None:
             envelope = envelope.model_copy(update={"to": to if isinstance(to, str) else to[0]})
         self.published.append(envelope)
+
+    def spawn(self, coro, *, name: str | None = None) -> asyncio.Task:
+        task = asyncio.create_task(coro, name=name)
+        self.spawned.append(task)
+
+        def _done(t: asyncio.Task) -> None:
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is not None:
+                self.task_failures.append(exc)
+
+        task.add_done_callback(_done)
+        return task
 
     async def ack(self, envelope_id: str) -> None: ...
     async def nack(self, envelope_id: str, requeue: bool = True) -> None: ...

--- a/packages/core/tests/test_scheduler_liveness.py
+++ b/packages/core/tests/test_scheduler_liveness.py
@@ -1,0 +1,217 @@
+"""A dead scheduler must become visible to the bus.
+
+Regression guard for #586. APScheduler runs ``run_until_stopped`` inside its
+own task group; when that task dies (a locked database, say) the group unwinds
+internally, the library logs "Scheduler crashed", and nothing else happens.
+``start()`` returned successfully long before, so the endpoint stays registered
+and ``bus status`` keeps reporting it healthy — while every scheduled job has
+stopped firing.
+
+The machinery to handle this already existed and nothing fed it:
+``BusHandle.spawn`` routes a failed tracked task to the bus, which calls
+``EndpointSupervisor.record_failure``, which restarts with backoff and
+quarantines after ``restarts_before_quarantine`` attempts. These tests cover
+the link that was missing — the watchdog that notices and raises.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from apscheduler import RunState
+
+from agent_core.endpoints import scheduler as scheduler_mod
+from agent_core.endpoints.scheduler import SchedulerEndpoint
+
+
+class _FakeScheduler:
+    """Stands in for AsyncScheduler.
+
+    The watchdog only reads ``state``, but ``stop()`` calls ``__aexit__`` on
+    whatever is in ``_scheduler`` — so the fake must honour that too. It did
+    not at first, and the resulting teardown AttributeError made the
+    end-to-end test *fail without the fix for the wrong reason*, which would
+    have made its negative control meaningless. A fake has to refuse and
+    accept exactly what the real object does.
+    """
+
+    def __init__(self, state: RunState = RunState.started) -> None:
+        self.state = state
+        self.exited = False
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        self.exited = True
+
+
+def _endpoint(tmp_path) -> SchedulerEndpoint:
+    return SchedulerEndpoint(name="scheduler", db_path=str(tmp_path / "s.db"))
+
+
+@pytest.fixture(autouse=True)
+def _fast_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the watchdog's poll short so these tests stay quick."""
+    monkeypatch.setattr(scheduler_mod, "_LIVENESS_POLL_SECONDS", 0.01)
+
+
+@pytest.mark.asyncio
+async def test_watchdog_raises_when_scheduler_died(tmp_path) -> None:
+    """A stopped scheduler must raise, so spawn() reports it to the supervisor."""
+    ep = _endpoint(tmp_path)
+    ep._scheduler = _FakeScheduler(RunState.stopped)  # type: ignore[assignment]
+    ep._stopping = False
+
+    with pytest.raises(RuntimeError, match="no longer running"):
+        await asyncio.wait_for(ep._watch_scheduler_liveness(), timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_watchdog_stays_quiet_while_scheduler_runs(tmp_path) -> None:
+    """A healthy scheduler must produce no failure report.
+
+    Without this, a watchdog that raised unconditionally would still pass the
+    crash test above while making every daemon restart-loop forever.
+    """
+    ep = _endpoint(tmp_path)
+    ep._scheduler = _FakeScheduler(RunState.started)  # type: ignore[assignment]
+    ep._stopping = False
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(ep._watch_scheduler_liveness(), timeout=0.2)
+
+
+@pytest.mark.asyncio
+async def test_watchdog_exits_quietly_on_intentional_stop(tmp_path) -> None:
+    """A clean shutdown must not be reported as a crash.
+
+    stop() makes the scheduler not-running, which is indistinguishable from a
+    crash by state alone. If the watchdog cried wolf here, every ordinary
+    daemon shutdown would record an endpoint failure.
+    """
+    ep = _endpoint(tmp_path)
+    ep._scheduler = _FakeScheduler(RunState.stopped)  # type: ignore[assignment]
+    ep._stopping = True  # what stop() sets before tearing down
+
+    await asyncio.wait_for(ep._watch_scheduler_liveness(), timeout=2.0)  # returns, no raise
+
+
+@pytest.mark.asyncio
+async def test_watchdog_exits_quietly_when_scheduler_already_gone(tmp_path) -> None:
+    """stop() nulls _scheduler; the watchdog must treat that as shutdown."""
+    ep = _endpoint(tmp_path)
+    ep._scheduler = None
+    ep._stopping = False
+
+    await asyncio.wait_for(ep._watch_scheduler_liveness(), timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_stop_sets_stopping_before_teardown(tmp_path) -> None:
+    """The flag must be set by stop(), not merely exist.
+
+    Ordering matters: stop() tears the scheduler down, so the flag has to be
+    set first or the watchdog observes a not-running scheduler with
+    _stopping still False and reports a spurious failure.
+    """
+    ep = _endpoint(tmp_path)
+    assert ep._stopping is False
+    await ep.stop()
+    assert ep._stopping is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dead_scheduler_reaches_the_supervisor(tmp_path, build_bus) -> None:
+    """The whole point: a dead scheduler must become visible to the bus.
+
+    The unit tests above prove the watchdog raises. This proves raising
+    actually lands somewhere — spawn() -> task failure hook ->
+    EndpointSupervisor.record_failure -> status 'restarting'. Without this the
+    fix would rest on reading the wiring rather than exercising it, which is
+    exactly how #586 went unnoticed: every individual piece was present.
+    """
+    import yaml
+
+    from agent_core.bus.runner import build_bus_from_config  # noqa: F401  (fixture uses it)
+
+    cfg = tmp_path / "agent_core.yaml"
+    cfg.write_text(
+        yaml.dump(
+            {
+                "bus": {"storage_path": str(tmp_path / "bus.sqlite")},
+                "endpoints": [
+                    {
+                        "type": "builtin.scheduler",
+                        "name": "scheduler",
+                        "description": "scheduler under test",
+                        "params": {"db_path": str(tmp_path / "sched.db")},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bus, _ = await build_bus(cfg)
+    await bus.start()
+    try:
+        supervisor = bus._supervisor
+        assert supervisor is not None
+        assert supervisor.state("scheduler").status == "active"
+
+        # Simulate the crash: APScheduler's background task has died, so its
+        # state is no longer `started`. The endpoint itself still looks fine.
+        #
+        # The real scheduler is kept and restored before teardown. Swapping it
+        # out permanently orphans it — stop() would call __aexit__ on the fake
+        # instead, leaving the real AsyncScheduler's resources unreleased. The
+        # suite's leak guard caught exactly that.
+        endpoint = bus._endpoints_by_name["scheduler"].endpoint
+        real_scheduler = endpoint._scheduler
+        endpoint._scheduler = _FakeScheduler(RunState.stopped)
+
+        for _ in range(200):  # up to ~4s
+            if supervisor.state("scheduler").status != "active":
+                break
+            await asyncio.sleep(0.02)
+
+        state = supervisor.state("scheduler")
+        assert state.status == "restarting", (
+            "a dead scheduler must be reported to the supervisor; instead the "
+            f"endpoint still reads {state.status!r} — the failure is invisible"
+        )
+        assert "no longer running" in (state.last_error or "")
+        endpoint._scheduler = real_scheduler  # so stop() tears down the real one
+    finally:
+        await bus.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_succeeds_after_the_watchdog_already_fired(tmp_path) -> None:
+    """stop() must survive a watchdog that has already raised.
+
+    Found while building this: awaiting a task that finished with an exception
+    re-raises it, so cancel()+await in stop() blew up on exactly the endpoints
+    the supervisor was about to restart — aborting before the engine was
+    disposed and leaking an aiosqlite pool per restart. The supervisor calls
+    stop() on every restart, so the fix for #586 would have reintroduced #468.
+    """
+    ep = _endpoint(tmp_path)
+    ep._scheduler = _FakeScheduler(RunState.stopped)  # type: ignore[assignment]
+    ep._stopping = False
+
+    # Let the watchdog run to completion (it raises).
+    task = asyncio.create_task(ep._watch_scheduler_liveness())
+    with pytest.raises(RuntimeError):
+        await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+    ep._liveness_task = task
+    assert task.done() and task.exception() is not None
+
+    await ep.stop()  # must not raise
+
+    assert ep._liveness_task is None
+    assert ep._engine is None, "engine must still be disposed after a fired watchdog"


### PR DESCRIPTION
Closes #586. Companion to #587, which fixed one *cause* of the scheduler dying; this makes the death visible at all.

## The shape of it

When APScheduler's background task dies, nothing notices. It runs `run_until_stopped` inside its **own** task group, so the exception unwinds there, the library logs `Scheduler crashed`, and that is the end of it. `start()` returned successfully long before, so the endpoint stays in `_active_endpoints` and `bus status` keeps listing it as a healthy endpoint with 0 pending — while every scheduled job has stopped firing. The only evidence is one ERROR line and the absence of things that should have happened.

## The machinery already existed. Nothing was feeding it.

```
BusHandle.spawn -> _task_done -> task failure hook
  -> EndpointSupervisor.record_failure
  -> restart with backoff
  -> quarantine after restarts_before_quarantine (default 5)
  -> "Degraded Endpoints" in bus status
```

`bus/protocol.py` documents `spawn()` as how endpoints must run background work. **Nothing in `packages/core` called it** — the grep finds only the protocol's own docstrings. The road was built and empty.

So this PR adds one link: a liveness watchdog, spawned through the handle, that raises when the scheduler is no longer running. That turns an invisible death into the restart-then-degrade behaviour the supervisor already implements. **No new retry or quarantine policy** — it reuses the configured defaults.

## Three defects found while building it

Each caught by a guard, not by reasoning about the code.

**1. The fix would have reintroduced #468.** `stop()` did `cancel()` then `await`. Awaiting a task that already finished with an exception *re-raises it*, so `stop()` blew up on exactly the endpoints the supervisor was about to restart — aborting before the engine was disposed. The supervisor calls `stop()` on every restart, so this would have leaked an aiosqlite pool per restart. The suite's leak guard caught it.

**2. Two `BusHandle` test doubles had no `spawn()`.** This is part of why the bug survived: the method the endpoint needs did not exist on the fakes, so no test could have exercised spawn-based supervision. Both now mirror the real contract. Seven other test files carry handle doubles that also lack `spawn`; they fake endpoints that do not spawn, so they are left alone — noting it here rather than silently expanding this PR.

**3. My own end-to-end test orphaned the real `AsyncScheduler`** by swapping `_scheduler` for a fake, so `stop()` called `__aexit__` on the fake and the real object was never released. It now restores the real one before teardown.

## Tests assert effects, not wiring

- **End-to-end**: drives a real bus, kills the scheduler, asserts `supervisor.state("scheduler").status` actually becomes `restarting`. Negative-controlled — remove the `spawn` call and it fails with `still reads 'active' — the failure is invisible`. This is the test that matters, because #586 happened precisely when every individual piece was present and unconnected.
- **Stays-quiet**: a watchdog that raised unconditionally would pass the crash test while making every daemon restart forever.
- **Clean shutdown**: `stop()` makes the scheduler not-running, which is indistinguishable from a crash by state alone. Without this, every ordinary shutdown would report a spurious endpoint failure.
- **Stop-after-fire**: locks defect 1 above.

## Verification

- `packages/core/tests`: **1244 passed, 44 skipped**, no leak-guard errors.
- `ruff check` / `ruff format` clean.
- `mypy packages/core/src`: only the pre-existing `agent_core_discord` stub error, identical on clean `origin/main`.

## One chosen default worth a glance

`_LIVENESS_POLL_SECONDS = 5.0` — detection latency, not a correctness knob. A dead scheduler is reported within roughly that long. The check is an in-memory enum read, so it is cheap. Easy to change if you'd prefer a different number.
