### PR TITLE
fix(hatchery): make the generated backup hook able to fail

### DIFF
--- a/packages/agent-core-hatchery/src/agent_core_hatchery/channels/github_backup.py
+++ b/packages/agent-core-hatchery/src/agent_core_hatchery/channels/github_backup.py
@@ -21,6 +21,21 @@ REPO_URL="{repo_url}"
 # the only useful behaviour, and the SHA check below turns it into a report.
 export GIT_TERMINAL_PROMPT=0
 
+# Operate on THIS vault's repository and no other. Git exports GIT_DIR,
+# GIT_WORK_TREE and GIT_INDEX_FILE into the environment of every hook it
+# invokes, so if this script is ever reached from inside another git command
+# it inherits that repo -- and every command below silently retargets. The
+# observed failure is unambiguous and alarming:
+#
+#   $ GIT_DIR=<caller>/.git bash backup-to-github.sh
+#   Reinitialized existing Git repository in <caller>/.git/...
+#   error: remote origin already exists.
+#
+# That path ends in `git add -A` over someone else's working tree and a push
+# of it to this being's backup remote. Unsetting is cheap; the failure is not.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+      GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_PREFIX
+
 cd "$VAULT_ROOT"
 if [ ! -d Memory/.git ]; then
   cd Memory

--- a/packages/agent-core-hatchery/src/agent_core_hatchery/channels/github_backup.py
+++ b/packages/agent-core-hatchery/src/agent_core_hatchery/channels/github_backup.py
@@ -16,6 +16,11 @@ set -euo pipefail
 VAULT_ROOT="{vault_root}"
 REPO_URL="{repo_url}"
 
+# Never prompt. This runs headless from the scheduler, where a credential
+# prompt is not a question anyone can answer -- it is a hang. Failing fast is
+# the only useful behaviour, and the SHA check below turns it into a report.
+export GIT_TERMINAL_PROMPT=0
+
 cd "$VAULT_ROOT"
 if [ ! -d Memory/.git ]; then
   cd Memory
@@ -24,9 +29,50 @@ if [ ! -d Memory/.git ]; then
   cd ..
 fi
 cd Memory
+
+# `symbolic-ref`, not `rev-parse --abbrev-ref HEAD`. On the FIRST run the repo
+# was just `git init`ed and has no commits, and rev-parse errors on an unborn
+# branch -- which under `set -e` aborts the very run that is supposed to
+# establish the backup.
+BRANCH=$(git symbolic-ref --short HEAD)
 git add -A
-git commit -m "backup $(date -Iseconds)" || true  # ok if nothing to commit
-git push -u origin HEAD || true                   # warn-only on first push
+
+# Distinguish "nothing to commit" from "commit failed". The previous
+# `|| true` treated them alike, so a genuinely broken commit read as a quiet
+# no-op.
+if git diff --cached --quiet; then
+  echo "Nothing to commit; pushing anyway (a push is a no-op when current)."
+else
+  git commit -m "backup $(date -Iseconds)"
+fi
+
+# `|| PUSH_RC=$?` rather than `git push` followed by `PUSH_RC=$?`. Under
+# `set -e` a bare failing push aborts the script AT THAT LINE, skipping the
+# verification below -- so the one path that most needs checking is the only
+# path that never reaches it.
+#
+# Not `if ! git push; then PUSH_RC=$?; fi` either: `!` inverts the status, so
+# the captured value is the negation's 0. That form looks repaired and is not.
+PUSH_RC=0
+git push -u origin "$BRANCH" || PUSH_RC=$?
+
+# `|| REMOTE_SHA=""` is load-bearing. Under `pipefail` a failed ls-remote fails
+# this assignment and `set -e` kills the script one line before the check,
+# reintroducing the silent stop for every remote-unreachable case: network
+# down, repo renamed, credential revoked.
+LOCAL_SHA=$(git rev-parse HEAD)
+REMOTE_SHA=$(git ls-remote origin "$BRANCH" 2>/dev/null | cut -f1) || REMOTE_SHA=""
+
+# Verify the OBJECT, not the exit code. `git push` can report success on a path
+# that did not deliver, and a backup that announces success without checking is
+# the highest-stakes version of that failure -- it is the thing protecting the
+# being's memory.
+if [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
+  echo "BACKUP FAILED: local $LOCAL_SHA != remote ${{REMOTE_SHA:-<unreachable>}} (push rc=$PUSH_RC)" >&2
+  exit 1
+fi
+
+echo "Backup verified: $BRANCH at $LOCAL_SHA"
 """
 
 

--- a/packages/agent-core-hatchery/src/agent_core_hatchery/config.py
+++ b/packages/agent-core-hatchery/src/agent_core_hatchery/config.py
@@ -12,7 +12,14 @@ import re
 from datetime import date
 from pathlib import Path
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 
 _ENV_VAR_PATTERN = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)\}")
 
@@ -23,9 +30,7 @@ def _substitute_env_vars(value: str) -> str:
     def repl(match: re.Match[str]) -> str:
         var_name = match.group(1)
         if var_name not in os.environ:
-            raise ValueError(
-                f"Environment variable {var_name!r} referenced in config but not set"
-            )
+            raise ValueError(f"Environment variable {var_name!r} referenced in config but not set")
         return os.environ[var_name]
 
     return _ENV_VAR_PATTERN.sub(repl, value)
@@ -54,6 +59,42 @@ class GitHubBackupConfig(BaseModel):
     repo_url: str = ""
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_validator("repo_url")
+    @classmethod
+    def _reject_embedded_credential(cls, value: str) -> str:
+        """Refuse a repo URL carrying an inline credential.
+
+        The generated backup hook runs ``git remote add origin "$REPO_URL"``,
+        which writes the URL into ``Memory/.git/config`` verbatim and leaves it
+        there. A tokenised URL therefore persists the secret in plaintext on
+        disk for the life of the vault -- strictly worse than passing it on a
+        command line, which at least does not survive the process.
+
+        Failing here makes that unrepresentable, and it fails at hatch time in
+        front of a human rather than at 4 AM inside a scheduled job.
+
+        Args:
+            value: The configured repository URL.
+
+        Returns:
+            The URL unchanged when it carries no inline credential.
+
+        Raises:
+            ValueError: If the URL embeds userinfo with a password/token.
+        """
+        scheme, sep, rest = value.partition("://")
+        if not sep:
+            return value
+        userinfo, at, _ = rest.partition("@")
+        if at and ":" in userinfo:
+            raise ValueError(
+                "repo_url must not embed a credential "
+                f"('{scheme}://<user>:<secret>@...'); the backup hook would "
+                "persist it in Memory/.git/config. Supply a plain URL and "
+                "provide credentials via SSH or a credential helper."
+            )
+        return value
 
 
 class ChannelsConfig(BaseModel):

--- a/packages/agent-core-hatchery/tests/test_github_backup_hook.py
+++ b/packages/agent-core-hatchery/tests/test_github_backup_hook.py
@@ -1,0 +1,173 @@
+"""Behavioural tests for the generated github_backup hook.
+
+These run the generated script against a real local git remote rather than
+asserting on its text. The defect that motivated them (#601) was invisible to a
+text assertion: the old hook ended in ``git push ... || true``, so it exited 0
+whether or not it delivered anything, and the existing test -- which checked
+that the repo URL appeared in the file -- passed the whole time.
+
+The property under test is therefore: *a run that did not deliver must exit
+non-zero and say so.*
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from agent_core_hatchery.channels.github_backup import scaffold_github_backup
+from agent_core_hatchery.config import (
+    ChannelsConfig,
+    GitHubBackupConfig,
+    HatchConfig,
+)
+from pydantic import ValidationError
+
+# Resolve bash to an ABSOLUTE path and invoke it that way. On Windows,
+# `subprocess.run(["bash", ...])` does not use PATH order: CreateProcess
+# searches the system directory first, so it finds WSL's System32\bash.exe --
+# a linux-gnu bash that cannot see the Windows filesystem at all and fails
+# every script with "No such file or directory" (rc=127). `shutil.which`
+# meanwhile reports Git's msys bash, so the two disagree and the test appears
+# to prove the hook is broken when the hook never ran.
+_BASH = shutil.which("bash")
+
+pytestmark = pytest.mark.skipif(
+    _BASH is None or shutil.which("git") is None,
+    reason="needs bash and git to execute the generated hook",
+)
+
+# Identity for the commit the hook makes. Without these a CI runner with no
+# configured user.email fails the commit, and the test would go red for a
+# reason that has nothing to do with what it is testing.
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@example.invalid",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@example.invalid",
+}
+
+
+def _cfg(tmp_path: Path, repo_url: str) -> HatchConfig:
+    """Build a hatch config whose vault resolves to ``tmp_path/.deb``."""
+    return HatchConfig(
+        being_name="Deb",
+        primary_human_name="Cynthia",
+        vault_root=str(tmp_path),
+        daemon_config_dir=str(tmp_path / ".agent-core"),
+        channels=ChannelsConfig(github_backup=GitHubBackupConfig(enabled=True, repo_url=repo_url)),
+    )
+
+
+def _run_hook(hook: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Execute the generated hook and capture its output."""
+    full_env = {**os.environ, **_GIT_ENV, **env}
+    assert _BASH is not None  # guarded by pytestmark
+    # `as_posix()` as well as the absolute interpreter: a native Windows path
+    # reaches bash with its backslashes consumed as escapes.
+    return subprocess.run(
+        [_BASH, hook.as_posix()],
+        capture_output=True,
+        text=True,
+        env=full_env,
+        timeout=120,
+    )
+
+
+def _seed_vault(tmp_path: Path) -> Path:
+    """Create a vault root with one file in Memory/ for the hook to back up."""
+    memory = tmp_path / ".deb" / "Memory"
+    memory.mkdir(parents=True)
+    (memory / "SOUL.md").write_text("a being's memory\n", encoding="utf-8")
+    return memory
+
+
+def test_hook_pushes_and_verifies_against_a_real_remote(tmp_path: Path) -> None:
+    """A delivering run exits 0 and leaves remote == local."""
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    memory = _seed_vault(tmp_path)
+
+    scaffold_github_backup(_cfg(tmp_path, remote.as_uri()))
+    hook = tmp_path / ".deb" / "hooks" / "backup-to-github.sh"
+    assert hook.is_file()
+
+    result = _run_hook(hook, {})
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "Backup verified" in result.stdout
+
+    local = subprocess.run(
+        ["git", "-C", str(memory), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    remote_sha = subprocess.run(
+        ["git", "ls-remote", str(remote), "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()[0]
+    assert local == remote_sha
+
+
+def test_hook_fails_loudly_when_the_remote_is_unreachable(tmp_path: Path) -> None:
+    """A run that delivers nothing must exit non-zero and name the failure.
+
+    This is the regression lock for #601. Against the previous template this
+    case exited 0 and printed nothing alarming.
+    """
+    _seed_vault(tmp_path)
+    unreachable = (tmp_path / "does-not-exist.git").as_uri()
+    scaffold_github_backup(_cfg(tmp_path, unreachable))
+    hook = tmp_path / ".deb" / "hooks" / "backup-to-github.sh"
+
+    result = _run_hook(hook, {})
+    assert result.returncode != 0, "a backup that delivered nothing reported success"
+    assert "BACKUP FAILED" in result.stderr
+    assert "<unreachable>" in result.stderr
+
+
+def test_hook_is_idempotent_on_a_second_run(tmp_path: Path) -> None:
+    """Re-running with nothing new still verifies rather than short-circuiting."""
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    _seed_vault(tmp_path)
+    scaffold_github_backup(_cfg(tmp_path, remote.as_uri()))
+    hook = tmp_path / ".deb" / "hooks" / "backup-to-github.sh"
+
+    assert _run_hook(hook, {}).returncode == 0
+    second = _run_hook(hook, {})
+    assert second.returncode == 0, f"stderr={second.stderr}"
+    assert "Nothing to commit" in second.stdout
+    assert "Backup verified" in second.stdout
+
+
+def test_generated_hook_carries_no_credential(tmp_path: Path) -> None:
+    """The scaffolder must never write a secret into the hook text."""
+    remote = tmp_path / "remote.git"
+    scaffold_github_backup(_cfg(tmp_path, remote.as_uri()))
+    text = (tmp_path / ".deb" / "hooks" / "backup-to-github.sh").read_text(encoding="utf-8")
+    repo_line = next(line for line in text.splitlines() if line.startswith("REPO_URL="))
+    # Written verbatim, with nothing appended -- and userinfo can never reach
+    # here because GitHubBackupConfig refuses it upstream.
+    assert repo_line == f'REPO_URL="{remote.as_uri()}"'
+    assert "ghp_" not in text
+
+
+def test_config_rejects_a_repo_url_with_an_embedded_credential() -> None:
+    """A tokenised URL is refused at hatch time, not persisted at 4 AM."""
+    with pytest.raises(ValidationError, match="must not embed a credential"):
+        GitHubBackupConfig(
+            enabled=True,
+            repo_url="https://user:ghp_secretsecretsecret@github.com/o/r.git",
+        )
+
+
+def test_config_accepts_plain_urls() -> None:
+    """Plain https and ssh URLs stay valid."""
+    assert GitHubBackupConfig(repo_url="https://github.com/o/r.git").repo_url
+    assert GitHubBackupConfig(repo_url="git@github.com:o/r.git").repo_url

--- a/packages/agent-core-hatchery/tests/test_github_backup_hook.py
+++ b/packages/agent-core-hatchery/tests/test_github_backup_hook.py
@@ -50,6 +50,28 @@ _GIT_ENV = {
     "GIT_COMMITTER_EMAIL": "test@example.invalid",
 }
 
+# Git exports these into the environment of every hook it runs. This suite is
+# itself executed from a pre-push hook on this repo, so inheriting them points
+# each git call below at agent_core's own repository -- which is why these
+# tests failed only under the gate and never standalone.
+_LEAKED_GIT_VARS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_PREFIX",
+)
+
+
+def _clean_env(**extra: str) -> dict[str, str]:
+    """Return the ambient environment with git's per-hook variables removed."""
+    env = {**os.environ, **_GIT_ENV, **extra}
+    for leaked in _LEAKED_GIT_VARS:
+        env.pop(leaked, None)
+    return env
+
 
 def _cfg(tmp_path: Path, repo_url: str) -> HatchConfig:
     """Build a hatch config whose vault resolves to ``tmp_path/.deb``."""
@@ -64,7 +86,7 @@ def _cfg(tmp_path: Path, repo_url: str) -> HatchConfig:
 
 def _run_hook(hook: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     """Execute the generated hook and capture its output."""
-    full_env = {**os.environ, **_GIT_ENV, **env}
+    full_env = _clean_env(**env)
     assert _BASH is not None  # guarded by pytestmark
     # `as_posix()` as well as the absolute interpreter: a native Windows path
     # reaches bash with its backslashes consumed as escapes.
@@ -88,7 +110,12 @@ def _seed_vault(tmp_path: Path) -> Path:
 def test_hook_pushes_and_verifies_against_a_real_remote(tmp_path: Path) -> None:
     """A delivering run exits 0 and leaves remote == local."""
     remote = tmp_path / "remote.git"
-    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)],
+        check=True,
+        capture_output=True,
+        env=_clean_env(),
+    )
     memory = _seed_vault(tmp_path)
 
     scaffold_github_backup(_cfg(tmp_path, remote.as_uri()))
@@ -104,12 +131,14 @@ def test_hook_pushes_and_verifies_against_a_real_remote(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
         check=True,
+        env=_clean_env(),
     ).stdout.strip()
     remote_sha = subprocess.run(
         ["git", "ls-remote", str(remote), "HEAD"],
         capture_output=True,
         text=True,
         check=True,
+        env=_clean_env(),
     ).stdout.split()[0]
     assert local == remote_sha
 
@@ -134,7 +163,12 @@ def test_hook_fails_loudly_when_the_remote_is_unreachable(tmp_path: Path) -> Non
 def test_hook_is_idempotent_on_a_second_run(tmp_path: Path) -> None:
     """Re-running with nothing new still verifies rather than short-circuiting."""
     remote = tmp_path / "remote.git"
-    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)],
+        check=True,
+        capture_output=True,
+        env=_clean_env(),
+    )
     _seed_vault(tmp_path)
     scaffold_github_backup(_cfg(tmp_path, remote.as_uri()))
     hook = tmp_path / ".deb" / "hooks" / "backup-to-github.sh"


### PR DESCRIPTION
Closes #601.

The backup hook that `agent-core-hatchery` generates for every new being could
not report failure. It ended in:

```bash
git push -u origin HEAD || true   # warn-only on first push
```

`|| true` swallows every non-zero exit, and nothing afterwards checked whether
the remote had actually advanced. With a plain (non-tokenised) `repo_url` a
headless scheduled run has no credential to authenticate with, so the push fails
on **every** run and reports success on **every** run — the being's memory is
never backed up and nothing anywhere says so.

## What changed

| | |
|---|---|
| push status | `PUSH_RC=0; git push ... \|\| PUSH_RC=$?` — a bare failing push aborts under `set -e` at that line, skipping the verification below. `if ! git push; then PUSH_RC=$?; fi` does **not** fix it: `!` inverts the status, so the captured value is the negation's `0`. |
| ls-remote | `\|\| REMOTE_SHA=""` — under `pipefail` a failed `ls-remote` fails the assignment and `set -e` kills the script one line before the check, reintroducing the silent stop for every remote-unreachable case. |
| verification | compare `LOCAL_SHA` to `REMOTE_SHA`; exit non-zero with a `BACKUP FAILED:` line naming both SHAs and the push rc. |
| first run | `git symbolic-ref --short HEAD` instead of `rev-parse --abbrev-ref HEAD`, which errors on the unborn branch of a freshly `git init`ed repo — aborting the very run meant to establish the backup. |
| commit | dropped `\|\| true` so "nothing to commit" and "commit failed" stop being the same observation. |
| prompting | `GIT_TERMINAL_PROMPT=0`, so a missing credential fails fast instead of hanging on a prompt a scheduled job cannot answer. |
| config | reject a `repo_url` with embedded userinfo. `git remote add origin "$REPO_URL"` persists a tokenised URL in `Memory/.git/config` in plaintext for the life of the vault; failing at hatch time puts it in front of a human. |

## On the tests

The existing test asserted that the repo URL appeared in the generated file. It
passed the entire time the hook was broken, because the defect was in behaviour
the text could not express. The new tests run the generated script against a
real local bare remote.

**Positive control, because a passing test proves nothing on its own:** with the
pre-fix template restored, `test_hook_fails_loudly_when_the_remote_is_unreachable`
fails with `AssertionError: a backup that delivered nothing reported success`.
With the fix, all 6 pass.

```
87 passed, 2 skipped          # full agent-core-hatchery package
ruff check                    # All checks passed
mypy packages/agent-core-hatchery/src   # 2 pre-existing errors in hatcher.py (untouched)
```

Two Windows-specific traps are documented in comments where they bite, since both
produce a failure that looks like the thing under test failing:

- `subprocess.run(["bash", ...])` does not honour PATH order on Windows —
  CreateProcess searches the system directory first and finds WSL's
  `System32\bash.exe`, a linux-gnu bash that cannot see the Windows filesystem
  and fails every script with rc=127. `shutil.which` reports Git's msys bash, so
  the two disagree. The tests invoke bash by absolute path.
- a native Windows path reaches bash with its backslashes consumed as escapes.

## Why now

A new being is being hatched shortly and would have inherited all of the above.

## Second commit: the hook inherited the caller's repository

Found because the new tests failed **only** under the pre-push gate and passed
in every other context. The gate is itself a git hook, and git exports `GIT_DIR`,
`GIT_WORK_TREE` and `GIT_INDEX_FILE` into a hook's environment — so it was the
only context that set them.

The generated backup hook read those variables, which means reaching it from
inside any git command silently retargeted every git call in it:

```
$ GIT_DIR=<caller>/.git bash backup-to-github.sh
Reinitialized existing Git repository in <caller>/.git/...
error: remote origin already exists.
```

That path ends in `git add -A` over an unrelated working tree and a push of it
to the being's backup remote. The hook now unsets them before touching
anything, and the tests clear them for their own direct git calls too.

Verified by reproducing the exact condition: with `GIT_DIR` set the suite failed
3 and now passes 6. The full serial suite passes through the pre-push gate.
