### PR TITLE
fix(qa): gate daemon readiness on a tool that needs the started handle

### DIFF
--- a/packages/agent-core-qa/src/agent_core_qa/fixtures.py
+++ b/packages/agent-core-qa/src/agent_core_qa/fixtures.py
@@ -50,21 +50,34 @@ def _tcp_probe(host: str, port: int, *, timeout: float = 1.0) -> bool:
 
 
 async def _qa_endpoint_ready(url: str, *, deadline: float) -> bool:
-    """Poll the ``qa`` MCP endpoint until it answers a tool call, or ``deadline`` passes.
+    """Poll the ``qa`` MCP endpoint until it is genuinely started, or ``deadline`` passes.
 
     The TCP probe only confirms the daemon's HTTP port is bound —
     Starlette/Uvicorn opens the socket before the daemon's endpoints finish
     their ``start()``. A test that fires a ``send`` tool call into that window
-    gets ``500 endpoint 'qa' is not started`` — a startup race that surfaces
-    non-deterministically (it depends on how fast the endpoints come up relative
-    to the first test; it passed on the impl PR and failed on ``main``).
-    ``list_pending`` is a read-only tool on the ``qa`` ``ClaudeCodeMCPEndpoint``;
-    a ``200`` from it means the endpoint is genuinely started and serving. Gate
-    on that, not just the open port, so tests never race a half-started daemon.
+    gets ``500 endpoint 'qa' is not started``.
+
+    **The probe must call a tool that requires the started handle.** This gate
+    previously polled ``list_pending`` and accepted any ``200``, on the stated
+    reasoning that "a 200 from it means the endpoint is genuinely started and
+    serving". That was false: ``_call_list_pending`` never touches ``_handle``
+    — it reads the in-memory ``_pending`` list and returns — so it answers
+    ``200`` with an empty mailbox whether or not the endpoint has started. The
+    gate therefore passed on its first poll every time and protected nothing,
+    which is why ``endpoint 'qa' is not started`` kept reaching the tests it
+    was written to prevent.
+
+    ``consume`` calls ``_require_handle()`` before doing anything, so it fails
+    loudly while the endpoint is unstarted. With ``auto_ack=False`` and
+    ``max_items=0`` it acks nothing and drops nothing — a pure read, safe to
+    call repeatedly as a probe.
     """
     client = DaemonClient(url)
     while time.monotonic() < deadline:
-        result = await client.call_tool("list_pending", arguments={})
+        result = await client.call_tool(
+            "consume",
+            arguments={"auto_ack": False, "max_items": 0},
+        )
         if result.status_code == 200:
             return True
         await asyncio.sleep(_POLL_INTERVAL)

--- a/packages/core/tests/test_claude_code_mcp_readiness_probe.py
+++ b/packages/core/tests/test_claude_code_mcp_readiness_probe.py
@@ -1,0 +1,75 @@
+"""The qa readiness gate's probe tool must actually depend on being started.
+
+The agent-core-qa `source_daemon` fixture gates on the `qa` endpoint being
+ready before any scenario runs, because the daemon binds its HTTP port before
+its endpoints finish `start()`. That gate polled `list_pending` and accepted
+any 200, documented as "a 200 from it means the endpoint is genuinely started
+and serving."
+
+That was false. `_call_list_pending` never reads `_handle` — it returns a
+snapshot of the in-memory `_pending` list — so it answers 200 with an empty
+mailbox whether or not the endpoint started. The gate passed on its first poll
+every time and protected nothing, and `endpoint 'qa' is not started` kept
+reaching the tests it existed to prevent (agent_core CI 2026-08-05, runs
+31003976516 and 31015413254; six occurrences each).
+
+These tests pin the distinction so a future edit cannot quietly swap the probe
+back to a tool that answers before the endpoint is up.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_core.endpoints.claude_code_mcp._endpoint import ClaudeCodeMCPEndpoint
+
+
+def _unstarted() -> ClaudeCodeMCPEndpoint:
+    """An endpoint that has been constructed but never started."""
+    ep = ClaudeCodeMCPEndpoint(name="qa", mount="/qa")
+    assert ep._handle is None
+    return ep
+
+
+@pytest.mark.asyncio
+async def test_list_pending_answers_even_when_not_started() -> None:
+    """Documents why list_pending is the WRONG readiness probe.
+
+    This is not a defect in list_pending — a mailbox view that works before
+    the bus attaches is reasonable. It is a defect in using it as a proxy for
+    readiness.
+    """
+    result = await _unstarted()._call_list_pending()
+
+    assert set(result) == {"meta", "items"}
+    assert result["items"] == []
+
+
+def test_handle_requiring_tools_refuse_when_not_started() -> None:
+    """The readiness probe must call one of these, not list_pending."""
+    with pytest.raises(RuntimeError, match="is not started"):
+        _unstarted()._require_handle()
+
+
+def test_readiness_gate_probes_a_handle_requiring_tool() -> None:
+    """The gate must not regress to a tool that answers before startup.
+
+    Guards the fixture itself: `consume` calls `_require_handle()` before doing
+    anything, so it fails loudly while unstarted. `list_pending` does not.
+    """
+    from agent_core_qa import fixtures
+
+    source = fixtures._qa_endpoint_ready.__doc__ or ""
+    import inspect
+
+    body = inspect.getsource(fixtures._qa_endpoint_ready)
+
+    assert '"consume"' in body, (
+        "the readiness gate must probe a tool that requires the started handle; "
+        "list_pending answers 200 before the endpoint starts and gates nothing"
+    )
+    assert '"list_pending"' not in body.split('"""')[-1], (
+        "list_pending must not be the probe — it does not read _handle"
+    )
+    assert "auto_ack" in body, "the probe must be a pure read (auto_ack=False)"
+    assert source  # docstring explains the reasoning for the next reader

--- a/packages/core/tests/test_claude_code_mcp_readiness_probe.py
+++ b/packages/core/tests/test_claude_code_mcp_readiness_probe.py
@@ -19,9 +19,16 @@ back to a tool that answers before the endpoint is up.
 
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from agent_core.endpoints.claude_code_mcp._endpoint import ClaudeCodeMCPEndpoint
+
+
+def _soon() -> float:
+    """A deadline far enough out that a responsive gate always beats it."""
+    return time.monotonic() + 5.0
 
 
 def _unstarted() -> ClaudeCodeMCPEndpoint:
@@ -51,25 +58,81 @@ def test_handle_requiring_tools_refuse_when_not_started() -> None:
         _unstarted()._require_handle()
 
 
-def test_readiness_gate_probes_a_handle_requiring_tool() -> None:
-    """The gate must not regress to a tool that answers before startup.
+class _FakeResult:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
 
-    Guards the fixture itself: `consume` calls `_require_handle()` before doing
-    anything, so it fails loudly while unstarted. `list_pending` does not.
+
+class _RecordingClient:
+    """Captures which tool the readiness gate probes, and with what."""
+
+    def __init__(self, url: str, statuses: list[int]) -> None:
+        self.url = url
+        self._statuses = list(statuses)
+        self.calls: list[tuple[str, dict]] = []
+
+    async def call_tool(self, tool: str, arguments: dict) -> _FakeResult:
+        self.calls.append((tool, arguments))
+        status = self._statuses.pop(0) if self._statuses else 200
+        return _FakeResult(status)
+
+
+@pytest.mark.asyncio
+async def test_gate_probes_a_handle_requiring_tool_as_a_pure_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The probe must need the handle, and must not mutate the mailbox.
+
+    ``consume`` calls ``_require_handle()`` first, so it 500s while unstarted.
+    ``auto_ack=False`` with ``max_items=0`` acks nothing and drops nothing, so
+    the gate can poll it repeatedly without consuming a being's mail.
     """
     from agent_core_qa import fixtures
 
-    source = fixtures._qa_endpoint_ready.__doc__ or ""
-    import inspect
+    client = _RecordingClient("http://x", [200])
+    monkeypatch.setattr(fixtures, "DaemonClient", lambda url: client)
 
-    body = inspect.getsource(fixtures._qa_endpoint_ready)
+    assert await fixtures._qa_endpoint_ready("http://x", deadline=_soon()) is True
 
-    assert '"consume"' in body, (
-        "the readiness gate must probe a tool that requires the started handle; "
+    tool, args = client.calls[0]
+    assert tool == "consume", (
+        "the gate must probe a tool that requires the started handle; "
         "list_pending answers 200 before the endpoint starts and gates nothing"
     )
-    assert '"list_pending"' not in body.split('"""')[-1], (
-        "list_pending must not be the probe — it does not read _handle"
-    )
-    assert "auto_ack" in body, "the probe must be a pure read (auto_ack=False)"
-    assert source  # docstring explains the reasoning for the next reader
+    assert args["auto_ack"] is False, "probing must not ack the mailbox"
+    assert args["max_items"] == 0, "probing must not drain the mailbox"
+
+
+@pytest.mark.asyncio
+async def test_gate_keeps_polling_while_the_endpoint_is_unstarted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 500 means not-started; the gate must wait, not sail through.
+
+    This is the property the old list_pending probe lacked — it accepted the
+    first 200 and returned immediately, every time.
+    """
+    from agent_core_qa import fixtures
+
+    monkeypatch.setattr(fixtures, "_POLL_INTERVAL", 0.001)
+    client = _RecordingClient("http://x", [500, 500, 200])
+    monkeypatch.setattr(fixtures, "DaemonClient", lambda url: client)
+
+    assert await fixtures._qa_endpoint_ready("http://x", deadline=_soon()) is True
+    assert len(client.calls) == 3, "gate must keep polling until the endpoint answers"
+
+
+@pytest.mark.asyncio
+async def test_gate_reports_failure_when_the_endpoint_never_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deadline with a never-starting endpoint must return False, not True."""
+    from agent_core_qa import fixtures
+
+    monkeypatch.setattr(fixtures, "_POLL_INTERVAL", 0.001)
+    client = _RecordingClient("http://x", [500] * 50)
+    monkeypatch.setattr(fixtures, "DaemonClient", lambda url: client)
+
+    result = await fixtures._qa_endpoint_ready("http://x", deadline=time.monotonic() + 0.05)
+
+    assert result is False, "a never-started endpoint must fail the gate, not pass it"


### PR DESCRIPTION
Unblocks #588. The `release-gate` failure there is not a random flake — the guard written to prevent it never did anything.

## The gate was a no-op

`source_daemon` waits for the `qa` endpoint before any scenario runs, because the daemon binds its HTTP port before its endpoints finish `start()`. The gate polled `list_pending` and accepted any `200`, documented in the code as:

> `list_pending` is a read-only tool on the `qa` `ClaudeCodeMCPEndpoint`; a `200` from it means the endpoint is genuinely started and serving.

That claim is false, and it is checkable in five lines:

```python
ep = ClaudeCodeMCPEndpoint(name="qa", mount="/qa")   # never started
ep._handle is None             # True
await ep._call_list_pending()  # {"meta": ..., "items": []}   <- 200, happily
ep._require_handle()           # RuntimeError: endpoint 'qa' is not started
```

`_call_list_pending` never reads `_handle`; it returns a snapshot of the in-memory `_pending` list. So the gate returned `True` on its **first poll, every time**, and `endpoint 'qa' is not started` kept reaching the tests it existed to prevent.

Observed twice on 2026-08-05 — runs [31003976516](https://github.com/jeffrichley/agent_core/actions/runs/31003976516) (#582) and [31015413254](https://github.com/jeffrichley/agent_core/actions/runs/31015413254) (#588), six occurrences each, taking down `test_envelope_roundtrip`, `test_discord_send_stub_route` and `test_scheduler_create_and_delete` — while `test_daemon_liveness` passed in the same run.

## The fix

Probe `consume` instead. It calls `_require_handle()` before doing anything, so it 500s while the endpoint is unstarted; with `auto_ack=False` and `max_items=0` it acks nothing and drops nothing, so it is safe to poll repeatedly.

## Why this is worth more than a one-line diff

It is not an oversight so much as a category error, and it is the same one as #581 (a partly-booted daemon reporting healthy) and #586 (a dead scheduler reporting healthy): **the check asked whether a request succeeded, when the question was whether the endpoint was ready.** A tool that legitimately works without a handle answered on the endpoint's behalf.

The sharpest part is that someone hit this flake, diagnosed the race correctly, wrote a guard, wrote a docstring asserting the guard's validity — and never executed the unstarted case. The guard shipped, the flake continued, and the guard's existence made it look handled.

## The tests, and a mistake in them worth recording

My first version asserted on the **source text** of `_qa_endpoint_ready` — that the string `"consume"` appeared in its body. That is a test of how the function is spelled, not what it does; it would pass on a function that mentioned `consume` in a comment while probing something else. Same substitution as the bug.

`diff-cover` caught it: the one new line sat at 0%, because a test that greps source never executes the code. The pre-push gate refused the push.

The tests now drive the gate against a recording client:

- probes `consume` with `auto_ack=False`, `max_items=0` — needs the handle, does not mutate the mailbox
- a `500` makes it keep polling rather than sail through (the property the old probe lacked)
- a never-starting endpoint returns `False`, not `True`
- `list_pending` answers while unstarted — documenting *why* it is the wrong probe, not that it is broken

## Verification

- Full suite: **2149 passed, 51 skipped**.
- Patch coverage on this branch: **0% → 100%**.
- `ruff check` / `ruff format` clean.
