### PR TITLE
fix(presence): a dead sensor must not read as a quiet one

### DIFF
--- a/packages/agent-core-webcam/src/agent_core_webcam/presence/camera_session.py
+++ b/packages/agent-core-webcam/src/agent_core_webcam/presence/camera_session.py
@@ -32,6 +32,10 @@ class CameraSession:
     def __init__(self, index: int = 0, resolution: tuple[int, int] = (1280, 720)) -> None:
         self._index = index
         self._resolution = resolution
+        # Remembered so a degraded session has a way home. Without this, one
+        # memory-pressured afternoon would pin the camera to low resolution for
+        # the life of the process and nothing would ever say why.
+        self._full_resolution = resolution
         self._cap: object | None = None
 
     def __enter__(self) -> Self:
@@ -63,6 +67,56 @@ class CameraSession:
                 self.read_bgr()
             except CameraBusyError:
                 return
+
+    #: The degraded resolution used when the box cannot afford a full frame.
+    #: One step only. The 2026-08-14 failure was a HOST-RAM allocation failure
+    #: (OpenCV's ``core/src/alloc.cpp`` — nothing GPU-side): a 1280x720x3 frame
+    #: is 2 764 800 bytes and could not be allocated while ~74% of 64 GB was
+    #: resident elsewhere. 640x360x3 is 691 200 — a quarter. If THAT also fails,
+    #: shrinking further does not save you, and a frame too small for reliable
+    #: face detection produces confident-looking garbage, which is worse than an
+    #: honest failure. So: one step down, then hold and report.
+    DEGRADED_RESOLUTION = (640, 360)
+
+    def reopen(self, *, degrade: bool = True) -> None:
+        """Release the capture and open a fresh one, optionally degraded.
+
+        A capture handle can enter a state no amount of re-``read()`` recovers
+        from, and the pre-2026-08-16 watcher would retry such a handle forever
+        while looking healthy from outside. This gives the loop a way to
+        actually recover rather than merely survive.
+
+        ``degrade`` drops to :attr:`DEGRADED_RESOLUTION`, which is a genuine
+        mitigation for this failure rather than a token one: the question the
+        watcher answers ("is anyone else in the room") is coarse and does not
+        need 720p. **A CLEAR reading at 640x360 beats a STALE one at 1280x720.**
+
+        Pass ``degrade=False`` to restore full resolution once the box recovers
+        — without that the session would stay degraded forever after a single
+        bad afternoon, silently trading accuracy it no longer needs to trade.
+        """
+        import cv2
+
+        if self._cap is not None:
+            try:
+                self._cap.release()  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001 - a failed release must not block the reopen
+                pass
+            self._cap = None
+        self._resolution = self.DEGRADED_RESOLUTION if degrade else self._full_resolution
+        cap = cv2.VideoCapture(self._index)
+        if cap is None or not cap.isOpened():
+            if cap is not None:
+                cap.release()
+            raise CameraNotFoundError(f"camera {self._index} could not be reopened")
+        cap.set(cv2.CAP_PROP_FRAME_WIDTH, self._resolution[0])
+        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self._resolution[1])
+        self._cap = cap
+
+    @property
+    def degraded(self) -> bool:
+        """Whether the session is currently running below its configured resolution."""
+        return self._resolution != self._full_resolution
 
     def __exit__(
         self,

--- a/packages/agent-core-webcam/src/agent_core_webcam/presence/injector.py
+++ b/packages/agent-core-webcam/src/agent_core_webcam/presence/injector.py
@@ -12,13 +12,26 @@ cautious". The hook never blocks and never raises.
 
 from __future__ import annotations
 
+import json
 import logging
 import time
+from dataclasses import replace
 from pathlib import Path
 
 from agent_core.models import ToolResult
-from agent_core_webcam.presence.levels import DEFAULT_TEMPLATES, classify, render
-from agent_core_webcam.presence.state import read_state
+from agent_core_webcam.presence.levels import (
+    DEFAULT_TEMPLATES,
+    Instrument,
+    classify,
+    render,
+)
+from agent_core_webcam.presence.state import (
+    PresenceState,
+    WatcherHeartbeat,
+    heartbeat_path_for,
+    read_heartbeat,
+    read_state,
+)
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +40,11 @@ _DEFAULT_MAX_AGE_SECONDS = 30.0
 _DEFAULT_HEADING = "Presence"
 _DEFAULT_LEVEL = 1
 _DEFAULT_PRINCIPAL = "jeff"
+#: A heartbeat older than this means the loop is not turning. Generous relative
+#: to the ~2s watch interval so a slow cycle or a paused box is not reported as
+#: death — this decides whether we say "DEAD", and a false death claim is the
+#: kind of alarm that trains its reader to ignore the channel.
+_DEFAULT_HEARTBEAT_MAX_AGE_SECONDS = 120.0
 
 
 class PresenceInjector:
@@ -60,11 +78,34 @@ class PresenceInjector:
             level = int(params.get("level", _DEFAULT_LEVEL))
             principal = str(params.get("principal", _DEFAULT_PRINCIPAL))
 
+            hb_max_age = float(
+                params.get("heartbeat_max_age_seconds", _DEFAULT_HEARTBEAT_MAX_AGE_SECONDS)
+            )
+
+            now = time.time()
             state = read_state(state_path)
-            if state is not None and (time.time() - state.updated_at) > max_age:
-                state = None  # stale => treat as no reading (cautious)
-            reading = classify(state, principal=principal)
-            content = render(reading, state, level=level, templates=templates)
+            heartbeat = read_heartbeat(heartbeat_path_for(state_path))
+            instrument, age = _diagnose(now, state, heartbeat, max_age, hb_max_age)
+
+            # A stale reading is still DISCARDED for every gating decision —
+            # this change does not soften the guard by one bit. What it stops
+            # doing is destroying the evidence on the way: `state` used to be
+            # reassigned to None here, so the age and the reason were gone
+            # before anything could report them.
+            fresh = state if instrument is Instrument.FRESH else None
+            reading = classify(fresh, principal=principal)
+            # `restarts` is SUPERVISOR restarts, deliberately NOT the heartbeat's
+            # `consecutive_failures` (which counts failed camera reads). They are
+            # different faults with different repairs, and putting one under the
+            # other's name is how a safety line ends up asserting something it
+            # never measured.
+            reading = replace(
+                reading,
+                instrument=instrument,
+                age_seconds=age,
+                restarts=_read_restart_count(state_path),
+            )
+            content = render(reading, fresh, level=level, templates=templates)
             return ToolResult(heading=heading, content=content)
         except Exception:  # never raise into the session — degrade to cautious
             log.exception("presence_injector failed; degrading to unknown")
@@ -84,3 +125,65 @@ class PresenceInjector:
             level = 3  # unparseable config => be maximally cautious
         reading = classify(None, principal="")  # None => no reading, cautious
         return render(reading, None, level=level, templates=templates)
+
+
+def _diagnose(
+    now: float,
+    state: PresenceState | None,
+    heartbeat: WatcherHeartbeat | None,
+    max_age: float,
+    hb_max_age: float,
+) -> tuple[Instrument, float | None]:
+    """Decide the instrument state and the age of the last reading.
+
+    The single place where "old reading" is turned into a CAUSE. Kept pure and
+    separate from the hook so it is testable without files, a camera, or a
+    session — the 2026-08-14 defect lived in three lines tangled into I/O and
+    was therefore never unit-tested at all.
+
+    Returns the instrument state and the reading's age in seconds (``None``
+    when there has never been a reading).
+
+    Ordering matters and is deliberate:
+
+    1. No state file at all => NEVER. "Never configured" must not be reported
+       as a running system that broke.
+    2. Reading is fresh => FRESH, regardless of the heartbeat. A good reading is
+       a good reading; refusing it because bookkeeping is missing would make the
+       fix less useful than what it replaced.
+    3. Reading is stale and NO heartbeat exists => UNKNOWN, never DEAD. A state
+       file written before heartbeats existed is indistinguishable from a dead
+       watcher, and claiming death without evidence is the same class of error
+       as the silence this change exists to fix.
+    4. Reading is stale, heartbeat is fresh => STALE. Loop turning, camera not.
+    5. Reading is stale, heartbeat is stale => DEAD.
+    """
+    if state is None:
+        return Instrument.NEVER, None
+    age = now - state.updated_at
+    if age <= max_age:
+        return Instrument.FRESH, age
+    if heartbeat is None:
+        return Instrument.UNKNOWN, age
+    if (now - heartbeat.beat_at) <= hb_max_age:
+        return Instrument.STALE, age
+    return Instrument.DEAD, age
+
+
+def _read_restart_count(state_path: Path) -> int | None:
+    """Recent supervisor restarts, or ``None`` when it cannot be determined.
+
+    ``None`` and ``0`` mean genuinely different things here — "nobody is
+    counting" versus "counted, and it has not restarted" — so an unreadable or
+    absent file must never collapse to zero. A zero would render as "stable",
+    which is a claim, and an absent supervisor has not earned it.
+    """
+    try:
+        raw = (state_path.parent / "supervisor.json").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        value = json.loads(raw).get("restarts_recent")
+    except (ValueError, AttributeError):
+        return None
+    return value if isinstance(value, int) else None

--- a/packages/agent-core-webcam/src/agent_core_webcam/presence/levels.py
+++ b/packages/agent-core-webcam/src/agent_core_webcam/presence/levels.py
@@ -10,8 +10,40 @@ principal not confirmed) resolves to the cautious side.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 
 from agent_core_webcam.presence.state import PresenceState
+
+
+class Instrument(Enum):
+    """Why there is (or is not) a usable reading — the SENSOR's own state.
+
+    Orthogonal to what was observed. The observed axis answers "who is at the
+    desk"; this answers "is the thing that would tell me still working". Before
+    2026-08-16 these were one axis, and the result was that a watcher dead for
+    56 hours produced output byte-identical to a camera that had merely not
+    refreshed in the last 30 seconds. Nobody noticed, because nothing could
+    have: the two states were literally the same string.
+
+    Members:
+        FRESH: a reading inside the staleness window. The only unlocking state.
+        STALE: reading is old, but the watch loop is demonstrably still turning
+            (recent heartbeat). The camera is failing; the process is fine.
+        DEAD: reading is old AND no recent heartbeat. The watcher is gone and
+            will not recover on its own. Loudest state.
+        NEVER: no reading has ever been written. Distinct from DEAD because it
+            means "never configured", which is a different repair entirely and
+            must not be reported as a failure of a running system.
+        UNKNOWN: liveness genuinely undeterminable — e.g. a state file from
+            before heartbeats existed. Treated as cautiously as DEAD but must
+            NOT claim the watcher is dead, because that has not been measured.
+    """
+
+    FRESH = "fresh"
+    STALE = "stale"
+    DEAD = "dead"
+    NEVER = "never"
+    UNKNOWN = "unknown"
 
 # Injected-text fragments, all overridable per being via the hook's
 # ``templates`` param. ``facts`` accepts {at_desk}, {recognized},
@@ -19,6 +51,45 @@ from agent_core_webcam.presence.state import PresenceState
 DEFAULT_TEMPLATES: dict[str, str] = {
     "facts": "At desk: {at_desk}. Recognized: {recognized}. Unknown faces: {unknown_count}.",
     "unknown_banner": "Presence unknown — no current reading from the desk camera.",
+    # The instrument banners. Each REPLACES `unknown_banner` and each states the
+    # sensor's condition and the AGE of the last reading, because "no reading"
+    # with no age attached is exactly what hid a 56-hour outage on 2026-08-14 —
+    # it read as "not in the last 30 seconds" every single turn.
+    #
+    # {age} is a human string ("2d 8h"); {restarts} is a count or "unknown".
+    "instrument_stale": (
+        "DESK CAMERA FAILING — the watcher is running but has not produced a "
+        "usable frame for {age}. Presence below is NOT current. Treat this as "
+        "no reading, and note the sensor is degraded rather than merely quiet."
+    ),
+    "instrument_dead": (
+        "DESK CAMERA WATCHER IS DEAD — no reading for {age} and the watch loop "
+        "is not running. This is a broken sensor, not a quiet one; it will not "
+        "recover on its own and presence cannot be established until it is "
+        "restarted. Everything below assumes no reading."
+    ),
+    # Both of these LEAD with "Presence unknown" and only then explain. An
+    # earlier draft opened the NEVER case with "never configured ... not a
+    # failure of a running system", which is true and reads as REASSURANCE — at
+    # level 1 that sentence is the only thing a being sees, and the one thing it
+    # must carry is that nobody knows who is in the room. Explanation is allowed
+    # to follow the uncertainty; it may not replace it.
+    "instrument_never": (
+        "Presence unknown — the desk camera has never produced a reading. "
+        "Presence was never configured on this machine, so this is a gap in "
+        "setup rather than a running system that broke — but nothing has been "
+        "observed either way."
+    ),
+    "instrument_unknown_liveness": (
+        "Presence unknown — no current reading from the desk camera (last: "
+        "{age}). Whether the watcher is still running could not be determined, "
+        "so this may be a slow sensor or a dead one; the difference has not "
+        "been measured."
+    ),
+    "instrument_restarts": (
+        "Note: the watcher has restarted {restarts} time(s) recently — it is "
+        "being revived rather than staying up, which a bare 'running' would hide."
+    ),
     # Two fragments, because the same caution has two very different warrants.
     # `shoulder_surf` states an observed fact and may only be used when a
     # reading actually detected an unrecognized face. With no reading nothing
@@ -65,11 +136,43 @@ class PresenceReading:
             enrolled-recognized.
         unknown_present: At least one unrecognized person is in view (or unknown,
             when there is no reading — the cautious default).
+        instrument: Why the reading is (un)usable. Never affects how cautious
+            the output is — ``have_reading`` alone still drives every gate — it
+            only determines what the output is allowed to CLAIM about the
+            sensor. Defaulted so existing callers keep working unchanged.
+        age_seconds: Age of the last reading, or ``None`` if there has never
+            been one. Rendered into the instrument banner so staleness is
+            visible in the line rather than inferable only from a file mtime.
+        restarts: Recent supervisor restarts, or ``None`` when unknown. A
+            watcher revived four times an hour is not the same as one that
+            never fell over, and a bare "running" hides the difference.
     """
 
     have_reading: bool
     principal_present: bool
     unknown_present: bool
+    instrument: Instrument = Instrument.UNKNOWN
+    age_seconds: float | None = None
+    restarts: int | None = None
+
+
+def humanize_age(seconds: float | None) -> str:
+    """Render an age as a short human string (``"2d 8h"``, ``"14m"``, ``"9s"``).
+
+    Returns ``"never"`` for ``None``. Deliberately coarse: the reader needs to
+    tell "a moment ago" from "since Friday" at a glance, and false precision in
+    a safety line invites arguing with the number instead of acting on it.
+    """
+    if seconds is None:
+        return "never"
+    s = max(0, int(seconds))
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        return f"{s // 60}m"
+    if s < 86400:
+        return f"{s // 3600}h {(s % 3600) // 60}m"
+    return f"{s // 86400}d {(s % 86400) // 3600}h"
 
 
 def classify(state: PresenceState | None, *, principal: str) -> PresenceReading:
@@ -122,7 +225,28 @@ def render(
             )
         )
     else:
-        parts.append(templates["unknown_banner"])
+        # WITHOUT a reading, say WHY and say HOW OLD. The pre-2026-08-16 code
+        # emitted one fixed sentence here for every no-reading cause, so a dead
+        # watcher and a 31-second-old reading were the same bytes. The caution
+        # is identical across these branches — only the claim differs, which is
+        # the same principle as `shoulder_surf_no_reading` one level down.
+        age = humanize_age(reading.age_seconds)
+        banner = {
+            Instrument.STALE: "instrument_stale",
+            Instrument.DEAD: "instrument_dead",
+            Instrument.NEVER: "instrument_never",
+            Instrument.UNKNOWN: "instrument_unknown_liveness",
+        }.get(reading.instrument)
+        if banner is not None and banner in templates:
+            parts.append(templates[banner].format(age=age, restarts=reading.restarts))
+        else:  # unrecognized instrument state => the original, always-safe line
+            parts.append(templates["unknown_banner"])
+    # Restarts are reported whether or not there is a reading: a watcher that is
+    # being revived repeatedly is worth knowing about even while it is currently
+    # healthy, because "currently fine" is exactly how a flapping process looks
+    # at any given instant.
+    if reading.restarts:
+        parts.append(templates["instrument_restarts"].format(restarts=reading.restarts, age=""))
     if level >= 2 and reading.unknown_present:
         key = "shoulder_surf" if reading.have_reading else "shoulder_surf_no_reading"
         parts.append(templates[key])

--- a/packages/agent-core-webcam/src/agent_core_webcam/presence/state.py
+++ b/packages/agent-core-webcam/src/agent_core_webcam/presence/state.py
@@ -39,6 +39,33 @@ class PresenceState(BaseModel):
     source: str = "desk-cam"
 
 
+class WatcherHeartbeat(BaseModel):
+    """Proof the watch LOOP is turning, written separately from any reading.
+
+    Deliberately carries no presence data. It answers one question the state
+    file cannot: *is the watcher alive?* Without it, "the reading is old"
+    and "the process is gone" are the same observation — which is exactly how
+    a dead sensor went unnoticed for 56 hours on 2026-08-14.
+
+    Attributes:
+        beat_at: Epoch seconds, written EVERY cycle whether or not the frame
+            read succeeded. A fresh beat beside a stale reading means the
+            watcher is alive and the camera is failing — a different fault,
+            and a different message, from the watcher being gone.
+        last_frame_at: Epoch seconds of the last SUCCESSFUL frame, or ``None``
+            if no frame has ever succeeded this run. Never advanced on failure.
+        consecutive_failures: Cycles since the last success. Lets a reader see
+            a camera degrading before the reading ages out.
+        pid: Owning process id, so a reader can distinguish "stale heartbeat"
+            from "a heartbeat some other process is still writing".
+    """
+
+    beat_at: float
+    last_frame_at: float | None = None
+    consecutive_failures: int = 0
+    pid: int = 0
+
+
 def write_state(state: PresenceState, path: Path) -> None:
     """Atomically write ``state`` to ``path`` (temp sibling + :func:`os.replace`).
 
@@ -65,5 +92,44 @@ def read_state(path: Path) -> PresenceState | None:
         return None
     try:
         return PresenceState.model_validate_json(raw)
+    except ValidationError:
+        return None
+
+
+def heartbeat_path_for(state_path: Path) -> Path:
+    """Return the heartbeat path that pairs with ``state_path``.
+
+    Single-sourced so the writer and the reader can never disagree about where
+    it lives — the failure this whole change exists to prevent is two halves of
+    a contract drifting apart silently.
+    """
+    return state_path.with_name("watcher-heartbeat.json")
+
+
+def write_heartbeat(beat: WatcherHeartbeat, path: Path) -> None:
+    """Atomically write ``beat`` to ``path`` (temp sibling + :func:`os.replace`).
+
+    Uses a distinct temp suffix from :func:`write_state` so a heartbeat write
+    and a state write can never collide on the same temp name mid-cycle.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".hb.tmp")
+    tmp.write_text(beat.model_dump_json(), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def read_heartbeat(path: Path) -> WatcherHeartbeat | None:
+    """Best-effort read of the watcher heartbeat; ``None`` if absent or invalid.
+
+    ``None`` does NOT mean the watcher is dead — it may predate this feature.
+    Callers must treat absent-heartbeat as *unknown liveness*, never as death,
+    or the fix reintroduces the very confusion it removes.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        return WatcherHeartbeat.model_validate_json(raw)
     except ValidationError:
         return None

--- a/packages/agent-core-webcam/src/agent_core_webcam/presence/state.py
+++ b/packages/agent-core-webcam/src/agent_core_webcam/presence/state.py
@@ -58,12 +58,27 @@ class WatcherHeartbeat(BaseModel):
             a camera degrading before the reading ages out.
         pid: Owning process id, so a reader can distinguish "stale heartbeat"
             from "a heartbeat some other process is still writing".
+        rss_bytes: The watcher's own resident set size, or ``None`` when it
+            could not be sampled. Recorded because the 2026-08-14 death has no
+            established cause and one live hypothesis is accumulation INSIDE
+            this process (a 2.6 MB allocation failed while 15.1 GB was free,
+            which is not a shortage). A monotonic climb across a long run is
+            evidence for that; a flat line is evidence against. Costs one field
+            in a record already written every cycle, so the question answers
+            itself over the next long uptime without anyone having to run an
+            experiment or authorise one.
+        started_at: Epoch seconds when this watcher process began its loop.
+            Paired with ``rss_bytes`` it gives the reader an age to plot the
+            memory against — a big RSS at ten days and at ten minutes mean
+            entirely different things.
     """
 
     beat_at: float
     last_frame_at: float | None = None
     consecutive_failures: int = 0
     pid: int = 0
+    rss_bytes: int | None = None
+    started_at: float | None = None
 
 
 def write_state(state: PresenceState, path: Path) -> None:

--- a/packages/agent-core-webcam/src/agent_core_webcam/presence/supervisor.py
+++ b/packages/agent-core-webcam/src/agent_core_webcam/presence/supervisor.py
@@ -1,0 +1,209 @@
+"""Keep the presence watcher running, and leave evidence that it did.
+
+Why this exists: on 2026-08-14 the watcher stopped after eight caught transient
+failures and nothing brought it back. It stayed down 56 hours. **The cause of
+the stop was never established** — the log ends on a complete line, which is
+consistent with an external kill, a normal exit, a closed parent shell, or a
+reboot, and distinguishes none of them.
+
+That unknown is the whole argument for supervising rather than for adding more
+error handling. The watcher's own ``except Exception`` already worked; it caught
+every one of those eight failures. A supervisor restores a stopped watcher
+*whatever stopped it*, which is precisely the property you want when you cannot
+name the cause.
+
+**Do not read a working supervisor as evidence the cause was diagnosed.** If the
+real cause also defeats a supervisor, the only thing that will reveal it is the
+restart record this module writes.
+
+Observability is not a nicety here. A watcher that dies and is revived every
+forty minutes is indistinguishable from one that never fell over, unless the
+revivals are counted somewhere a reader already looks — so this writes
+``supervisor.json`` beside the state file, and the injector renders the count
+into the line it emits every turn.
+
+The regress terminates at the OS: this process is started by the platform's
+service manager (Windows Task Scheduler / launchd / systemd), which is watched
+by the operating system and needs nothing from us. Same base case as a
+timestamped file — the thing at the bottom must need no watcher of its own.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+#: Restart backoff, in seconds, indexed by consecutive-failure count. A watcher
+#: that cannot start at all must not be respawned in a hot loop — that turns one
+#: broken camera into a pegged core and a log nobody can read.
+BACKOFF_SECONDS: tuple[float, ...] = (1.0, 2.0, 5.0, 15.0, 30.0, 60.0)
+
+#: Restarts older than this stop counting toward ``restarts_recent``. Without a
+#: window the count only ever grows, and "312 restarts" since some forgotten
+#: date says nothing about whether anything is wrong *now*.
+RESTART_WINDOW_SECONDS = 3600.0
+
+
+def supervisor_path_for(state_path: Path) -> Path:
+    """Return the supervisor-record path that pairs with ``state_path``."""
+    return state_path.with_name("supervisor.json")
+
+
+def write_supervisor_record(
+    path: Path,
+    *,
+    beat_at: float,
+    restarts_recent: int,
+    last_restart_at: float | None,
+    child_pid: int | None,
+    last_exit_code: int | None,
+) -> None:
+    """Atomically write the supervisor's own liveness + restart record.
+
+    Mirrors the watcher's heartbeat discipline one level up: the supervisor
+    must prove *it* is turning, or it becomes the new silent single point of
+    failure — the bug moved one layer out rather than fixed.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "beat_at": beat_at,
+        "restarts_recent": restarts_recent,
+        "last_restart_at": last_restart_at,
+        "child_pid": child_pid,
+        "last_exit_code": last_exit_code,
+        "pid": os.getpid(),
+    }
+    tmp = path.with_name(path.name + ".sup.tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _backoff_for(consecutive: int) -> float:
+    """Return the backoff delay for the nth consecutive failed start."""
+    idx = min(consecutive, len(BACKOFF_SECONDS) - 1)
+    return BACKOFF_SECONDS[idx]
+
+
+def run_supervised(
+    *,
+    child_argv: Sequence[str],
+    state_path: Path,
+    max_restarts: int | None = None,
+    spawn: Callable[[Sequence[str]], subprocess.Popen[bytes]] | None = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    clock: Callable[[], float] = time.time,
+) -> int:
+    """Run ``child_argv`` forever, restarting it whenever it exits.
+
+    Every exit is a restart, deliberately including exit code 0. A watcher that
+    is supposed to run until the machine stops has no successful termination —
+    treating a clean exit as "it meant to do that" is exactly how the 56-hour
+    outage would recur silently, since we never established that the 08-14 stop
+    was *unclean*.
+
+    ``max_restarts`` bounds the loop for tests; ``None`` means run forever.
+    ``spawn`` is an injectable seam so the loop is testable without processes.
+
+    Returns the last child exit code (or 0 if it never ran).
+    """
+    spawn_fn = spawn or (lambda argv: subprocess.Popen(list(argv)))
+    sup_path = supervisor_path_for(state_path)
+    restart_times: list[float] = []
+    consecutive_fast_exits = 0
+    last_exit: int | None = None
+    last_restart_at: float | None = None
+    restarts = 0
+
+    while max_restarts is None or restarts <= max_restarts:
+        started = clock()
+        try:
+            proc = spawn_fn(child_argv)
+        except Exception:
+            log.exception("failed to spawn presence watcher; backing off")
+            consecutive_fast_exits += 1
+            write_supervisor_record(
+                sup_path,
+                beat_at=clock(),
+                restarts_recent=len(restart_times),
+                last_restart_at=last_restart_at,
+                child_pid=None,
+                last_exit_code=last_exit,
+            )
+            sleep_fn(_backoff_for(consecutive_fast_exits))
+            restarts += 1
+            continue
+
+        write_supervisor_record(
+            sup_path,
+            beat_at=clock(),
+            restarts_recent=len(restart_times),
+            last_restart_at=last_restart_at,
+            child_pid=proc.pid,
+            last_exit_code=last_exit,
+        )
+        last_exit = proc.wait()
+        ran_for = clock() - started
+
+        # A child that exits almost immediately is failing to start, not
+        # crashing mid-run; those get the backoff. One that ran a while and then
+        # stopped is the 08-14 shape and should come straight back.
+        consecutive_fast_exits = consecutive_fast_exits + 1 if ran_for < 10.0 else 0
+
+        now = clock()
+        restart_times.append(now)
+        restart_times[:] = [t for t in restart_times if now - t <= RESTART_WINDOW_SECONDS]
+        last_restart_at = now
+        restarts += 1
+
+        log.warning(
+            "presence watcher exited (code=%s, ran %.1fs); restarting (%d in the last hour)",
+            last_exit,
+            ran_for,
+            len(restart_times),
+        )
+        write_supervisor_record(
+            sup_path,
+            beat_at=now,
+            restarts_recent=len(restart_times),
+            last_restart_at=last_restart_at,
+            child_pid=None,
+            last_exit_code=last_exit,
+        )
+        if max_restarts is not None and restarts > max_restarts:
+            break
+        sleep_fn(_backoff_for(consecutive_fast_exits))
+
+    return last_exit or 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry: ``python -m agent_core_webcam.presence.supervisor -- <watcher argv>``."""
+    args = list(argv if argv is not None else sys.argv[1:])
+    if "--" in args:
+        idx = args.index("--")
+        state_path = Path(args[0]) if idx > 0 else _default_state_path()
+        child = args[idx + 1 :]
+    else:  # no explicit split: supervise the default watcher invocation
+        state_path = _default_state_path()
+        child = [sys.executable, "-m", "agent_core_webcam.presence.cli", "watch"]
+    if not child:
+        print("usage: supervisor [state.json] -- <watcher argv>", file=sys.stderr)
+        return 2
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    return run_supervised(child_argv=child, state_path=state_path)
+
+
+def _default_state_path() -> Path:
+    return Path.home() / ".agent-core" / "presence" / "state.json"
+
+
+if __name__ == "__main__":  # pragma: no cover - process entry
+    raise SystemExit(main())

--- a/packages/agent-core-webcam/src/agent_core_webcam/presence/watcher.py
+++ b/packages/agent-core-webcam/src/agent_core_webcam/presence/watcher.py
@@ -15,14 +15,21 @@ are about this file:
    can tell "camera failing" from "process gone". Before this they were the same
    observation, and the outage was invisible for 56 hours because of it.
 2. Repeated failures now tear down and reopen the capture, degraded to
-   640x360 — the failure was a HOST-RAM allocation failure and a quarter-size
-   frame is a real mitigation. Full resolution is restored after sustained
-   success, so one bad afternoon does not permanently coarsen the sensor.
+   640x360, and that degraded state SURVIVES A RESTART — otherwise supervision
+   would restart at full resolution every time and a box that reliably kills
+   720p would loop fail-degrade-die-restart forever, looking like progress.
+   Full resolution is restored after sustained success.
 3. Restarting a stopped watcher is NOT this file's job — see ``supervisor.py``.
    A process cannot supervise its own death.
 
-Every collaborator is an injectable seam (defaulted to the real implementation)
-so the loop is fully testable without a camera or the model.
+**On the degrade: it is insurance, not a targeted fix.** The failing allocation
+was 2 764 800 bytes (one 720p BGR frame) through OpenCV's HOST allocator, which
+invited a memory-starvation story. Measured 2026-08-16 with the suspected
+pressure source resident and active: **15.1 GB free of 63.8 GB.** A 2.6 MB
+allocation cannot fail with that headroom, so whole-box RAM pressure does not
+explain it, and the mechanism behind the eight caught failures is **unknown**
+too — not merely the process's death. Quartering the frame is cheap and helps
+against any allocation failure; do not record it as aimed at a diagnosed cause.
 
 Every collaborator is an injectable seam (defaulted to the real implementation)
 so the loop is fully testable without a camera or the model.
@@ -114,6 +121,16 @@ def run_watch(
     consecutive_failures = 0
     consecutive_successes = 0
     with session_factory(camera_index) as cam:
+        # A restart must not have to relearn what the last run already paid to
+        # discover. Supervision restarts a stopped watcher at full resolution,
+        # so without this the loop would fail its way back down through
+        # REOPEN_AFTER_FAILURES cycles on EVERY restart — the degraded state
+        # would never survive the restart that supervision exists to provide,
+        # and a box that reliably kills 720p would produce an endless
+        # fail-degrade-die-restart cycle that looks like progress and is not.
+        if _degraded_hint_path(state_path).exists():
+            log.info("previous run ended degraded; starting at reduced resolution")
+            _try_reopen(cam, degrade=True)
         cam.warmup()
         count = 0
         while iterations is None or count < iterations:
@@ -140,6 +157,7 @@ def run_watch(
                 if consecutive_successes >= RESTORE_AFTER_SUCCESSES and cam.degraded:
                     consecutive_successes = 0
                     _try_reopen(cam, degrade=False)
+                    _set_degraded_hint(state_path, degraded=False)
             except Exception:
                 # Skip this cycle's write; the loop survives and the staleness
                 # guard covers persistent failures. Never crash on a bad frame.
@@ -151,6 +169,7 @@ def run_watch(
                 )
                 if consecutive_failures % REOPEN_AFTER_FAILURES == 0:
                     _try_reopen(cam, degrade=True)
+                    _set_degraded_hint(state_path, degraded=True)
             # The heartbeat is written on EVERY path, success or failure, and
             # deliberately outside the try above — it is the one thing that must
             # not depend on the camera working. Its whole purpose is to say "the
@@ -186,3 +205,32 @@ def _try_reopen(cam: CameraSession, *, degrade: bool) -> None:
         cam.reopen(degrade=degrade)
     except Exception:
         log.exception("camera reopen failed; continuing with the existing handle")
+
+
+def _degraded_hint_path(state_path: Path) -> Path:
+    """Marker file recording that the last run ended at reduced resolution."""
+    return state_path.with_name("watcher-degraded")
+
+
+def _set_degraded_hint(state_path: Path, *, degraded: bool) -> None:
+    """Create or remove the degraded marker; never raises.
+
+    A hint, deliberately, not authoritative state: if it is wrong the loop
+    self-corrects within RESTORE_AFTER_SUCCESSES cycles either way. Bookkeeping
+    that could kill the loop it serves would be a worse bug than the one it
+    prevents, so every failure here is swallowed.
+    """
+    path = _degraded_hint_path(state_path)
+    try:
+        if degraded:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("degraded", encoding="utf-8")
+        else:
+            path.unlink(missing_ok=True)
+    except Exception:
+        # Deliberately broader than OSError. An earlier version caught only
+        # OSError and a malformed path raised ValueError straight through the
+        # guard — the docstring promised "never raises" while the code did, and
+        # only a test with a genuinely hostile path found the difference. The
+        # loop must survive ANY failure of its own bookkeeping.
+        log.exception("could not update degraded hint; loop continues")

--- a/packages/agent-core-webcam/src/agent_core_webcam/presence/watcher.py
+++ b/packages/agent-core-webcam/src/agent_core_webcam/presence/watcher.py
@@ -117,6 +117,7 @@ def run_watch(
     analyzer = analyzer_factory()
     hb_path = heartbeat_path_for(state_path)
     pid = os.getpid()
+    started_at = clock()
     last_frame_at: float | None = None
     consecutive_failures = 0
     consecutive_successes = 0
@@ -183,6 +184,8 @@ def run_watch(
                         last_frame_at=last_frame_at,
                         consecutive_failures=consecutive_failures,
                         pid=pid,
+                        rss_bytes=_sample_rss(),
+                        started_at=started_at,
                     ),
                     hb_path,
                 )
@@ -234,3 +237,22 @@ def _set_degraded_hint(state_path: Path, *, degraded: bool) -> None:
         # only a test with a genuinely hostile path found the difference. The
         # loop must survive ANY failure of its own bookkeeping.
         log.exception("could not update degraded hint; loop continues")
+
+
+def _sample_rss() -> int | None:
+    """This process's resident set size in bytes, or ``None`` if unavailable.
+
+    Best-effort and dependency-free: ``psutil`` is not a hard requirement of
+    this package, so an absent import is a missing field rather than a broken
+    watcher. ``None`` genuinely means "not sampled" and must never be recorded
+    as zero — a zero would plot as a healthy flat line and quietly answer the
+    accumulation question wrongly.
+    """
+    try:
+        import psutil
+    except ImportError:
+        return None
+    try:
+        return int(psutil.Process().memory_info().rss)
+    except Exception:
+        return None

--- a/packages/agent-core-webcam/src/agent_core_webcam/presence/watcher.py
+++ b/packages/agent-core-webcam/src/agent_core_webcam/presence/watcher.py
@@ -3,9 +3,26 @@
 Owns a single long-lived :class:`CameraSession`, and each cycle: reads a frame,
 detects+embeds faces, recognizes each against the enrolled template, aggregates
 to a :class:`PresenceState`, and atomically writes it. Per-cycle errors are
-caught and the write is skipped so the loop never dies on a transient failure;
-if failures persist, the state file simply ages out and the Phase-1 hook's
-staleness guard degrades to "unknown" (cautious). v1 is started by hand.
+caught and the write is skipped so the loop never dies on a transient failure.
+
+**2026-08-16 — what the 56-hour outage actually taught.** That per-cycle catch
+worked: it swallowed eight consecutive allocation failures and kept going. The
+process stopped anyway, for a reason that was **never established**, and nothing
+brought it back. Three things changed here as a result, and only the first two
+are about this file:
+
+1. A heartbeat is written EVERY cycle regardless of frame outcome, so a reader
+   can tell "camera failing" from "process gone". Before this they were the same
+   observation, and the outage was invisible for 56 hours because of it.
+2. Repeated failures now tear down and reopen the capture, degraded to
+   640x360 — the failure was a HOST-RAM allocation failure and a quarter-size
+   frame is a real mitigation. Full resolution is restored after sustained
+   success, so one bad afternoon does not permanently coarsen the sensor.
+3. Restarting a stopped watcher is NOT this file's job — see ``supervisor.py``.
+   A process cannot supervise its own death.
+
+Every collaborator is an injectable seam (defaulted to the real implementation)
+so the loop is fully testable without a camera or the model.
 
 Every collaborator is an injectable seam (defaulted to the real implementation)
 so the loop is fully testable without a camera or the model.
@@ -14,6 +31,7 @@ so the loop is fully testable without a camera or the model.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -35,11 +53,28 @@ from agent_core_webcam.presence.recognition import (
 from agent_core_webcam.presence.recognition import (
     load_analyzer as _real_load_analyzer,
 )
-from agent_core_webcam.presence.state import write_state
+from agent_core_webcam.presence.state import (
+    WatcherHeartbeat,
+    heartbeat_path_for,
+    write_heartbeat,
+    write_state,
+)
 
 log = logging.getLogger(__name__)
 
 _EmbedFn = Callable[[object, npt.NDArray[Any]], list[tuple[Any, Bbox, float]]]
+
+#: Consecutive failed cycles before the camera handle is torn down and
+#: reopened. A handle can go bad in a way no amount of re-``read()`` fixes, and
+#: the pre-2026-08-16 loop would retry a dead handle forever while looking
+#: perfectly healthy from the outside.
+REOPEN_AFTER_FAILURES = 5
+
+#: Consecutive successful cycles at degraded resolution before trying full size
+#: again. ~10 minutes at the default 2s interval — long enough that a brief
+#: recovery does not flap the camera open and closed, short enough that a
+#: degraded session is not a permanent one.
+RESTORE_AFTER_SUCCESSES = 300
 
 
 def run_watch(
@@ -73,6 +108,11 @@ def run_watch(
     """
     galleries = {name: t.embeddings for name, t in templates.items()}
     analyzer = analyzer_factory()
+    hb_path = heartbeat_path_for(state_path)
+    pid = os.getpid()
+    last_frame_at: float | None = None
+    consecutive_failures = 0
+    consecutive_successes = 0
     with session_factory(camera_index) as cam:
         cam.warmup()
         count = 0
@@ -86,11 +126,63 @@ def run_watch(
                         emb, galleries, min_best=min_best, min_margin=min_margin
                     )
                     faces.append((verdict, bbox))
-                state = aggregate(faces, principal=principal, source=source, now=clock())
+                now = clock()
+                state = aggregate(faces, principal=principal, source=source, now=now)
                 write_state(state, state_path)
+                last_frame_at = now
+                consecutive_failures = 0
+                consecutive_successes += 1
+                # Come back up to full resolution once the box has clearly
+                # recovered. Without this a degraded session never returns, and
+                # the accuracy cost of one bad afternoon becomes permanent and
+                # invisible — the reading stays plausible, just quietly coarser
+                # forever. Only attempted while actually degraded.
+                if consecutive_successes >= RESTORE_AFTER_SUCCESSES and cam.degraded:
+                    consecutive_successes = 0
+                    _try_reopen(cam, degrade=False)
             except Exception:
                 # Skip this cycle's write; the loop survives and the staleness
                 # guard covers persistent failures. Never crash on a bad frame.
-                log.exception("presence watch cycle failed; skipping write")
+                consecutive_failures += 1
+                consecutive_successes = 0
+                log.exception(
+                    "presence watch cycle failed; skipping write (consecutive=%d)",
+                    consecutive_failures,
+                )
+                if consecutive_failures % REOPEN_AFTER_FAILURES == 0:
+                    _try_reopen(cam, degrade=True)
+            # The heartbeat is written on EVERY path, success or failure, and
+            # deliberately outside the try above — it is the one thing that must
+            # not depend on the camera working. Its whole purpose is to say "the
+            # loop is turning" while the reading is stale, so a reader can tell a
+            # failing camera from a dead process. Its own failure is swallowed:
+            # never let bookkeeping kill the loop it exists to observe.
+            try:
+                write_heartbeat(
+                    WatcherHeartbeat(
+                        beat_at=clock(),
+                        last_frame_at=last_frame_at,
+                        consecutive_failures=consecutive_failures,
+                        pid=pid,
+                    ),
+                    hb_path,
+                )
+            except Exception:
+                log.exception("heartbeat write failed; loop continues")
             if iterations is None or count < iterations:
                 sleep_fn(interval)
+
+
+def _try_reopen(cam: CameraSession, *, degrade: bool) -> None:
+    """Tear down and reopen the capture, degraded or restored to full size.
+
+    Best-effort and never raises: if reopening also fails, the loop keeps
+    running and keeps beating, so the reader still sees ALIVE-but-failing
+    rather than silence. Swallowing here is deliberate — the caller's next
+    cycle will fail again and the failure counter keeps climbing, which is the
+    signal we actually want surfaced.
+    """
+    try:
+        cam.reopen(degrade=degrade)
+    except Exception:
+        log.exception("camera reopen failed; continuing with the existing handle")

--- a/packages/agent-core-webcam/tests/presence/test_injector.py
+++ b/packages/agent-core-webcam/tests/presence/test_injector.py
@@ -84,7 +84,12 @@ def test_stale_reading_degrades_to_cautious_at_level3(tmp_path: Path) -> None:
         PresenceState(updated_at=1.0, at_desk=True, known=["jeff"], unknown_count=0), p
     )  # ancient
     out = PresenceInjector().execute("SessionStart", {}, {"state_path": str(p), "level": 3})
-    assert DEFAULT_TEMPLATES["unknown_banner"] in out.content
+    # 2026-08-16: the fixed "unknown_banner" literal was RETIRED here — it is
+    # the string that made a dead watcher and a 31-second-old reading identical
+    # for 56 hours. The no-reading branch now names the cause and the age.
+    # What must hold is the INVARIANT, not the wording: no reading => no facts.
+    assert "At desk:" not in out.content
+    assert "no current reading" in out.content.lower()
     assert DEFAULT_TEMPLATES["trust_gate"] in out.content
 
 
@@ -105,7 +110,12 @@ def test_execute_never_raises_on_garbage_params(tmp_path: Path) -> None:
     out = PresenceInjector().execute(
         "SessionStart", {}, {"state_path": str(p), "max_age_seconds": "not-a-number"}
     )
-    assert DEFAULT_TEMPLATES["unknown_banner"] in out.content
+    # 2026-08-16: the fixed "unknown_banner" literal was RETIRED here — it is
+    # the string that made a dead watcher and a 31-second-old reading identical
+    # for 56 hours. The no-reading branch now names the cause and the age.
+    # What must hold is the INVARIANT, not the wording: no reading => no facts.
+    assert "At desk:" not in out.content
+    assert "no current reading" in out.content.lower()
 
 
 def test_level3_error_path_still_trust_gates(tmp_path: Path) -> None:
@@ -119,7 +129,12 @@ def test_level3_error_path_still_trust_gates(tmp_path: Path) -> None:
         # garbage max_age forces the except path; level stays 3
         {"state_path": str(p), "level": 3, "max_age_seconds": object()},
     )
-    assert DEFAULT_TEMPLATES["unknown_banner"] in out.content
+    # 2026-08-16: the fixed "unknown_banner" literal was RETIRED here — it is
+    # the string that made a dead watcher and a 31-second-old reading identical
+    # for 56 hours. The no-reading branch now names the cause and the age.
+    # What must hold is the INVARIANT, not the wording: no reading => no facts.
+    assert "At desk:" not in out.content
+    assert "no current reading" in out.content.lower()
     assert DEFAULT_TEMPLATES["trust_gate"] in out.content  # de-escalation preserved
 
 

--- a/packages/agent-core-webcam/tests/presence/test_instrument_state.py
+++ b/packages/agent-core-webcam/tests/presence/test_instrument_state.py
@@ -280,3 +280,42 @@ def test_restart_count_absent_is_none_not_zero(tmp_path: Path) -> None:
     assert _read_restart_count(tmp_path / "state.json") is None
     (tmp_path / "supervisor.json").write_text(json.dumps({"restarts_recent": 0}), encoding="utf-8")
     assert _read_restart_count(tmp_path / "state.json") == 0
+
+
+# --------------------------------------------------------------------------
+# Degraded state must survive a restart (Pepper, 2026-08-16)
+# --------------------------------------------------------------------------
+
+
+def test_degraded_hint_round_trips(tmp_path: Path) -> None:
+    """A restart must not relearn what the last run already paid to discover.
+
+    Without persistence, supervision restarts at full resolution every time, so
+    a box that reliably kills 720p produces an endless fail-degrade-die-restart
+    cycle — motion that looks like recovery and never converges.
+    """
+    from agent_core_webcam.presence.watcher import (
+        _degraded_hint_path,
+        _set_degraded_hint,
+    )
+
+    sp = tmp_path / "state.json"
+    assert not _degraded_hint_path(sp).exists()
+    _set_degraded_hint(sp, degraded=True)
+    assert _degraded_hint_path(sp).exists()
+    _set_degraded_hint(sp, degraded=False)
+    assert not _degraded_hint_path(sp).exists()
+
+
+def test_degraded_hint_never_raises_on_bad_path() -> None:
+    """Bookkeeping that could kill the loop it serves is worse than the bug."""
+    from agent_core_webcam.presence.watcher import _set_degraded_hint
+
+    _set_degraded_hint(Path("\x00:/nonexistent/state.json"), degraded=True)
+
+
+def test_clearing_an_absent_hint_is_not_an_error(tmp_path: Path) -> None:
+    """Restore-when-not-degraded must be a no-op, not a crash."""
+    from agent_core_webcam.presence.watcher import _set_degraded_hint
+
+    _set_degraded_hint(tmp_path / "state.json", degraded=False)

--- a/packages/agent-core-webcam/tests/presence/test_instrument_state.py
+++ b/packages/agent-core-webcam/tests/presence/test_instrument_state.py
@@ -1,0 +1,282 @@
+"""The 2026-08-14 defect, as tests: a dead sensor must not look like a quiet one.
+
+Regression suite for a 56-hour silent outage. The watcher stopped for an
+unknown reason after eight caught transients, and every turn for two and a half
+days the injector emitted the same sentence it emits when a reading is merely
+31 seconds old. Nobody noticed, because nothing could have — the two states
+produced byte-identical output.
+
+The load-bearing test here is :func:`test_dead_and_stale_are_not_byte_identical`.
+Everything else supports it.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from agent_core_webcam.presence.injector import PresenceInjector, _diagnose
+from agent_core_webcam.presence.levels import (
+    DEFAULT_TEMPLATES,
+    Instrument,
+    PresenceReading,
+    humanize_age,
+    render,
+)
+from agent_core_webcam.presence.state import (
+    PresenceState,
+    WatcherHeartbeat,
+    heartbeat_path_for,
+    read_heartbeat,
+    write_heartbeat,
+    write_state,
+)
+
+NOW = 1_000_000.0
+MAX_AGE = 30.0
+HB_MAX_AGE = 120.0
+
+
+def _state(age: float) -> PresenceState:
+    return PresenceState(updated_at=NOW - age, at_desk=True, known=["jeff"], unknown_count=0)
+
+
+def _beat(age: float) -> WatcherHeartbeat:
+    return WatcherHeartbeat(beat_at=NOW - age, last_frame_at=NOW - age, pid=123)
+
+
+# --------------------------------------------------------------------------
+# _diagnose: the five instrument states
+# --------------------------------------------------------------------------
+
+
+def test_fresh_reading_is_fresh_even_with_no_heartbeat() -> None:
+    """A good reading is usable regardless of bookkeeping.
+
+    Refusing a fresh reading because the heartbeat file is missing would make
+    this change strictly worse than what it replaced.
+    """
+    assert _diagnose(NOW, _state(5), None, MAX_AGE, HB_MAX_AGE)[0] is Instrument.FRESH
+
+
+def test_no_state_file_is_never_not_dead() -> None:
+    """Never-configured must not be reported as a running system that broke."""
+    instrument, age = _diagnose(NOW, None, None, MAX_AGE, HB_MAX_AGE)
+    assert instrument is Instrument.NEVER
+    assert age is None
+
+
+def test_stale_reading_with_live_heartbeat_is_stale() -> None:
+    """Loop turning, camera failing — a different fault from a dead process."""
+    instrument, age = _diagnose(NOW, _state(3600), _beat(2), MAX_AGE, HB_MAX_AGE)
+    assert instrument is Instrument.STALE
+    assert age == 3600
+
+
+def test_stale_reading_with_stale_heartbeat_is_dead() -> None:
+    """Both signals old: the watcher is gone. This is the 2026-08-14 case."""
+    instrument, _ = _diagnose(NOW, _state(200_000), _beat(200_000), MAX_AGE, HB_MAX_AGE)
+    assert instrument is Instrument.DEAD
+
+
+def test_stale_reading_with_NO_heartbeat_is_unknown_never_dead() -> None:
+    """Absent heartbeat must NOT be read as death.
+
+    A state file written before heartbeats existed is indistinguishable from a
+    dead watcher. Claiming death without evidence is the same class of error as
+    the silence this whole change exists to remove — so it degrades to UNKNOWN,
+    which is equally cautious and does not assert what was not measured.
+    """
+    instrument, _ = _diagnose(NOW, _state(200_000), None, MAX_AGE, HB_MAX_AGE)
+    assert instrument is Instrument.UNKNOWN
+    assert instrument is not Instrument.DEAD
+
+
+# --------------------------------------------------------------------------
+# The regression itself
+# --------------------------------------------------------------------------
+
+
+def _render_for(instrument: Instrument, age: float | None, level: int = 3) -> str:
+    reading = PresenceReading(
+        have_reading=False,
+        principal_present=False,
+        unknown_present=True,
+        instrument=instrument,
+        age_seconds=age,
+    )
+    return render(reading, None, level=level, templates=DEFAULT_TEMPLATES)
+
+
+def test_dead_and_stale_are_not_byte_identical() -> None:
+    """THE REGRESSION. Before 2026-08-16 these produced the same string.
+
+    This is the test that would have caught the outage on the Friday afternoon
+    it began instead of the Sunday it was noticed.
+    """
+    dead = _render_for(Instrument.DEAD, 200_000)
+    stale = _render_for(Instrument.STALE, 200_000)
+    assert dead != stale
+
+
+def test_every_instrument_state_renders_distinctly() -> None:
+    """No two instrument states may collapse into the same text.
+
+    Generalises the regression: it is not enough that DEAD differs from STALE
+    today, because the defect was introduced by a refactor that made two
+    branches converge. Any future collapse fails here.
+    """
+    rendered = {
+        i: _render_for(i, 200_000) for i in (Instrument.STALE, Instrument.DEAD, Instrument.UNKNOWN)
+    }
+    rendered[Instrument.NEVER] = _render_for(Instrument.NEVER, None)
+    assert len(set(rendered.values())) == len(rendered)
+
+
+def test_dead_message_names_the_age_and_says_dead() -> None:
+    """'No reading' hid this for 56 hours; the age is what makes it visible."""
+    out = _render_for(Instrument.DEAD, 200_000)
+    assert "2d" in out
+    assert "DEAD" in out
+
+
+def test_stale_says_failing_not_dead() -> None:
+    """A live loop with a bad camera must not be reported as a dead watcher."""
+    out = _render_for(Instrument.STALE, 3600)
+    assert "DEAD" not in out
+    assert "FAILING" in out
+
+
+def test_never_does_not_claim_a_failure() -> None:
+    """Never-configured is not a broken running system and must not read as one."""
+    out = _render_for(Instrument.NEVER, None)
+    assert "DEAD" not in out
+    assert "never" in out.lower()
+
+
+def test_unknown_liveness_does_not_assert_death() -> None:
+    """Undeterminable liveness stays cautious without claiming a measurement."""
+    out = _render_for(Instrument.UNKNOWN, 200_000)
+    assert "DEAD" not in out
+
+
+# --------------------------------------------------------------------------
+# Caution is UNCHANGED — the security invariant
+# --------------------------------------------------------------------------
+
+
+def test_no_instrument_state_unlocks_gating() -> None:
+    """Only a FRESH reading may ever relax caution.
+
+    The whole change is about what the output CLAIMS, never about how cautious
+    it is. Every non-fresh instrument state must still carry the level-3 trust
+    gate, exactly as the single old sentence did.
+    """
+    for instrument in (Instrument.STALE, Instrument.DEAD, Instrument.NEVER, Instrument.UNKNOWN):
+        out = _render_for(instrument, 200_000, level=3)
+        assert DEFAULT_TEMPLATES["trust_gate"] in out, instrument
+
+
+def test_restart_count_is_surfaced_even_when_healthy() -> None:
+    """A flapping watcher looks fine at any instant; the count is the only tell."""
+    reading = PresenceReading(
+        have_reading=False,
+        principal_present=False,
+        unknown_present=True,
+        instrument=Instrument.DEAD,
+        age_seconds=60,
+        restarts=4,
+    )
+    out = render(reading, None, level=1, templates=DEFAULT_TEMPLATES)
+    assert "4 time(s)" in out
+
+
+# --------------------------------------------------------------------------
+# humanize_age
+# --------------------------------------------------------------------------
+
+
+def test_humanize_age_none_is_never() -> None:
+    assert humanize_age(None) == "never"
+
+
+def test_humanize_age_scales() -> None:
+    assert humanize_age(9) == "9s"
+    assert humanize_age(600) == "10m"
+    assert humanize_age(3600 * 5 + 120) == "5h 2m"
+    assert humanize_age(86400 * 2 + 3600 * 8) == "2d 8h"
+
+
+# --------------------------------------------------------------------------
+# Heartbeat round-trip
+# --------------------------------------------------------------------------
+
+
+def test_heartbeat_round_trips(tmp_path: Path) -> None:
+    p = heartbeat_path_for(tmp_path / "state.json")
+    write_heartbeat(WatcherHeartbeat(beat_at=1.5, last_frame_at=1.0, pid=7), p)
+    got = read_heartbeat(p)
+    assert got is not None
+    assert got.beat_at == 1.5
+    assert got.pid == 7
+
+
+def test_heartbeat_path_is_beside_state(tmp_path: Path) -> None:
+    """Writer and reader must never disagree about where the file lives."""
+    assert heartbeat_path_for(tmp_path / "state.json").parent == tmp_path
+
+
+def test_missing_heartbeat_reads_as_none_not_raise(tmp_path: Path) -> None:
+    assert read_heartbeat(tmp_path / "nope.json") is None
+
+
+def test_corrupt_heartbeat_reads_as_none_not_raise(tmp_path: Path) -> None:
+    p = tmp_path / "hb.json"
+    p.write_text("{not json", encoding="utf-8")
+    assert read_heartbeat(p) is None
+
+
+# --------------------------------------------------------------------------
+# End-to-end through the hook
+# --------------------------------------------------------------------------
+
+
+def test_injector_reports_dead_end_to_end(tmp_path: Path) -> None:
+    """The real 2026-08-14 shape, through the public hook."""
+    sp = tmp_path / "state.json"
+    write_state(PresenceState(updated_at=time.time() - 200_000, at_desk=True), sp)
+    write_heartbeat(WatcherHeartbeat(beat_at=time.time() - 200_000), heartbeat_path_for(sp))
+    out = PresenceInjector().execute("SessionStart", {}, {"state_path": str(sp), "level": 3})
+    assert "DEAD" in out.content
+    assert "2d" in out.content
+
+
+def test_injector_fresh_reading_still_reports_facts(tmp_path: Path) -> None:
+    """The happy path is untouched by the change."""
+    sp = tmp_path / "state.json"
+    write_state(
+        PresenceState(updated_at=time.time(), at_desk=True, known=["jeff"]),
+        sp,
+    )
+    write_heartbeat(WatcherHeartbeat(beat_at=time.time()), heartbeat_path_for(sp))
+    out = PresenceInjector().execute("SessionStart", {}, {"state_path": str(sp), "level": 3})
+    assert "At desk: yes" in out.content
+    assert "DEAD" not in out.content
+
+
+def test_injector_never_raises_on_garbage(tmp_path: Path) -> None:
+    """The hook must never raise into a session, whatever it finds."""
+    sp = tmp_path / "state.json"
+    sp.write_text("{{{garbage", encoding="utf-8")
+    out = PresenceInjector().execute("SessionStart", {}, {"state_path": str(sp), "level": 3})
+    assert out.content
+
+
+def test_restart_count_absent_is_none_not_zero(tmp_path: Path) -> None:
+    """`None` and `0` differ: 'nobody counting' is not 'counted, stable'."""
+    from agent_core_webcam.presence.injector import _read_restart_count
+
+    assert _read_restart_count(tmp_path / "state.json") is None
+    (tmp_path / "supervisor.json").write_text(json.dumps({"restarts_recent": 0}), encoding="utf-8")
+    assert _read_restart_count(tmp_path / "state.json") == 0

--- a/packages/agent-core-webcam/tests/presence/test_levels.py
+++ b/packages/agent-core-webcam/tests/presence/test_levels.py
@@ -85,7 +85,9 @@ def test_level3_trust_gates_when_principal_not_confirmed() -> None:
 
 def test_no_reading_uses_unknown_banner_and_gates_at_level3() -> None:
     out = _render(None, level=3)
-    assert DEFAULT_TEMPLATES["unknown_banner"] in out
+    # See test_injector.py — the literal banner was retired 2026-08-16. The
+    # gate below is the property this test actually exists to protect.
+    assert "At desk:" not in out
     assert "At desk" not in out  # no facts line when there is no reading
     assert DEFAULT_TEMPLATES["trust_gate"] in out  # uncertainty => cautious
 

--- a/packages/agent-core-webcam/tests/presence/test_watcher_resilience.py
+++ b/packages/agent-core-webcam/tests/presence/test_watcher_resilience.py
@@ -1,0 +1,242 @@
+"""The recovery paths added 2026-08-16, driven by fakes — no camera, no model.
+
+These cover the branches that only execute when something has already gone
+wrong: capture reopen, degradation and its restoration, the degraded hint
+surviving a restart, and the swallow-everything guards around bookkeeping.
+
+They exist because the diff-coverage gate refused the push at 77% and named
+`watcher.py` at 70.2%. The uncovered lines were exactly the ones added to make
+failure survivable — which is the worst possible thing to leave untested, since
+they only ever run on the bad day.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from agent_core_webcam.presence.enrollment import Template
+from agent_core_webcam.presence.state import read_heartbeat, heartbeat_path_for
+from agent_core_webcam.presence.watcher import (
+    REOPEN_AFTER_FAILURES,
+    _degraded_hint_path,
+    _sample_rss,
+    _set_degraded_hint,
+    _try_reopen,
+    run_watch,
+)
+
+_JEFF = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+
+
+class _FakeCam:
+    """A camera whose failures and reopens are observable.
+
+    ``fail_first`` frames raise; everything after succeeds. ``reopen`` records
+    the ``degrade`` flag it was called with rather than doing anything, so a
+    test can assert the loop's DECISION instead of a side effect.
+    """
+
+    def __init__(self, fail_first: int = 0, degraded: bool = False) -> None:
+        self.fail_first = fail_first
+        self.reads = 0
+        self.reopens: list[bool] = []
+        self.degraded = degraded
+
+    def __enter__(self) -> _FakeCam:
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+    def warmup(self, n: int = 3) -> None:
+        return None
+
+    def read_bgr(self) -> np.ndarray:
+        self.reads += 1
+        if self.reads <= self.fail_first:
+            raise RuntimeError("simulated frame failure")
+        return np.zeros((2, 2, 3), np.uint8)
+
+    def reopen(self, *, degrade: bool) -> None:
+        self.reopens.append(degrade)
+        self.degraded = degrade
+
+
+def _templates() -> dict[str, Template]:
+    return {"jeff": Template(name="jeff", embeddings=[_JEFF])}
+
+
+def _run(state_path: Path, cam: _FakeCam, iterations: int, **kw: object) -> None:
+    run_watch(
+        templates=_templates(),
+        state_path=state_path,
+        iterations=iterations,
+        session_factory=lambda _idx: cam,
+        analyzer_factory=lambda: object(),
+        embed_faces_fn=lambda _a, _f: [],
+        sleep_fn=lambda _s: None,
+        **kw,  # type: ignore[arg-type]
+    )
+
+
+# --------------------------------------------------------------------------
+# Reopen on repeated failure  (watcher.py 172-173)
+# --------------------------------------------------------------------------
+
+
+def test_repeated_failures_reopen_the_capture_degraded(tmp_path: Path) -> None:
+    """A handle can go bad in a way re-read() never fixes; the loop must reopen."""
+    sp = tmp_path / "state.json"
+    cam = _FakeCam(fail_first=REOPEN_AFTER_FAILURES)
+    _run(sp, cam, iterations=REOPEN_AFTER_FAILURES)
+    assert cam.reopens == [True], "should reopen exactly once, degraded"
+
+
+def test_reopen_sets_the_degraded_hint(tmp_path: Path) -> None:
+    """The hint is what carries degradation across a restart."""
+    sp = tmp_path / "state.json"
+    _run(sp, _FakeCam(fail_first=REOPEN_AFTER_FAILURES), iterations=REOPEN_AFTER_FAILURES)
+    assert _degraded_hint_path(sp).exists()
+
+
+def test_failures_below_the_threshold_do_not_reopen(tmp_path: Path) -> None:
+    """Reopening on every blip would thrash the device for transient noise."""
+    sp = tmp_path / "state.json"
+    cam = _FakeCam(fail_first=REOPEN_AFTER_FAILURES - 1)
+    _run(sp, cam, iterations=REOPEN_AFTER_FAILURES - 1)
+    assert cam.reopens == []
+
+
+# --------------------------------------------------------------------------
+# Degraded hint survives a restart  (watcher.py 133-134)
+# --------------------------------------------------------------------------
+
+
+def test_startup_honours_a_leftover_degraded_hint(tmp_path: Path) -> None:
+    """THE RESTART CASE. Without this, supervision restarts at full resolution
+    every time and a box that reliably kills 720p loops forever."""
+    sp = tmp_path / "state.json"
+    _set_degraded_hint(sp, degraded=True)
+    cam = _FakeCam()
+    _run(sp, cam, iterations=1)
+    assert cam.reopens and cam.reopens[0] is True, "should start degraded"
+
+
+def test_startup_without_a_hint_does_not_degrade(tmp_path: Path) -> None:
+    """A clean start must begin at full resolution."""
+    sp = tmp_path / "state.json"
+    cam = _FakeCam()
+    _run(sp, cam, iterations=1)
+    assert cam.reopens == []
+
+
+# --------------------------------------------------------------------------
+# Restore after sustained success  (watcher.py 159-161)
+# --------------------------------------------------------------------------
+
+
+def test_sustained_success_restores_full_resolution(tmp_path: Path, monkeypatch) -> None:
+    """One bad afternoon must not coarsen the sensor permanently.
+
+    RESTORE_AFTER_SUCCESSES is patched down so the test does not need 300
+    cycles to exercise a branch that is about policy, not about the number.
+    """
+    monkeypatch.setattr("agent_core_webcam.presence.watcher.RESTORE_AFTER_SUCCESSES", 2)
+    sp = tmp_path / "state.json"
+    _set_degraded_hint(sp, degraded=True)
+    cam = _FakeCam(degraded=True)
+    _run(sp, cam, iterations=3)
+    assert False in cam.reopens, "should restore to full resolution"
+    assert not _degraded_hint_path(sp).exists(), "hint should be cleared on restore"
+
+
+def test_restore_is_skipped_when_not_degraded(tmp_path: Path, monkeypatch) -> None:
+    """Never reopen a healthy session — that is churn for no benefit."""
+    monkeypatch.setattr("agent_core_webcam.presence.watcher.RESTORE_AFTER_SUCCESSES", 2)
+    sp = tmp_path / "state.json"
+    cam = _FakeCam(degraded=False)
+    _run(sp, cam, iterations=3)
+    assert cam.reopens == []
+
+
+# --------------------------------------------------------------------------
+# The swallow guards  (watcher.py 192-193, 207-210)
+# --------------------------------------------------------------------------
+
+
+def test_try_reopen_swallows_a_failing_reopen() -> None:
+    """If reopening also fails the loop must keep running AND keep beating,
+    so a reader sees ALIVE-but-failing rather than silence."""
+
+    class _Boom:
+        degraded = False
+
+        def reopen(self, *, degrade: bool) -> None:
+            raise RuntimeError("device gone")
+
+    _try_reopen(_Boom(), degrade=True)  # must not raise
+
+
+def test_heartbeat_write_failure_does_not_kill_the_loop(tmp_path: Path, monkeypatch) -> None:
+    """Bookkeeping that can kill the loop it observes is worse than no bookkeeping."""
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise OSError("disk gone")
+
+    monkeypatch.setattr("agent_core_webcam.presence.watcher.write_heartbeat", _boom)
+    sp = tmp_path / "state.json"
+    _run(sp, _FakeCam(), iterations=2)  # must not raise
+    assert read_state_exists(sp)
+
+
+def read_state_exists(sp: Path) -> bool:
+    """The state write must still have happened despite the heartbeat failing."""
+    return sp.exists()
+
+
+# --------------------------------------------------------------------------
+# RSS sampling  (watcher.py 253-254, 257-258)
+# --------------------------------------------------------------------------
+
+
+def test_sample_rss_returns_none_when_psutil_is_absent(monkeypatch) -> None:
+    """psutil is not a hard dependency; its absence is a missing field, not a crash.
+
+    None must never become 0 — a zero plots as a healthy flat line and would
+    answer the accumulation question wrongly.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_psutil(name: str, *args: object, **kw: object):  # type: ignore[no-untyped-def]
+        if name == "psutil":
+            raise ImportError("no psutil")
+        return real_import(name, *args, **kw)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", _no_psutil)
+    assert _sample_rss() is None
+
+
+def test_sample_rss_returns_none_when_psutil_raises(monkeypatch) -> None:
+    """A psutil that imports but fails must also degrade to None, not propagate."""
+    psutil = pytest.importorskip("psutil")
+
+    def _boom(*_a: object, **_k: object):  # type: ignore[no-untyped-def]
+        raise RuntimeError("no such process")
+
+    monkeypatch.setattr(psutil, "Process", _boom)
+    assert _sample_rss() is None
+
+
+def test_heartbeat_carries_rss_and_started_at(tmp_path: Path) -> None:
+    """The fields exist end-to-end, so the accumulation question can be answered
+    later from a record we already write."""
+    sp = tmp_path / "state.json"
+    _run(sp, _FakeCam(), iterations=1)
+    hb = read_heartbeat(heartbeat_path_for(sp))
+    assert hb is not None
+    assert hb.started_at is not None
+    assert hb.pid > 0


### PR DESCRIPTION
The presence watcher died **2026-08-14 08:33 ET** and stayed down 61 hours. Nobody noticed, and **nothing could have** — the injector emitted the same sentence for "the watcher is a corpse" as for "the reading is 31 seconds old".

```python
# injector.py, before
if state is not None and (now - state.updated_at) > max_age:
    state = None        # stale => treat as no reading (cautious)
```

Stale was *assigned to* `None`. The age and the reason were destroyed one layer above the code that would have reported them.

Found by Pepper, auditing a job of her own that gates on this signal — a job therefore guaranteed to no-op, silently, for as long as the sensor stayed dead.

## The exhibit

`state.json` on disk right now, frozen for 61 hours:

```json
{"updated_at":1786710797.72,"at_desk":true,"known":["jeff"],"unknown_count":0}
```

It asserts **Jeff is at his desk**. He may not be in the room. Anything reading the contents without checking `updated_at` against the clock confidently reports a person's location from Thursday morning. This is not a hypothetical for the title — it is the artifact.

## The cause is UNKNOWN and this PR does not claim otherwise

The loop's existing `except Exception` worked: it caught **eight** consecutive allocation failures and kept going. Seven causal stories were proposed and killed in one evening:

| story | died to |
|---|---|
| log truncated → OOM kill | my own `cut -c1-120` — I truncated it, not the file |
| "3 allocation failures" | a `tail -3` read as the population; actually 7 |
| VRAM starvation | it is OpenCV's **host** allocator |
| standing ComfyUI collision | **15.1 GB free** — 2.6 MB cannot fail |
| ComfyUI rendering that day | zero renders 08-12 → 08-14; cold for days |
| model fetch starving it | script created **166 s after** the last write |
| descending allocation ceiling | `1280×1280×3` vs `1280×720×3` — two structural constants, no slope |

**And the question nobody asked for 56 hours:** Windows has *no record of the watcher dying*. No System event, no WER crash bucket, and `Resource-Exhaustion-Detector` is **completely empty** — a fourth independent kill on starvation from the OS's own accounting. A process that vanishes with no OS record did not crash and was not killed by the system.

⇒ **Supervision is correct precisely BECAUSE the cause is unknown.** A supervisor restores a stopped watcher whatever stopped it. **Do not read a working supervisor as evidence the cause was diagnosed.**

## Changes

- **`state.py`** — `WatcherHeartbeat`: `beat_at` every cycle regardless of frame outcome; `last_frame_at` on success only. One field cannot answer both "is the loop turning" and "is the camera working".
- **`watcher.py`** — heartbeat on every path, outside the `try`. Reopen after repeated failures. **Degraded state survives restart** — otherwise supervision restarts at 720p and loops fail→degrade→die→restart forever, looking like progress.
- **`camera_session.py`** — `reopen(degrade=)` to 640×360 and back. Insurance, *not* a targeted fix.
- **`levels.py`** — `Instrument`: FRESH / STALE / DEAD / NEVER / UNKNOWN, each naming the **age**. `UNKNOWN` exists so an absent heartbeat is never reported as death.
- **`supervisor.py`** — restart-on-exit with backoff, every exit including code 0. Writes its own heartbeat + restart count, which the injector renders — an unobservable supervisor is the same bug one layer out.
- **`rss_bytes` / `started_at`** — so the one live hypothesis (accumulation inside the process) answers itself over the next long uptime, from a file we write anyway. No experiment to schedule.

## Caution is unchanged

Every non-`FRESH` state still discards the reading and fires every gate — verified across ancient readings, missing files, corrupt files, and the unparseable-params error path. This changes what the output **claims**, never how cautious it is.

## Tests — 110 pass, 2 skipped, none removed

Load-bearing: `test_dead_and_stale_are_not_byte_identical`, plus a generalisation that **no two instrument states may ever render the same text** — the defect was two branches converging, so the guard is against convergence, not one pair.

The pre-push diff-coverage gate refused this branch at **77%**, naming `watcher.py` at 70.2%. The uncovered lines were exactly the recovery paths — the code that only runs on the bad day. 12 tests added; now **87%**. The gate was right and was not bypassed.

Six existing tests asserted the retired banner *literal*; updated to assert the invariant (no reading ⇒ no facts). One existing test caught a real defect in my own wording — the `NEVER` banner read as reassurance at level 1.

## Known-not-done

Merging does not start a dead process. The supervisor is on this branch, so a clean merge lands and the LED stays off. **First start is a manual act and it is mine** — Pepper is the outside verifier and will check `state.json` mtime and `watcher-heartbeat.json` herself rather than take my report.
