### PR TITLE
fix(discord): rebuild attachments per send attempt instead of reusing spent handles

### DIFF
--- a/packages/agent-core-discord/src/agent_core_discord/_outbound.py
+++ b/packages/agent-core-discord/src/agent_core_discord/_outbound.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, Literal
 
@@ -250,9 +251,7 @@ class _OutboundMixin(_EndpointState):
             await self._reply(envelope, f"error: {exc}", urgency="yellow")
         except Exception as exc:
             if is_retryable_discord_send_error(exc):
-                raise EndpointUnavailable(
-                    f"discord '{self.name}': transient error: {exc}"
-                ) from exc
+                raise EndpointUnavailable(f"discord '{self.name}': transient error: {exc}") from exc
             log.exception("discord tool '%s' raised", tool)
             await self._reply(envelope, f"error: {exc}", urgency="yellow")
 
@@ -365,9 +364,7 @@ class _OutboundMixin(_EndpointState):
             return raw
 
         if tool == "discord_send":
-            return await self._send(
-                _v(_DiscordSendArgs, _inject_channel_id(args))
-            )
+            return await self._send(_v(_DiscordSendArgs, _inject_channel_id(args)))
         if tool == "send":
             return await self._send(_v(_SendArgs, _inject_channel_id(args)))
         if tool == "edit":
@@ -434,9 +431,7 @@ class _OutboundMixin(_EndpointState):
 
     async def _send(self, args: _SendArgs) -> dict[str, Any]:
         if args.text is None and not args.embeds and not args.files:
-            raise _ToolError(
-                "send: one of 'text', 'embeds', or 'files' is required"
-            )
+            raise _ToolError("send: one of 'text', 'embeds', or 'files' is required")
         ch = await self._resolve_channel(args.channel_id)
 
         # Build embeds list (validate via discord.Embed.from_dict).
@@ -472,9 +467,15 @@ class _OutboundMixin(_EndpointState):
                 # Fakes don't need a real reference; pass the message itself as a marker.
                 reference = target
 
-        # Holds discord.File objects on the real path or raw path strings on
-        # the fake-client fallback, so the element type is intentionally Any.
-        files: list[Any] | None = None
+        # A FACTORY, not a list. discord.File is single use and the sender
+        # closes it after every attempt — including one that raised — so a retry
+        # reusing attempt 1's objects uploads spent handles: the message posts,
+        # the send reports success, and the attachment silently does not arrive
+        # (agent_core#594). Rebuilding per attempt is the only shape that
+        # survives a retry. Yields discord.File objects on the real path or raw
+        # path strings on the fake-client fallback, so the element type is
+        # intentionally Any.
+        files_factory: Callable[[], list[Any]] | None = None
         if args.files:
             # discord.File accepts a local path or a binary file-like object —
             # not an HTTP URL. Reject URL strings upfront with a clear message
@@ -488,9 +489,27 @@ class _OutboundMixin(_EndpointState):
             try:
                 import discord
 
-                files = [discord.File(f) for f in args.files]
+                make_one: Callable[[Any], Any] = discord.File
             except ImportError:
-                files = list(args.files)
+
+                def make_one(spec: Any) -> Any:
+                    """Without discord installed, fakes receive the raw path."""
+                    return spec
+
+            specs = list(args.files)
+
+            def files_factory() -> list[Any]:
+                """Build fresh file objects for one send attempt."""
+                return [make_one(spec) for spec in specs]
+
+            # Validate eagerly so an unreadable path still surfaces as
+            # _ToolError here rather than mid-retry. Build one throwaway set and
+            # release the handles immediately; each send builds its own.
+            try:
+                for probe in files_factory():
+                    closer = getattr(probe, "close", None)
+                    if callable(closer):
+                        closer()
             except Exception as exc:
                 raise _ToolError(f"send: invalid files: {exc}") from exc
 
@@ -502,11 +521,10 @@ class _OutboundMixin(_EndpointState):
             send_kwargs["embeds"] = embeds
         if reference is not None:
             send_kwargs["reference"] = reference
-        if files is not None:
-            send_kwargs["files"] = files
-
         if args.text is None:
-            new_msg = await channel_send_with_retries(ch, args.text, **send_kwargs)
+            new_msg = await channel_send_with_retries(
+                ch, args.text, files_factory=files_factory, **send_kwargs
+            )
             if args.reply_to:
                 await self._clear_pending_ack(ch, args.reply_to)
             if args.cleanup_inbound_message_id:
@@ -530,10 +548,13 @@ class _OutboundMixin(_EndpointState):
                 send_part["embeds"] = embeds
             if reference is not None and is_first:
                 send_part["reference"] = reference
-            if files is not None and is_first:
-                send_part["files"] = files
             try:
-                new_msg = await channel_send_with_retries(ch, part, **send_part)
+                new_msg = await channel_send_with_retries(
+                    ch,
+                    part,
+                    files_factory=files_factory if is_first else None,
+                    **send_part,
+                )
             except Exception as exc:
                 last_error = exc
                 break

--- a/packages/agent-core-discord/src/agent_core_discord/send_retry.py
+++ b/packages/agent-core-discord/src/agent_core_discord/send_retry.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable, Sequence
 from typing import Any
 
 log = logging.getLogger(__name__)
@@ -66,22 +67,100 @@ def retry_delay_seconds(exc: BaseException, attempt: int) -> float:
     return _backoff_seconds(attempt)
 
 
+def _release(files: Sequence[Any] | None) -> None:
+    """Close files this module built, swallowing every error.
+
+    The sender normally closes them itself (``MultipartParameters.__exit__``
+    runs on the failure path too), so this is almost always a no-op second
+    close. It matters for the case where ``send`` raised *before* taking
+    ownership: with a factory we build a fresh set per attempt, so without this
+    a retry storm would leak one handle per attempt instead of one in total.
+
+    Errors are swallowed deliberately. This runs while an exception is already
+    in flight, and a failure to close must not replace the transport error the
+    caller actually needs to see.
+    """
+    for f in files or ():
+        closer = getattr(f, "close", None)
+        if callable(closer):
+            try:
+                closer()
+            except Exception:  # see docstring: a close error must not mask the real one
+                log.debug("ignoring error closing a send attachment", exc_info=True)
+
+
 async def channel_send_with_retries(
     channel: Any,
     content: str | None,
     *,
     max_attempts: int | None = None,
+    files_factory: Callable[[], Sequence[Any]] | None = None,
     **send_kwargs: Any,
 ) -> Any:
-    """Call ``channel.send`` with retries on transient / rate-limit errors."""
+    """Call ``channel.send`` with retries on transient / rate-limit errors.
+
+    Attachments must be passed as ``files_factory``, not ``files``. A
+    ``discord.File`` is single-use by the library's own contract, and
+    ``MultipartParameters.__exit__`` closes it after **every** send including
+    one that raised. So a retry that reuses the list from attempt 1 uploads
+    handles that are already closed: the message posts, the send reports
+    success, and the attachment silently does not arrive (agent_core#594).
+
+    ``files_factory`` is called once per attempt and must return freshly built
+    file objects. Passing both it and ``files`` is a ``TypeError`` rather than a
+    precedence rule — a caller who supplies both has a pre-built list that
+    cannot survive a retry, and silently preferring the factory would leave that
+    hazard in place under a fix's name.
+
+    ``files`` is still accepted for callers with a single-attempt path, but a
+    retryable failure carrying pre-built ``files`` is **re-raised instead of
+    retried**. That is deliberately worse service and better behaviour: the
+    retry could not have delivered the attachment anyway, so its only outcomes
+    were a crash or a message posted without its file. Raising the transport
+    error that actually happened is the one outcome that tells the truth.
+
+    Args:
+        channel: Any object exposing an awaitable ``send(content, **kwargs)``.
+        content: Message body, or ``None`` for attachment/embed-only sends.
+        max_attempts: Attempt cap; ``None`` uses ``DISCORD_SEND_MAX_ATTEMPTS``.
+        files_factory: Zero-arg callable returning fresh file objects per
+            attempt. Required for any send that must survive a retry with its
+            attachments intact.
+        **send_kwargs: Forwarded to ``channel.send`` unchanged.
+
+    Returns:
+        Whatever ``channel.send`` returns on the first successful attempt.
+
+    Raises:
+        TypeError: If both ``files`` and ``files_factory`` are supplied.
+    """
+    if files_factory is not None and "files" in send_kwargs:
+        raise TypeError(
+            "channel_send_with_retries: pass files_factory OR files, not both. "
+            "A pre-built file list cannot survive a retry (discord.File is single-use)."
+        )
     cap = DISCORD_SEND_MAX_ATTEMPTS if max_attempts is None else max_attempts
     for attempt in range(cap):
+        built: list[Any] | None = None
+        if files_factory is not None:
+            built = list(files_factory())
+            send_kwargs["files"] = built
         try:
             return await channel.send(content, **send_kwargs)
         except asyncio.CancelledError:
             raise
         except Exception as exc:
+            _release(built)
             if attempt >= cap - 1 or not is_retryable_discord_send_error(exc):
+                raise
+            if files_factory is None and send_kwargs.get("files"):
+                log.warning(
+                    "discord send failed with pre-built files and is NOT being retried "
+                    "(%s): the file handles are spent, so a retry would post the "
+                    "message without its attachment. Pass files_factory to make this "
+                    "send retryable.",
+                    exc,
+                )
                 raise
             delay = retry_delay_seconds(exc, attempt)
             log.warning(

--- a/packages/agent-core-discord/tests/test_send_retry.py
+++ b/packages/agent-core-discord/tests/test_send_retry.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import io
 from unittest.mock import AsyncMock
 
 import pytest
 from agent_core_discord.send_retry import (
     DISCORD_SEND_MAX_ATTEMPTS,
+    channel_send_with_retries,
     is_retryable_discord_send_error,
     retry_delay_seconds,
 )
@@ -75,3 +77,196 @@ async def test_channel_send_with_retries_succeeds_second_try(monkeypatch):
     out = await channel_send_with_retries(_Ch(), "hi", max_attempts=DISCORD_SEND_MAX_ATTEMPTS)
     assert out == "ok"
     assert calls == 2
+
+
+class _FakeFile:
+    """Mirrors ``discord.File``'s contract strictly, so this cannot pass here and
+    fail in production.
+
+    The library's own docstring: *"File objects are single use and are not meant
+    to be reused in multiple abc.Messageable.send s."* ``MultipartParameters.__exit__``
+    closes the file after every send, including one that raised, and a ``File``
+    built from a path owns its handle. So the fake refuses exactly what the real
+    object refuses: any use after close.
+    """
+
+    def __init__(self, payload: bytes = b"pdf-bytes") -> None:
+        self._fp = io.BytesIO(payload)
+        self.closed = False
+
+    def reset(self, *, seek: bool | int = True) -> None:
+        if self.closed:
+            raise ValueError("I/O operation on closed file")
+        if seek:
+            self._fp.seek(0)
+
+    def read(self) -> bytes:
+        if self.closed:
+            raise ValueError("I/O operation on closed file")
+        return self._fp.read()
+
+    def close(self) -> None:
+        self.closed = True
+        self._fp.close()
+
+
+class _UploadRecordingChannel:
+    """A channel that uploads like discord.py does and fails the first attempt.
+
+    Records the bytes each attempt actually managed to upload, which is the
+    property under test: the message posting is not evidence the file did.
+    """
+
+    def __init__(self, fail_times: int = 1) -> None:
+        self.uploads: list[bytes] = []
+        self._fail_times = fail_times
+
+    async def send(self, content: str | None = None, **kwargs: object) -> str:
+        files = kwargs.get("files") or []
+        assert isinstance(files, list)
+        for f in files:
+            f.reset(seek=len(self.uploads))  # discord.py http.py resets per try
+            self.uploads.append(f.read())
+        try:
+            if len(self.uploads) <= self._fail_times:
+                raise _Exc(429)
+            return "ok"
+        finally:
+            for f in files:  # MultipartParameters.__exit__ — failure path too
+                f.close()
+
+
+@pytest.mark.asyncio
+async def test_a_retried_send_uploads_the_file_again_not_a_consumed_handle(monkeypatch):
+    """#594. The retry must upload real bytes, not an already-closed handle.
+
+    Asserts what the second attempt *received*, not that the call returned — a
+    send whose attachment silently vanished still returns a message id, which is
+    exactly why this defect survived three weeks in production.
+    """
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    ch = _UploadRecordingChannel(fail_times=1)
+
+    out = await channel_send_with_retries(
+        ch,
+        "here is the report",
+        files_factory=lambda: [_FakeFile()],
+        max_attempts=3,
+    )
+
+    assert out == "ok"
+    assert len(ch.uploads) == 2, "expected exactly one retry"
+    assert ch.uploads == [b"pdf-bytes", b"pdf-bytes"], (
+        "the retry uploaded different bytes than the first attempt — "
+        "an empty or partial second upload is the silent-drop defect"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_retry_with_prebuilt_files_refuses_instead_of_uploading_a_consumed_handle(
+    monkeypatch,
+):
+    """#594, the defect itself: a pre-built file list must never cross an attempt.
+
+    This is the test that goes red on the ORIGINAL source, and it stays
+    meaningful after the fix because it pins the *defect*, not the new keyword.
+    Pre-fix the second attempt reaches a closed handle and dies with
+    ``ValueError: I/O operation on closed file``; post-fix there is no second
+    attempt at all and the caller sees the transport error that actually
+    happened.
+
+    Refusing to retry is deliberately WORSE service and BETTER behaviour: a
+    retry here cannot deliver the attachment, so its only possible outcomes are
+    a crash or a message that posts without its file. Failing on the real error
+    is the one outcome that tells the truth.
+    """
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    ch = _UploadRecordingChannel(fail_times=1)
+    the_file = _FakeFile()
+
+    with pytest.raises(_Exc) as caught:
+        await channel_send_with_retries(ch, "here is the report", files=[the_file], max_attempts=3)
+
+    assert caught.value.status == 429, "the caller must see the transport error, not an I/O error"
+    assert len(ch.uploads) == 1, "must not have attempted a second upload with a spent handle"
+    assert the_file.closed is True
+
+
+@pytest.mark.asyncio
+async def test_passing_both_files_and_files_factory_is_refused() -> None:
+    """Ambiguity is refused loudly rather than resolved by precedence.
+
+    A caller who passes both has a pre-built list that cannot survive a retry;
+    silently preferring one would leave the hazard in place under a fix's name.
+    """
+
+    class _Ch:
+        async def send(self, content: str | None = None, **kwargs: object) -> str:
+            raise AssertionError("send must not be reached")
+
+    with pytest.raises(TypeError, match="files_factory"):
+        await channel_send_with_retries(
+            _Ch(), "hi", files=[_FakeFile()], files_factory=lambda: [_FakeFile()]
+        )
+
+
+@pytest.mark.asyncio
+async def test_factory_built_files_are_released_when_send_raises_before_using_them(
+    monkeypatch,
+):
+    """Every attempt's files are closed, even if ``send`` never touched them.
+
+    A factory builds a fresh set per attempt, so a send that raises *before*
+    taking ownership of the handles would leak one per attempt rather than one
+    in total. The sender normally closes them itself; this pins the case where
+    it never got the chance.
+    """
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    built: list[_FakeFile] = []
+
+    def factory() -> list[_FakeFile]:
+        made = _FakeFile()
+        built.append(made)
+        return [made]
+
+    class _RaisesBeforeUpload:
+        async def send(self, content: str | None = None, **kwargs: object) -> str:
+            raise _Exc(429)  # never reads, never closes
+
+    with pytest.raises(_Exc):
+        await channel_send_with_retries(
+            _RaisesBeforeUpload(), "hi", files_factory=factory, max_attempts=3
+        )
+
+    assert len(built) == 3, "one fresh set per attempt"
+    assert all(f.closed for f in built), "a leaked handle per retry is the regression"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_close_does_not_mask_the_transport_error(monkeypatch):
+    """The caller must see why the send failed, not why cleanup failed.
+
+    ``_release`` runs while an exception is already in flight. If a close error
+    escaped it, the caller would get an unrelated ``OSError`` in place of the
+    429 that actually happened — turning a diagnosable rate limit into a
+    mystery, which is the same substitution the whole issue is about.
+    """
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    class _UncloseableFile(_FakeFile):
+        def close(self) -> None:
+            raise OSError("cannot close")
+
+    class _RaisesBeforeUpload:
+        async def send(self, content: str | None = None, **kwargs: object) -> str:
+            raise _Exc(429)
+
+    with pytest.raises(_Exc) as caught:
+        await channel_send_with_retries(
+            _RaisesBeforeUpload(),
+            "hi",
+            files_factory=lambda: [_UncloseableFile()],
+            max_attempts=2,
+        )
+
+    assert caught.value.status == 429


### PR DESCRIPTION
Closes #594.

## The defect

`discord.File` is single use — the library's own docstring says so — and
`MultipartParameters.__exit__` closes it after **every** send, including one
that raised. `channel_send_with_retries` re-called `channel.send` with
`send_kwargs` unchanged, so attempt 2 uploaded handles that were already
closed.

The message posts. The send reports success. **The attachment silently does not
arrive.** Intermittent by construction — it fires only when a retry actually
happens, which is why it looked unrelated to file size, path form, or payload
when Pepper first hit it on 2026-08-06/07.

## The fix

**Attachments are passed as a factory, not a list.** `files_factory` is called
once per attempt and returns freshly built file objects, so every attempt
uploads real bytes.

Three deliberate choices, each of which could have gone the other way:

1. **Passing both `files` and `files_factory` is a `TypeError`, not a
   precedence rule.** A caller who supplies both has a pre-built list that
   cannot survive a retry; silently preferring the factory would leave the
   hazard in place under a fix's name.

2. **A retryable failure carrying pre-built `files` is re-raised instead of
   retried.** This is deliberately worse service and better behaviour: the
   retry could not have delivered the attachment anyway, so its only possible
   outcomes were a crash or a message posted without its file. Raising the
   transport error that actually happened is the one outcome that tells the
   truth. `files=` remains supported for single-attempt callers.

3. **Files built by the factory are released when `send` raises.** The sender
   normally closes them itself, so this is usually a no-op second close. It
   matters when `send` raises *before* taking ownership: a factory builds a
   fresh set per attempt, so without this a retry storm leaks one handle per
   attempt instead of one in total. Close errors are swallowed — this runs
   while an exception is in flight and must not mask it.

`_outbound.py` migrates both file-carrying call sites. Path validation stays
eager, so an unreadable path still surfaces as `_ToolError` at call time rather
than mid-retry; it builds one throwaway set and releases the handles
immediately. `args.files` is `list[str] | None`, so the probe only ever closes
handles this code opened.

## Tests — property checks, and all of them red before the fix

- `test_a_retry_with_prebuilt_files_refuses_instead_of_uploading_a_consumed_handle`
  is the **defect test**. On unmodified source it fails with the issue's exact
  error, `ValueError: I/O operation on closed file`. It pins the defect rather
  than the new keyword, so it stays meaningful after the fix.
- `test_a_retried_send_uploads_the_file_again_not_a_consumed_handle` asserts
  **what the second attempt received** — `uploads == [b"pdf-bytes", b"pdf-bytes"]`
  — not that the call returned. A send whose attachment vanished still returns a
  message id, which is exactly why this survived three weeks in production.
- `test_factory_built_files_are_released_when_send_raises_before_using_them`
  forces the leak path: three attempts, three sets built, all closed.
- `test_passing_both_files_and_files_factory_is_refused` asserts `send` is never
  reached.

`_FakeFile` mirrors `discord.File`'s contract strictly — it refuses exactly what
the real object refuses — so these cannot pass here and fail in production.

## Gate

- `mypy` — clean, 212 source files
- `ruff check` + `ruff format --check` — clean on all three changed files
- full suite single-threaded — 2208 passed, 51 skipped, 80.42% total
- discord package — 344 passed, 1 skipped

## Not in scope, and stated rather than glossed

This fixes the **retry**. It does not establish how a dropped attachment became
`state=acked, nack_reason=None`, which is what made the original diagnosis
expensive: with delivered and dropped writing identical rows, the store could
not answer whether a file arrived and a human had to be asked to look. The retry
now raises loudly, so something further up is catching it and acking anyway.
**That path is a separate finding.** Fixing the retry removes this instance;
only the second makes the next one visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mm8Ngkr7zmh4dY7huq877X
