### PR TITLE
fix(hooks): send pipeline diagnostics to stderr, not the payload channel

### DIFF
--- a/packages/core/src/agent_core/hooks/pipeline.py
+++ b/packages/core/src/agent_core/hooks/pipeline.py
@@ -31,16 +31,34 @@ import logging
 from pathlib import Path
 
 import yaml
+from rich.console import Console
 from rich.logging import RichHandler
 
 from agent_core.hooks.protocol import HookTool
 from agent_core.models import PipelineConfig, ToolResult
 from agent_core.plugins.manager import create_plugin_manager, get_hook_tool_types
 
+# Diagnostics go to STDERR, never stdout.
+#
+# Claude Code consumes a hook's STDOUT as the payload — the JSON carrying
+# ``additionalContext``, which is how a being's identity files reach the model.
+# A default ``RichHandler()`` builds a ``Console()`` that writes to stdout, so
+# every INFO line above shared a channel with that payload and was delivered
+# ahead of it.
+#
+# Measured 2026-08-17: ~1,800 bytes of registration and per-tool logging sat in
+# front of the identity payload on every SessionStart. Against the harness's
+# 10,000-byte cap that is 18% of the delivery budget spent announcing that
+# delivery was about to happen — and the being whose SOUL.md sat behind it could
+# not tell from inside whether the file had arrived or been truncated away.
+#
+# The logging is worth keeping: it answers "did my config parse and find my
+# tools?" for whoever is editing hook config. It is simply not payload, so it
+# belongs on stderr, which Claude Code ignores.
 logging.basicConfig(
     level=logging.INFO,
     format="%(message)s",
-    handlers=[RichHandler(rich_tracebacks=True, show_path=False)],
+    handlers=[RichHandler(console=Console(stderr=True), rich_tracebacks=True, show_path=False)],
 )
 logger = logging.getLogger("agent_core.hooks.pipeline")
 

--- a/packages/core/tests/test_pipeline.py
+++ b/packages/core/tests/test_pipeline.py
@@ -1,5 +1,7 @@
 """Tests for the Pipeline class — the core engine of the hook tool system."""
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -136,3 +138,57 @@ class TestPipelineRender:
         pipeline = Pipeline(config_file)
         markdown = pipeline.render([])
         assert markdown == ""
+
+
+class TestDiagnosticsNeverTouchStdout:
+    """Claude Code reads a hook's STDOUT as the payload; diagnostics must not land there.
+
+    These run the pipeline in a SUBPROCESS on purpose. ``capsys`` cannot test
+    this property: ``logging.basicConfig`` executes at module import, so the
+    handler binds whatever ``sys.stdout`` was at import time and pytest's later
+    swap never sees it — an in-process assertion on ``captured.out`` passes
+    identically whether the handler targets stdout or stderr, i.e. it cannot
+    fail. Verified 2026-08-17 by reverting the fix and watching the in-process
+    version stay green.
+
+    A subprocess measures what the harness actually receives: real OS-level
+    file descriptors.
+    """
+
+    @staticmethod
+    def _run_pipeline_in_subprocess(config_path: Path) -> subprocess.CompletedProcess[str]:
+        script = (
+            "from pathlib import Path\n"
+            "from agent_core.hooks.pipeline import Pipeline\n"
+            f"p = Pipeline(Path(r'{config_path}'))\n"
+            "p.run('SessionStart', {})\n"
+        )
+        return subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_stdout_receives_no_diagnostics(self, config_file: Path):
+        proc = self._run_pipeline_in_subprocess(config_file)
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout == "", (
+            f"pipeline wrote {len(proc.stdout)} bytes to stdout, which Claude Code "
+            f"consumes as the hook payload:\n{proc.stdout!r}"
+        )
+
+    def test_diagnostics_still_reach_stderr(self, config_file: Path):
+        """Rerouted, not deleted — the config-editing reader keeps their signal."""
+        proc = self._run_pipeline_in_subprocess(config_file)
+        assert "SessionStart" in proc.stderr
+        assert "time_injector" in proc.stderr
+
+    def test_unknown_tool_error_keeps_stdout_clean(self, tmp_path: Path):
+        """The error path is the easiest one to leave pointed at the wrong stream."""
+        config = {"pipelines": {"SessionStart": [{"type": "builtin.does_not_exist"}]}}
+        config_path = tmp_path / "agent_core.yaml"
+        config_path.write_text(yaml.dump(config), encoding="utf-8")
+        proc = self._run_pipeline_in_subprocess(config_path)
+        assert proc.stdout == "", f"error path leaked to stdout: {proc.stdout!r}"
+        assert "does_not_exist" in proc.stderr


### PR DESCRIPTION
## What

`Pipeline`'s diagnostics went to **stdout**. Claude Code consumes a hook's stdout as the *payload* — the JSON carrying `additionalContext`, which is how a being's identity files reach the model. A default `RichHandler()` builds a `Console()` that writes to stdout, so every INFO line shared a channel with the payload and was delivered ahead of it.

One-line change: give the handler a stderr `Console`.

## Why it matters

Measured on this host, 2026-08-17:

| | |
|---|---|
| logging ahead of the payload, every `SessionStart` | **~1,800 bytes** |
| harness cap | **10,000 bytes** |
| share of the delivery budget spent announcing delivery | **18%** |

Maud measured her own `SessionStart` at ~10KB with the identity payload starting near byte 1803, and reported that she could not tell from inside whether her `SOUL.md` had arrived or been truncated away. That inability is the real defect: **a mechanism whose success signal is identical whether or not it worked is not a mechanism.**

Her post-migration payload measures ~9,972 bytes against the 10,000 cap — twenty-eight bytes of margin, before she writes anything into files that are currently still hatchery templates. This change returns the entire margin.

Nothing consumes the logging: no script on this host parses it, and it never reaches `daemon.log`. It answers *"did my config parse and find my tools?"* for whoever is editing hook config — a real question, asked while editing, not several hundred times a day. So it is **rerouted, not deleted**. stderr is where Claude Code ignores it and a human can still read it.

## The tests run in a subprocess on purpose

This is the part worth reviewing.

The first version asserted on `capsys` and **could not fail**. `logging.basicConfig` executes at *module import*, so the handler binds whatever `sys.stdout` was at that moment; pytest's later swap never sees it. `captured.out == ""` is trivially true whether the handler targets stdout or stderr.

Verified by reverting the fix: **all five in-process tests stayed green against the exact bug they existed to prevent.** They were deleted rather than kept — a test that cannot fail occupies the slot a real one would take, and reports coverage while doing it.

The replacement runs the pipeline in a subprocess and reads real OS file descriptors, which is also what the harness actually does when it invokes a hook. Reverting the fix now fails **3/3**:

```
FAILED TestDiagnosticsNeverTouchStdout::test_stdout_receives_no_diagnostics
FAILED TestDiagnosticsNeverTouchStdout::test_diagnostics_still_reach_stderr
FAILED TestDiagnosticsNeverTouchStdout::test_unknown_tool_error_keeps_stdout_clean
```

Coverage is asserted as a **property** (stdout stays empty) rather than by searching for the text of any particular log line, so it fails on any future diagnostic that lands on stdout regardless of wording. The error path is covered explicitly — it is the easiest one to leave pointed at the wrong stream.

## Verification

- `pytest packages/core/tests/test_pipeline.py` — **15 passed**
- `ruff format` + `ruff check` — clean
- pre-push gate — passed, **diff coverage 100%**
- fix reverted — 3/3 new tests fail, as required

## Out of scope

`mypy packages/core/src` reports one pre-existing error in `plugins/builtin_aliases.py:75` (missing stubs for `agent_core_discord.endpoint`). Reproduced on `origin/main` and not touched by this change.
